### PR TITLE
Fix #1595 - Snap to grid setting is not persisted after page refresh

### DIFF
--- a/src/app/components/project-map/project-map.component.ts
+++ b/src/app/components/project-map/project-map.component.ts
@@ -883,7 +883,17 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
   }
 
   public toggleSnapToGrid(enabled: boolean) {
+    const previousValue = this.project.snap_to_grid;
     this.project.snap_to_grid = enabled;
+    this.projectService.update(this.controller, this.project).subscribe(
+      (project: Project) => {
+        this.project.snap_to_grid = project.snap_to_grid;
+      },
+      () => {
+        this.project.snap_to_grid = previousValue;
+        this.toasterService.error('Cannot update project settings');
+      }
+    );
   }
 
   private showMessage(msg) {

--- a/src/app/services/project.service.ts
+++ b/src/app/services/project.service.ts
@@ -95,6 +95,7 @@ export class ProjectService {
       name: project.name,
       scene_width: project.scene_width,
       scene_height: project.scene_height,
+      snap_to_grid: project.snap_to_grid,
       show_interface_labels: project.show_interface_labels,
     });
   }


### PR DESCRIPTION
Fix for issue 1595 - Snap to grid setting is not persisted after page refresh