### PR TITLE
feat(cartography): add null safety for link nodes in graph data manager

### DIFF
--- a/src/app/cartography/managers/graph-data-manager.ts
+++ b/src/app/cartography/managers/graph-data-manager.ts
@@ -99,12 +99,15 @@ export class GraphDataManager {
     });
 
     this.getLinks().forEach((link: MapLink) => {
-      const source_id = link.nodes[0].nodeId;
-      const target_id = link.nodes[1].nodeId;
-      if (source_id in nodes_by_id) {
+      if (!link.nodes || link.nodes.length < 2) {
+        return;
+      }
+      const source_id = link.nodes[0]?.nodeId;
+      const target_id = link.nodes[1]?.nodeId;
+      if (source_id && source_id in nodes_by_id) {
         link.source = nodes_by_id[source_id];
       }
-      if (target_id in nodes_by_id) {
+      if (target_id && target_id in nodes_by_id) {
         link.target = nodes_by_id[target_id];
       }
 


### PR DESCRIPTION
Add optional chaining and null checks to prevent errors when link nodes are undefined or incomplete. This ensures the graph data manager can handle malformed link data gracefully without crashing.