### PR TITLE
Fix for first auto-focused port gets highlighted immediately

### DIFF
--- a/src/app/components/project-map/project-map.component.scss
+++ b/src/app/components/project-map/project-map.component.scss
@@ -382,6 +382,13 @@ g.node text,
 .context-menu-items .mat-menu-item:focus {
   background: none;
 }
+
+.context-menu-items .mat-menu-item.cdk-focused:not(:hover),
+.context-menu-items .mat-menu-item.cdk-program-focused:not(:hover),
+.context-menu-items .mat-menu-item.cdk-keyboard-focused:not(:hover) {
+  background: none !important;
+}
+
 .context-menu-items .mat-menu-item:hover {
   background-color: #DC143C !important;
 }

--- a/src/theme.scss
+++ b/src/theme.scss
@@ -134,11 +134,27 @@ $light-theme: map-merge(
 }
 
 $menu-hover-background: #DC143C;
+$menu-selected-text-color: #FFFFFF;
 
-.mat-menu-panel .mat-menu-item:not([disabled]):hover,
-.mat-menu-panel .mat-menu-item:not([disabled]).cdk-program-focused,
-.mat-menu-panel .mat-menu-item:not([disabled]).cdk-keyboard-focused {
+.mat-menu-panel .mat-menu-item:not([disabled]):hover {
   background-color: $menu-hover-background !important;
+}
+
+.mat-menu-panel:not(.context-menu-items) .mat-menu-item:not([disabled]).cdk-program-focused,
+.mat-menu-panel:not(.context-menu-items) .mat-menu-item:not([disabled]).cdk-keyboard-focused {
+  background-color: $menu-hover-background !important;
+}
+
+.light-theme .mat-menu-panel .mat-menu-item:not([disabled]):hover,
+.light-theme .mat-menu-panel:not(.context-menu-items) .mat-menu-item:not([disabled]).cdk-program-focused,
+.light-theme .mat-menu-panel:not(.context-menu-items) .mat-menu-item:not([disabled]).cdk-keyboard-focused {
+  color: $menu-selected-text-color !important;
+}
+
+.light-theme .mat-menu-panel .mat-menu-item:not([disabled]):hover .mat-icon,
+.light-theme .mat-menu-panel:not(.context-menu-items) .mat-menu-item:not([disabled]).cdk-program-focused .mat-icon,
+.light-theme .mat-menu-panel:not(.context-menu-items) .mat-menu-item:not([disabled]).cdk-keyboard-focused .mat-icon {
+  color: $menu-selected-text-color !important;
 }
 
 .mat-menu-panel:not(.context-menu-items) .mat-menu-item {


### PR DESCRIPTION
I have corrected the issue for the auto-focused port.

Also for the light theme which uses black font for the menu items I have adjusted the selected font color to white to improve visibility