### PR TITLE
Issue #998 PR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for GNS3 Web-ui development
-FROM node:carbon
+FROM node:stretch
 
 # Create user
 RUN useradd --user-group --create-home --shell /bin/false gns3-web-ui


### PR DESCRIPTION
This PR to fix #998 issue
---
Tried to run the build from compose
```yaml
---
version: "3"
  gns3-web-ui:
    build:
      context: https://github.com/GNS3/gns3-web-ui.git#stable
    image: GNS3/gns3-web-ui
```
and got that error
```
[1/4] Resolving packages...
warning @angular/cli > universal-analytics > request@2.88.2: request has been deprecated, see https://github.com/request/request/issues/3142
warning @angular/cli > universal-analytics > request > har-validator@5.1.5: this library is no longer supported
[2/4] Fetching packages...
error @angular-devkit/architect@0.1001.6: The engine "node" is incompatible with this module. Expected version ">= 10.13.0". Got "8.17.0"
error Found incompatible module.
info Visit https://yarnpkg.com/en/docs/cli/global for documentation about this command.
ERROR: Service 'gns3-web-ui' failed to build : The command '/bin/sh -c yarn global add @angular/cli' returned a non-zero code: 1
```