### PR TITLE
feat(qemu-vm-template-details): improve validation error message

### DIFF
--- a/src/app/components/preferences/qemu/qemu-vm-template-details/qemu-vm-template-details.component.ts
+++ b/src/app/components/preferences/qemu/qemu-vm-template-details/qemu-vm-template-details.component.ts
@@ -141,7 +141,19 @@ export class QemuVmTemplateDetailsComponent implements OnInit {
 
   onSave() {
     if (this.generalSettingsForm.invalid) {
-      this.toasterService.error(`Fill all required fields`);
+      const missingFields: string[] = [];
+
+      if (this.generalSettingsForm.get('templateName').invalid) {
+        missingFields.push('Template name');
+      }
+      if (this.generalSettingsForm.get('defaultName').invalid) {
+        missingFields.push('Default name format');
+      }
+      if (this.generalSettingsForm.get('symbol').invalid) {
+        missingFields.push('Symbol');
+      }
+
+      this.toasterService.error(`Missing required fields: ${missingFields.join(', ')}`);
     } else {
       if (!this.activateCpuThrottling) {
         this.qemuTemplate.cpu_throttling = 0;


### PR DESCRIPTION
 ## Overview

  Improved validation error messaging in the QEMU VM template creation/editing interface to provide more specific user feedback.

##  What Changed

 ### Location

  src/app/components/preferences/qemu/qemu-vm-template-details/qemu-vm-template-details.component.ts

  ## Modification Details

  ### Before:
  - When users attempted to save a QEMU VM template with missing required fields, they received a generic error message
  - The error message simply stated "Fill all required fields" without specifying which fields were missing
  - Users had to manually inspect each field to identify what was missing

  ### After:
  - The system now performs granular validation checks on each required field
  - When validation fails, the error message dynamically lists the specific missing required fields
  - The error message format is: "Missing required fields: [Field 1], [Field 2], [Field 3]"
  - Required fields checked: Template name, Default name format, and Symbol

 ###  Benefits

  - Users receive immediate, actionable feedback about exactly which fields need attention
  - Reduces user confusion and time spent identifying missing information
  - Improves overall user experience during template configuration

  ---
  ## Video Demonstration

  ### Before Modification

https://github.com/user-attachments/assets/56e0edc9-4387-417d-84ec-f99642475eb6


  ### After Modification

https://github.com/user-attachments/assets/f8c58c27-d399-4339-bd00-fb7a712507fc


  ---
