### PR TITLE
Improve menu hover visibility and main menu spacing

### DIFF
--- a/src/app/components/project-map/project-map.component.scss
+++ b/src/app/components/project-map/project-map.component.scss
@@ -382,8 +382,8 @@ g.node text,
 .context-menu-items .mat-menu-item:focus {
   background: none;
 }
-.light-theme .context-menu-items .mat-menu-item:hover {
-  background-color: rgba(153, 152, 152, 0.795) !important;
+.context-menu-items .mat-menu-item:hover {
+  background-color: #DC143C !important;
 }
 
 .visible {

--- a/src/theme.scss
+++ b/src/theme.scss
@@ -132,3 +132,16 @@ $light-theme: map-merge(
   @include mat-tooltip-theme($light-theme);
   @include mat-snack-bar-theme($light-theme);
 }
+
+$menu-hover-background: #DC143C;
+
+.mat-menu-panel .mat-menu-item:not([disabled]):hover,
+.mat-menu-panel .mat-menu-item:not([disabled]).cdk-program-focused,
+.mat-menu-panel .mat-menu-item:not([disabled]).cdk-keyboard-focused {
+  background-color: $menu-hover-background !important;
+}
+
+.mat-menu-panel:not(.context-menu-items) .mat-menu-item {
+  height: 32px;
+  line-height: 32px;
+}


### PR DESCRIPTION
## Summary
Menu item hover feedback in the GNS3 Web UI is currently low-contrast in several places, which makes active selection states harder to see. This update standardizes menu hover color to `#DC143C` (Crimson) for contextual and non-contextual menus, and reduces non-contextual menu item spacing to improve scan speed.

## Problem Statement
- Current hover backgrounds are not consistently visible across menu surfaces.
- Main menus use larger default item spacing than needed, which increases vertical travel for common actions.
- Contextual menus already use compact spacing that should remain unchanged.

## Proposed Change
- Set hover background color to `#DC143C` for all `mat-menu` items.
- Apply `height: 32px` and `line-height: 32px` to menu items in non-contextual menu panels.
- Keep contextual menu item sizing as-is (no change to contextual menu density).

I used this color but it can be changed to a different color if this does not fit the current themes setup.