### PR TITLE
re enable configure dialog

### DIFF
--- a/src/app/components/template/template-list-dialog/template-list-dialog.component.html
+++ b/src/app/components/template/template-list-dialog/template-list-dialog.component.html
@@ -1,4 +1,4 @@
-<!-- <div class="title-container">
+<div class="title-container">
   <h1 mat-dialog-title>Add a node</h1>
   <button
     mat-button
@@ -80,4 +80,4 @@
   <button class="addButton" mat-button (click)="onAddClick()" tabindex="2" mat-raised-button color="primary">
     Add
   </button>
-</div> -->
+</div>


### PR DESCRIPTION
When add node, configure return a blank dialog.
This PR re-enable commented HTML code.
resolve #1470 