### PR TITLE
Bug Fix: Slot Configuration Error in IOS Router Dialog

### DIFF
--- a/src/app/components/project-map/node-editors/configurator/ios/configurator-ios.component.ts
+++ b/src/app/components/project-map/node-editors/configurator/ios/configurator-ios.component.ts
@@ -88,7 +88,11 @@ export class ConfiguratorDialogIosComponent implements OnInit {
 
     // save network adapters
     for (let i = 0; i <= 6; i++) {
-      if (this.adapterMatrix[this.node.properties.platform][this.node.properties.chassis || ''][i]) {
+      const platform = this.node.properties.platform;
+      const chassis = this.node.properties.chassis || '';
+      const slotAdapters = this.adapterMatrix?.[platform]?.[chassis]?.[i];
+
+      if (slotAdapters) {
         if (this.networkAdaptersForNode[i] === undefined)
           this.node.properties[`slot${i}`] = ""
         else
@@ -98,7 +102,10 @@ export class ConfiguratorDialogIosComponent implements OnInit {
 
     // save WICs
     for (let i = 0; i <= 3; i++) {
-      if (this.wicMatrix[this.node.properties.platform][i]) {
+      const platform = this.node.properties.platform;
+      const wicAdapters = this.wicMatrix?.[platform]?.[i];
+
+      if (wicAdapters) {
         if (this.wicsForNode[i] === undefined)
           this.node.properties[`wic${i}`] = ""
         else


### PR DESCRIPTION
# Bug Fix: Slot Configuration Error in IOS Router Dialog

## Summary

Fixed a critical bug that caused the application to crash when clicking "Apply" in the IOS router configuration dialog after configuring slot 6 for C7200 platform devices.

## Problem Description

### Affected Component
IOS Router Configuration Dialog (`ConfiguratorDialogIosComponent`)

### Reproduction Steps
1. Right-click on a C7200 device in the project canvas
2. Select "Configure" from the context menu
3. Navigate to the "Slots" tab
4. Configure slot 6 (or any slot 0-6)
5. Click the "Apply" button

### Error Message
```
Cannot read properties of undefined (reading '0')
```

### Root Cause
The `saveSlotsData()` method was accessing nested properties of the `adapterMatrix` object without proper null/undefined checks. When attempting to validate slot configurations, the code directly accessed deeply nested properties:

```
adapterMatrix[platform][chassis][slotIndex]
```

If any intermediate property was undefined (due to missing platform configuration, incorrect chassis value, or undefined slot definition), attempting to access properties on `undefined` would throw an error.

Additionally, the same issue existed in the WIC (WAN Interface Card) saving logic.

## Solution

### Changes Made
Modified the `saveSlotsData()` method to use optional chaining (safe navigation) when accessing nested properties in the configuration matrices.

#### Key Improvements
1. **Added defensive null checks** using optional chaining operators before accessing nested properties
2. **Extracted intermediate values** into separate variables for better code readability
3. **Applied the same fix** to both network adapter slots and WIC slots logic

#### Technical Details
- Replaced direct nested property access with safe navigation pattern
- Each level of the property chain is now validated before proceeding to the next level
- If any configuration is missing or invalid, the code gracefully skips that slot instead of throwing an error

## Impact

### Before Fix
- Application crashed when attempting to save slot configurations
- Users unable to configure C7200 devices or any IOS router with slot 6
- Potential data loss if users had made other configuration changes before the crash

### After Fix
- Slot configuration saves successfully for all valid platforms and slots
- Application handles edge cases gracefully (missing platform, invalid chassis, etc.)
- No crashes or errors when clicking "Apply"


## Files Modified

- `src/app/components/project-map/node-editors/configurator/ios/configurator-ios.component.ts`


## Video Demonstration

### Before Fix

https://github.com/user-attachments/assets/10243b0c-1fbe-47d3-8ad5-b58aaf07edfa



### After Fix


https://github.com/user-attachments/assets/7b5d1230-60a7-4174-9865-c1640dd936e4

