### PR TITLE
feat(dynamips): conditionally show I/O memory field for specific plat…

### DIFF
--- a/src/app/components/preferences/dynamips/ios-template-details/ios-template-details.component.html
+++ b/src/app/components/preferences/dynamips/ios-template-details/ios-template-details.component.html
@@ -157,7 +157,7 @@
             />
             <span matSuffix>MB</span>
           </mat-form-field>
-          <mat-form-field class="form-field">
+          <mat-form-field class="form-field" *ngIf="['c1700', 'c2600', 'c2691', 'c3600', 'c3725', 'c3745'].includes(iosTemplate.platform)">
             <input
               matInput
               type="number"

--- a/src/app/components/preferences/dynamips/ios-template-details/ios-template-details.component.ts
+++ b/src/app/components/preferences/dynamips/ios-template-details/ios-template-details.component.ts
@@ -59,7 +59,7 @@ export class IosTemplateDetailsComponent implements OnInit {
     this.memoryForm = this.formBuilder.group({
       ram: new UntypedFormControl('', Validators.required),
       nvram: new UntypedFormControl('', Validators.required),
-      iomemory: new UntypedFormControl('', Validators.required),
+      iomemory: new UntypedFormControl(''),
       disk0: new UntypedFormControl('', Validators.required),
       disk1: new UntypedFormControl('', Validators.required),
     });
@@ -211,9 +211,6 @@ export class IosTemplateDetailsComponent implements OnInit {
       }
       if (this.memoryForm.get('nvram').invalid) {
         missingFields.push('NVRAM size');
-      }
-      if (this.memoryForm.get('iomemory').invalid) {
-        missingFields.push('I/O memory');
       }
       if (this.memoryForm.get('disk0').invalid) {
         missingFields.push('PCMCIA disk0');

--- a/src/app/components/project-map/node-editors/configurator/ios/configurator-ios.component.html
+++ b/src/app/components/project-map/node-editors/configurator/ios/configurator-ios.component.html
@@ -88,7 +88,7 @@
                 <span matSuffix>MiB</span>
               </mat-form-field>
             </form>
-            <mat-form-field class="form-field" *ngIf="node.properties.iomem">
+            <mat-form-field class="form-field" *ngIf="['c1700', 'c2600', 'c2691', 'c3600', 'c3725', 'c3745'].includes(node.properties.platform)">
               <input
                 matInput
                 type="number"


### PR DESCRIPTION
…forms

- Make I/O memory field optional in IOS template details form
- Only show I/O memory field for c1700, c2600, c2691, c3600, c3725, c3745 platforms
- Remove I/O memory from required validation in template validation
- Apply same platform-based conditional display in node configurator component