### PR TITLE
Enhancement: Improve interface label visibility/positioning and multi-link spacing for bundled links (port-channel)

### DIFF
--- a/src/app/cartography/helpers/multi-link-calculator-helper.spec.ts
+++ b/src/app/cartography/helpers/multi-link-calculator-helper.spec.ts
@@ -1,0 +1,95 @@
+import { MapLink } from '../models/map/map-link';
+import { MapNode } from '../models/map/map-node';
+import { MultiLinkCalculatorHelper } from './multi-link-calculator-helper';
+
+describe('MultiLinkCalculatorHelper', () => {
+  let helper: MultiLinkCalculatorHelper;
+
+  beforeEach(() => {
+    helper = new MultiLinkCalculatorHelper();
+  });
+
+  it('should return no translation for zero distance', () => {
+    const translation = helper.linkTranslation(0, { x: 0, y: 0 }, { x: 100, y: 0 });
+
+    expect(translation).toEqual({ dx: 0, dy: 0 });
+  });
+
+  it('should return no translation for zero-length links', () => {
+    const translation = helper.linkTranslation(14, { x: 10, y: 20 }, { x: 10, y: 20 });
+
+    expect(translation).toEqual({ dx: 0, dy: 0 });
+  });
+
+  it('should translate perpendicular to a horizontal link', () => {
+    const translation = helper.linkTranslation(7, { x: 0, y: 0 }, { x: 100, y: 0 });
+
+    expect(translation.dx).toBeCloseTo(0, 6);
+    expect(translation.dy).toBeCloseTo(7, 6);
+  });
+
+  it('should translate perpendicular to a vertical link', () => {
+    const translation = helper.linkTranslation(7, { x: 0, y: 0 }, { x: 0, y: 100 });
+
+    expect(translation.dx).toBeCloseTo(-7, 6);
+    expect(translation.dy).toBeCloseTo(0, 6);
+  });
+
+  it('should assign symmetric offsets for odd link counts', () => {
+    const links = [createLink('A', 'B'), createLink('A', 'B'), createLink('A', 'B')];
+
+    helper.assignDataToLinks(links);
+
+    expect(links.map((link) => link.distance)).toEqual([-14, 0, 14]);
+  });
+
+  it('should assign symmetric offsets for even link counts', () => {
+    const links = [createLink('A', 'B'), createLink('A', 'B'), createLink('A', 'B'), createLink('A', 'B')];
+
+    helper.assignDataToLinks(links);
+
+    expect(links.map((link) => link.distance)).toEqual([-21, -7, 7, 21]);
+  });
+
+  it('should group links regardless of source/target ordering', () => {
+    const linkAB = createLink('A', 'B');
+    const linkBA = createLink('B', 'A');
+
+    helper.assignDataToLinks([linkAB, linkBA]);
+
+    expect(linkAB.distance).toBe(-7);
+    expect(linkBA.distance).toBe(7);
+  });
+
+  it('should handle missing source or target without affecting valid links', () => {
+    const missingSource = createLink(undefined, 'B');
+    const missingTarget = createLink('A', undefined);
+    const validOne = createLink('A', 'B');
+    const validTwo = createLink('A', 'B');
+
+    helper.assignDataToLinks([missingSource, missingTarget, validOne, validTwo]);
+
+    expect(missingSource.distance).toBe(0);
+    expect(missingTarget.distance).toBe(0);
+    expect(validOne.distance).toBe(-7);
+    expect(validTwo.distance).toBe(7);
+  });
+});
+
+function createNode(id: string): MapNode {
+  return { id } as MapNode;
+}
+
+function createLink(sourceId?: string, targetId?: string): MapLink {
+  const link = new MapLink();
+
+  if (sourceId) {
+    link.source = createNode(sourceId);
+  }
+
+  if (targetId) {
+    link.target = createNode(targetId);
+  }
+
+  return link;
+}

--- a/src/app/cartography/helpers/multi-link-calculator-helper.spec.ts
+++ b/src/app/cartography/helpers/multi-link-calculator-helper.spec.ts
@@ -51,6 +51,36 @@ describe('MultiLinkCalculatorHelper', () => {
     expect(links.map((link) => link.distance)).toEqual([-21, -7, 7, 21]);
   });
 
+  it('should reduce spacing for bundles larger than four links', () => {
+    const links = [
+      createLink('A', 'B'),
+      createLink('A', 'B'),
+      createLink('A', 'B'),
+      createLink('A', 'B'),
+      createLink('A', 'B'),
+    ];
+
+    helper.assignDataToLinks(links);
+
+    expect(links.map((link) => link.distance)).toEqual([-20, -10, 0, 10, 20]);
+  });
+
+  it('should enforce a minimum spacing floor for very dense bundles on small nodes', () => {
+    const links = [
+      createLink('A', 'B', 40, 40, 40, 40),
+      createLink('A', 'B', 40, 40, 40, 40),
+      createLink('A', 'B', 40, 40, 40, 40),
+      createLink('A', 'B', 40, 40, 40, 40),
+      createLink('A', 'B', 40, 40, 40, 40),
+      createLink('A', 'B', 40, 40, 40, 40),
+      createLink('A', 'B', 40, 40, 40, 40),
+    ];
+
+    helper.assignDataToLinks(links);
+
+    expect(links.map((link) => link.distance)).toEqual([-18, -12, -6, 0, 6, 12, 18]);
+  });
+
   it('should group links regardless of source/target ordering', () => {
     const linkAB = createLink('A', 'B');
     const linkBA = createLink('B', 'A');
@@ -74,21 +104,40 @@ describe('MultiLinkCalculatorHelper', () => {
     expect(validOne.distance).toBe(-7);
     expect(validTwo.distance).toBe(7);
   });
+
+  it('should set parallelLinksCount for grouped links', () => {
+    const links = [createLink('A', 'B'), createLink('A', 'B'), createLink('A', 'B')];
+
+    helper.assignDataToLinks(links);
+
+    expect(links.map((link) => link.parallelLinksCount)).toEqual([3, 3, 3]);
+  });
 });
 
-function createNode(id: string): MapNode {
-  return { id } as MapNode;
+function createNode(id: string, width?: number, height?: number): MapNode {
+  return {
+    id,
+    width,
+    height,
+  } as MapNode;
 }
 
-function createLink(sourceId?: string, targetId?: string): MapLink {
+function createLink(
+  sourceId?: string,
+  targetId?: string,
+  sourceWidth?: number,
+  sourceHeight?: number,
+  targetWidth?: number,
+  targetHeight?: number
+): MapLink {
   const link = new MapLink();
 
   if (sourceId) {
-    link.source = createNode(sourceId);
+    link.source = createNode(sourceId, sourceWidth, sourceHeight);
   }
 
   if (targetId) {
-    link.target = createNode(targetId);
+    link.target = createNode(targetId, targetWidth, targetHeight);
   }
 
   return link;

--- a/src/app/cartography/helpers/multi-link-calculator-helper.spec.ts
+++ b/src/app/cartography/helpers/multi-link-calculator-helper.spec.ts
@@ -81,6 +81,30 @@ describe('MultiLinkCalculatorHelper', () => {
     expect(links.map((link) => link.distance)).toEqual([-18, -12, -6, 0, 6, 12, 18]);
   });
 
+  it('should keep eight dense links visible and stack 14-link overflow on middle link #5', () => {
+    const links = Array.from({ length: 14 }, () => createLink('A', 'B', 72, 72, 72, 72));
+
+    helper.assignDataToLinks(links);
+
+    expect(links.map((link) => link.distance)).toEqual([4, 4, 4, -28, -20, -12, -4, 4, 12, 20, 28, 4, 4, 4]);
+  });
+
+  it('should keep eight dense links visible and stack 16-link overflow on middle link #5', () => {
+    const links = Array.from({ length: 16 }, () => createLink('A', 'B', 72, 72, 72, 72));
+
+    helper.assignDataToLinks(links);
+
+    expect(links.map((link) => link.distance)).toEqual([4, 4, 4, 4, -28, -20, -12, -4, 4, 12, 20, 28, 4, 4, 4, 4]);
+  });
+
+  it('should keep eight dense links uniformly spaced for odd dense bundles and stack overflow', () => {
+    const links = Array.from({ length: 15 }, () => createLink('A', 'B', 72, 72, 72, 72));
+
+    helper.assignDataToLinks(links);
+
+    expect(links.map((link) => link.distance)).toEqual([4, 4, 4, -28, -20, -12, -4, 4, 12, 20, 28, 4, 4, 4, 4]);
+  });
+
   it('should group links regardless of source/target ordering', () => {
     const linkAB = createLink('A', 'B');
     const linkBA = createLink('B', 'A');

--- a/src/app/cartography/helpers/multi-link-calculator-helper.ts
+++ b/src/app/cartography/helpers/multi-link-calculator-helper.ts
@@ -3,7 +3,11 @@ import { MapLink } from '../models/map/map-link';
 
 @Injectable()
 export class MultiLinkCalculatorHelper {
-  private static readonly LINK_SPACING = 14;
+  private static readonly DEFAULT_LINK_SPACING = 14;
+  private static readonly DENSE_LINK_SPACING = 10;
+  private static readonly MIN_LINK_SPACING = 6;
+  private static readonly DENSE_BUNDLE_THRESHOLD = 4;
+  private static readonly NODE_EDGE_PADDING = 8;
 
   public linkTranslation(
     distance: number,
@@ -43,6 +47,7 @@ export class MultiLinkCalculatorHelper {
     links.forEach((link: MapLink) => {
       if (!link.source || !link.target) {
         link.distance = 0;
+        link.parallelLinksCount = 1;
         return;
       }
 
@@ -59,10 +64,61 @@ export class MultiLinkCalculatorHelper {
     Object.keys(linksFromNodes).forEach((key) => {
       const groupedLinks = linksFromNodes[key];
       const center = (groupedLinks.length - 1) / 2;
+      const spacing = this.calculateSpacingForGroup(groupedLinks);
 
       groupedLinks.forEach((link: MapLink, index: number) => {
-        link.distance = (index - center) * MultiLinkCalculatorHelper.LINK_SPACING;
+        link.distance = (index - center) * spacing;
+        link.parallelLinksCount = groupedLinks.length;
       });
     });
+  }
+
+  private calculateSpacingForGroup(groupedLinks: MapLink[]): number {
+    if (groupedLinks.length <= MultiLinkCalculatorHelper.DENSE_BUNDLE_THRESHOLD) {
+      return MultiLinkCalculatorHelper.DEFAULT_LINK_SPACING;
+    }
+
+    let spacing = MultiLinkCalculatorHelper.DENSE_LINK_SPACING;
+    const maxSpacingFromNodeSize = this.getMaxSpacingFromNodeSize(groupedLinks);
+
+    if (maxSpacingFromNodeSize > 0) {
+      spacing = Math.min(spacing, maxSpacingFromNodeSize);
+    }
+
+    return Math.max(MultiLinkCalculatorHelper.MIN_LINK_SPACING, spacing);
+  }
+
+  private getMaxSpacingFromNodeSize(groupedLinks: MapLink[]): number {
+    if (groupedLinks.length <= 1) {
+      return MultiLinkCalculatorHelper.DEFAULT_LINK_SPACING;
+    }
+
+    const reference = groupedLinks[0];
+    const sourceSpan = this.getNodeCrossSection(reference.source);
+    const targetSpan = this.getNodeCrossSection(reference.target);
+
+    if (!sourceSpan || !targetSpan) {
+      return 0;
+    }
+
+    const availableSpan = Math.min(sourceSpan, targetSpan) - MultiLinkCalculatorHelper.NODE_EDGE_PADDING * 2;
+    if (availableSpan <= 0) {
+      return 0;
+    }
+
+    return availableSpan / (groupedLinks.length - 1);
+  }
+
+  private getNodeCrossSection(node: { width: number; height: number }): number {
+    if (!node) {
+      return 0;
+    }
+
+    const dimensions = [node.width, node.height].filter((value) => typeof value === 'number' && value > 0);
+    if (dimensions.length === 0) {
+      return 0;
+    }
+
+    return Math.min(...dimensions);
   }
 }

--- a/src/app/cartography/helpers/multi-link-calculator-helper.ts
+++ b/src/app/cartography/helpers/multi-link-calculator-helper.ts
@@ -8,6 +8,7 @@ export class MultiLinkCalculatorHelper {
   private static readonly MIN_LINK_SPACING = 6;
   private static readonly DENSE_BUNDLE_THRESHOLD = 4;
   private static readonly NODE_EDGE_PADDING = 8;
+  private static readonly MAX_VISIBLE_DENSE_LINKS = 8;
 
   public linkTranslation(
     distance: number,
@@ -63,14 +64,52 @@ export class MultiLinkCalculatorHelper {
 
     Object.keys(linksFromNodes).forEach((key) => {
       const groupedLinks = linksFromNodes[key];
-      const center = (groupedLinks.length - 1) / 2;
       const spacing = this.calculateSpacingForGroup(groupedLinks);
+      const visibleRange = this.getVisibleRange(groupedLinks.length);
+      const overflowStackDistance = this.getOverflowStackDistance(groupedLinks.length, spacing);
+      const visibleCenter = (visibleRange.count - 1) / 2;
 
       groupedLinks.forEach((link: MapLink, index: number) => {
-        link.distance = (index - center) * spacing;
+        if (index < visibleRange.start || index > visibleRange.end) {
+          link.distance = overflowStackDistance;
+        } else {
+          const visibleIndex = index - visibleRange.start;
+          link.distance = (visibleIndex - visibleCenter) * spacing;
+        }
+
         link.parallelLinksCount = groupedLinks.length;
       });
     });
+  }
+
+  private getVisibleRange(linkCount: number): { start: number; end: number; count: number } {
+    if (linkCount <= MultiLinkCalculatorHelper.MAX_VISIBLE_DENSE_LINKS) {
+      return {
+        start: 0,
+        end: Math.max(0, linkCount - 1),
+        count: linkCount,
+      };
+    }
+
+    const visibleLinksCount = this.getVisibleLinksCountForSpacing(linkCount);
+    const hiddenLinksCount = linkCount - visibleLinksCount;
+    const leftHiddenCount = Math.floor(hiddenLinksCount / 2);
+    const start = leftHiddenCount;
+
+    return {
+      start,
+      end: start + visibleLinksCount - 1,
+      count: visibleLinksCount,
+    };
+  }
+
+  private getOverflowStackDistance(linkCount: number, spacing: number): number {
+    if (linkCount <= MultiLinkCalculatorHelper.MAX_VISIBLE_DENSE_LINKS) {
+      return 0;
+    }
+
+    // Stack overflow links on middle visible link #5 when 8 dense links are shown.
+    return spacing / 2;
   }
 
   private calculateSpacingForGroup(groupedLinks: MapLink[]): number {
@@ -89,7 +128,9 @@ export class MultiLinkCalculatorHelper {
   }
 
   private getMaxSpacingFromNodeSize(groupedLinks: MapLink[]): number {
-    if (groupedLinks.length <= 1) {
+    const visibleLinksCount = this.getVisibleLinksCountForSpacing(groupedLinks.length);
+
+    if (visibleLinksCount <= 1) {
       return MultiLinkCalculatorHelper.DEFAULT_LINK_SPACING;
     }
 
@@ -106,7 +147,11 @@ export class MultiLinkCalculatorHelper {
       return 0;
     }
 
-    return availableSpan / (groupedLinks.length - 1);
+    return availableSpan / (visibleLinksCount - 1);
+  }
+
+  private getVisibleLinksCountForSpacing(linkCount: number): number {
+    return Math.min(linkCount, MultiLinkCalculatorHelper.MAX_VISIBLE_DENSE_LINKS);
   }
 
   private getNodeCrossSection(node: { width: number; height: number }): number {

--- a/src/app/cartography/helpers/multi-link-calculator-helper.ts
+++ b/src/app/cartography/helpers/multi-link-calculator-helper.ts
@@ -3,45 +3,66 @@ import { MapLink } from '../models/map/map-link';
 
 @Injectable()
 export class MultiLinkCalculatorHelper {
-  LINK_WIDTH = 2;
+  private static readonly LINK_SPACING = 14;
 
   public linkTranslation(
     distance: number,
     point0: { x: number; y: number },
     point1: { x: number; y: number }
   ): { dx: number; dy: number } {
-    const x1_x0 = point1.x - point0.x;
-    const y1_y0 = point1.y - point0.y;
-    let x2_x0;
-    let y2_y0;
-
-    if (y1_y0 === 0) {
-      x2_x0 = 0;
-      y2_y0 = distance;
-    } else {
-      const angle = Math.atan(x1_x0 / y1_y0);
-      x2_x0 = -distance * Math.cos(angle);
-      y2_y0 = distance * Math.sin(angle);
+    if (!distance) {
+      return {
+        dx: 0,
+        dy: 0,
+      };
     }
+
+    const deltaX = point1.x - point0.x;
+    const deltaY = point1.y - point0.y;
+    const lineLength = Math.sqrt(deltaX * deltaX + deltaY * deltaY);
+
+    if (lineLength === 0) {
+      return {
+        dx: 0,
+        dy: 0,
+      };
+    }
+
+    const perpendicularX = -deltaY / lineLength;
+    const perpendicularY = deltaX / lineLength;
+
     return {
-      dx: x2_x0,
-      dy: y2_y0,
+      dx: perpendicularX * distance,
+      dy: perpendicularY * distance,
     };
   }
 
   public assignDataToLinks(links: MapLink[]) {
-    const links_from_nodes = {};
-    links.forEach((l: MapLink, i: number) => {
-      const sid = l.source.id;
-      const tid = l.target.id;
-      const key = sid < tid ? sid + ',' + tid : tid + ',' + sid;
-      let idx = 1;
-      if (!(key in links_from_nodes)) {
-        links_from_nodes[key] = [i];
-      } else {
-        idx = links_from_nodes[key].push(i);
+    const linksFromNodes: { [key: string]: MapLink[] } = {};
+
+    links.forEach((link: MapLink) => {
+      if (!link.source || !link.target) {
+        link.distance = 0;
+        return;
       }
-      l.distance = idx % 2 === 0 ? idx * this.LINK_WIDTH : (-idx + 1) * this.LINK_WIDTH;
+
+      const sid = link.source.id;
+      const tid = link.target.id;
+      const key = sid < tid ? `${sid},${tid}` : `${tid},${sid}`;
+
+      if (!(key in linksFromNodes)) {
+        linksFromNodes[key] = [];
+      }
+      linksFromNodes[key].push(link);
+    });
+
+    Object.keys(linksFromNodes).forEach((key) => {
+      const groupedLinks = linksFromNodes[key];
+      const center = (groupedLinks.length - 1) / 2;
+
+      groupedLinks.forEach((link: MapLink, index: number) => {
+        link.distance = (index - center) * MultiLinkCalculatorHelper.LINK_SPACING;
+      });
     });
   }
 }

--- a/src/app/cartography/models/map/map-link.ts
+++ b/src/app/cartography/models/map/map-link.ts
@@ -23,6 +23,7 @@ export class MapLink implements Indexed {
 
   isSelected = false; // this is not from controller
   isMultiplied = false; // this is not from controller
+  parallelLinksCount = 1; // this is not from controller
   x: number; // this is not from controller
   y: number; // this is not from controller
 }

--- a/src/app/cartography/widgets/interface-status.ts
+++ b/src/app/cartography/widgets/interface-status.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { select } from 'd3-selection';
+import { select, Selection } from 'd3-selection';
 import { MapSettingsService } from '@services/mapsettings.service';
 import { LinkStatus } from '../models/link-status';
 import { MapLink } from '../models/map/map-link';
@@ -8,6 +8,7 @@ import { Widget } from './widget';
 
 @Injectable()
 export class InterfaceStatusWidget implements Widget {
+  private static readonly MAX_INLINE_LABELS_PARALLEL_LINKS = 4;
   private static readonly LABEL_DISTANCE = 60;
   private static readonly MIN_LINK_LENGTH_FOR_LABELS = 180;
   private static readonly LABEL_HEIGHT = 18;
@@ -23,40 +24,33 @@ export class InterfaceStatusWidget implements Widget {
 
   public draw(view: SVGSelection) {
     const self = this;
-    let mapLinks: MapLink[] = [];
 
     view.each(function (this: SVGGElement, l: MapLink) {
-      mapLinks.push(l);
-    });
-    mapLinks.forEach((mapLink) => {
-      mapLink.isMultiplied = false;
-      mapLinks.forEach((n) => {
-        if (n.nodes[0].linkId !== mapLink.nodes[0].linkId) {
-          if (
-            (mapLink.nodes[0].nodeId === n.nodes[0].nodeId && mapLink.nodes[1].nodeId === n.nodes[1].nodeId) ||
-            (mapLink.nodes[0].nodeId === n.nodes[1].nodeId && mapLink.nodes[1].nodeId === n.nodes[0].nodeId) ||
-            (mapLink.nodes[1].nodeId === n.nodes[0].nodeId && mapLink.nodes[0].nodeId === n.nodes[1].nodeId)
-          ) {
-            mapLink.isMultiplied = true;
-          }
-        }
-      });
-    });
+      l.isMultiplied = (l.parallelLinksCount || 1) > 1;
 
-    view.each(function (this: SVGGElement, l: MapLink) {
       const link_group = select<SVGGElement, MapLink>(this);
       const link_path = link_group.select<SVGPathElement>('path');
+      const showInterfaceLabels = self.mapSettingsService.showInterfaceLabels;
+      const useIntegratedLabels = showInterfaceLabels && self.mapSettingsService.integrateLinkLabelsToLinks;
+      const useTooltipOnlyLabels = showInterfaceLabels && self.shouldRenderTooltipOnly(l);
 
       let statuses: LinkStatus[] = [];
       const pathNode = link_path.node();
       if (pathNode) {
         const totalLength = pathNode.getTotalLength();
 
-        if (totalLength > InterfaceStatusWidget.MIN_LINK_LENGTH_FOR_LABELS && l.source && l.target) {
-          const start_point: SVGPoint = pathNode.getPointAtLength(InterfaceStatusWidget.LABEL_DISTANCE);
-          const end_point: SVGPoint = pathNode.getPointAtLength(totalLength - InterfaceStatusWidget.LABEL_DISTANCE);
-          const sourcePort = l.nodes.find((node) => node.nodeId === l.source.id)?.label?.text || '';
-          const destinationPort = l.nodes.find((node) => node.nodeId === l.target.id)?.label?.text || '';
+        if (
+          l.source &&
+          l.target &&
+          (useTooltipOnlyLabels || totalLength > InterfaceStatusWidget.MIN_LINK_LENGTH_FOR_LABELS)
+        ) {
+          const labelDistance = useTooltipOnlyLabels
+            ? Math.min(InterfaceStatusWidget.LABEL_DISTANCE, totalLength / 4)
+            : InterfaceStatusWidget.LABEL_DISTANCE;
+          const start_point: SVGPoint = pathNode.getPointAtLength(labelDistance);
+          const end_point: SVGPoint = pathNode.getPointAtLength(totalLength - labelDistance);
+          const sourcePort = l.nodes?.find((node) => node.nodeId === l.source.id)?.label?.text || '';
+          const destinationPort = l.nodes?.find((node) => node.nodeId === l.target.id)?.label?.text || '';
 
           statuses = [
             new LinkStatus(
@@ -75,6 +69,9 @@ export class InterfaceStatusWidget implements Widget {
         }
       }
 
+      self.renderEndpointHoverTooltips(link_group, statuses, useTooltipOnlyLabels);
+      self.bindEndpointTooltipHover(link_path, link_group, useTooltipOnlyLabels);
+
       link_group.selectAll<SVGCircleElement, LinkStatus>('circle.status_started').remove();
       link_group.selectAll<SVGCircleElement, LinkStatus>('circle.status_stopped').remove();
       link_group.selectAll<SVGCircleElement, LinkStatus>('circle.status_suspended').remove();
@@ -86,10 +83,7 @@ export class InterfaceStatusWidget implements Widget {
       link_group.selectAll<SVGRectElement, LinkStatus>('rect.status_suspended').remove();
       link_group.selectAll<SVGTextElement, LinkStatus>('text.status_suspended_label').remove();
 
-      if (
-        self.mapSettingsService.showInterfaceLabels &&
-        self.mapSettingsService.integrateLinkLabelsToLinks
-      ) {
+      if (useIntegratedLabels && !useTooltipOnlyLabels) {
         const status_labels = link_group.selectAll<SVGGElement, LinkStatus>('g.status_label').data(statuses);
         const status_labels_enter = status_labels.enter().append<SVGGElement>('g').attr('class', 'status_label');
 
@@ -209,5 +203,118 @@ export class InterfaceStatusWidget implements Widget {
       return 'red';
     }
     return '#FFFF00';
+  }
+
+  private shouldRenderTooltipOnly(link: MapLink): boolean {
+    return (link.parallelLinksCount || 1) > InterfaceStatusWidget.MAX_INLINE_LABELS_PARALLEL_LINKS;
+  }
+
+  private renderEndpointHoverTooltips(
+    linkGroup: Selection<SVGGElement, MapLink, SVGElement, any>,
+    statuses: LinkStatus[],
+    enabled: boolean
+  ) {
+    const tooltips = linkGroup
+      .selectAll<SVGGElement, LinkStatus>('g.status_hover_tooltip')
+      .data(enabled ? statuses : []);
+
+    const tooltipsEnter = tooltips
+      .enter()
+      .append<SVGGElement>('g')
+      .attr('class', 'status_hover_tooltip')
+      .attr('visibility', 'hidden');
+
+    const tooltipsMerge = tooltips
+      .merge(tooltipsEnter)
+      .style('pointer-events', 'none')
+      .attr('transform', (ls: LinkStatus) => `translate(${ls.x}, ${ls.y})`);
+
+    tooltipsMerge.raise();
+
+    const tooltipRects = tooltipsMerge.selectAll<SVGRectElement, LinkStatus>('rect').data((ls) => [ls]);
+    tooltipRects
+      .enter()
+      .append<SVGRectElement>('rect')
+      .merge(tooltipRects)
+      .attr('class', 'status_hover_tooltip_rect')
+      .attr('width', (ls: LinkStatus) => this.getLabelWidth(ls.port))
+      .attr('height', InterfaceStatusWidget.LABEL_HEIGHT)
+      .attr('x', (ls: LinkStatus) => -(this.getLabelWidth(ls.port) / 2))
+      .attr('y', -InterfaceStatusWidget.LABEL_HEIGHT / 2)
+      .attr('rx', InterfaceStatusWidget.LABEL_RADIUS)
+      .attr('ry', InterfaceStatusWidget.LABEL_RADIUS)
+      .style('fill', InterfaceStatusWidget.LABEL_BACKGROUND_COLOR)
+      .style('fill-opacity', 1)
+      .attr('stroke', (ls: LinkStatus) => this.getStatusStrokeColor(ls.status))
+      .attr('stroke-width', InterfaceStatusWidget.LABEL_STROKE_WIDTH);
+    tooltipRects.exit().remove();
+
+    const tooltipTexts = tooltipsMerge.selectAll<SVGTextElement, LinkStatus>('text').data((ls) => [ls]);
+    tooltipTexts
+      .enter()
+      .append<SVGTextElement>('text')
+      .merge(tooltipTexts)
+      .attr('class', 'status_hover_tooltip_label')
+      .text((ls: LinkStatus) => ls.port || '')
+      .attr('x', 0)
+      .attr('y', 0)
+      .attr('dy', '0em')
+      .attr('text-anchor', 'middle')
+      .attr('dominant-baseline', 'central')
+      .attr('alignment-baseline', 'central')
+      .attr('fill', '#111111')
+      .style('font-family', InterfaceStatusWidget.LABEL_FONT_FAMILY)
+      .style('font-size', `${InterfaceStatusWidget.LABEL_FONT_SIZE}px`)
+      .style('font-weight', '500');
+    tooltipTexts.exit().remove();
+
+    tooltips.exit().remove();
+  }
+
+  private bindEndpointTooltipHover(
+    linkPath: Selection<SVGPathElement, MapLink, SVGGElement, MapLink>,
+    linkGroup: Selection<SVGGElement, MapLink, SVGElement, any>,
+    enabled: boolean
+  ) {
+    const linkGroupNode = linkGroup.node();
+    const linkContainer =
+      linkGroupNode && linkGroupNode.parentNode
+        ? select<SVGGElement, MapLink>(linkGroupNode.parentNode as SVGGElement)
+        : null;
+
+    if (!enabled) {
+      linkPath.on('mouseover.status_hover_tooltip', null);
+      linkPath.on('mouseout.status_hover_tooltip', null);
+      linkPath.attr('pointer-events', null);
+      linkGroup.selectAll<SVGGElement, LinkStatus>('g.status_hover_tooltip').attr('visibility', 'hidden');
+      return;
+    }
+
+    linkPath.attr('pointer-events', 'stroke');
+
+    linkPath
+      .on('mouseover.status_hover_tooltip', () => {
+        if (linkContainer) {
+          linkContainer.raise();
+        }
+        linkGroup
+          .selectAll<SVGGElement, LinkStatus>('g.status_hover_tooltip')
+          .raise()
+          .attr('visibility', 'visible');
+      })
+      .on('mouseout.status_hover_tooltip', () => {
+        linkGroup.selectAll<SVGGElement, LinkStatus>('g.status_hover_tooltip').attr('visibility', 'hidden');
+      });
+
+    const pathNode = linkPath.node();
+    const isHovered = pathNode ? pathNode.matches(':hover') : false;
+    const tooltipSelection = linkGroup.selectAll<SVGGElement, LinkStatus>('g.status_hover_tooltip');
+    if (isHovered) {
+      if (linkContainer) {
+        linkContainer.raise();
+      }
+      tooltipSelection.raise();
+    }
+    tooltipSelection.attr('visibility', isHovered ? 'visible' : 'hidden');
   }
 }

--- a/src/app/cartography/widgets/interface-status.ts
+++ b/src/app/cartography/widgets/interface-status.ts
@@ -85,7 +85,6 @@ export class InterfaceStatusWidget implements Widget {
       link_group.selectAll<SVGTextElement, LinkStatus>('text.status_stopped_label').remove();
       link_group.selectAll<SVGRectElement, LinkStatus>('rect.status_suspended').remove();
       link_group.selectAll<SVGTextElement, LinkStatus>('text.status_suspended_label').remove();
-      link_group.selectAll<SVGGElement, LinkStatus>('g.status_label').remove();
 
       if (
         self.mapSettingsService.showInterfaceLabels &&
@@ -137,6 +136,8 @@ export class InterfaceStatusWidget implements Widget {
 
         status_labels.exit().remove();
       } else {
+        link_group.selectAll<SVGGElement, LinkStatus>('g.status_label').remove();
+
         const status_started = link_group
           .selectAll<SVGCircleElement, LinkStatus>('circle.status_started')
           .data(statuses.filter((link_status: LinkStatus) => link_status.status === 'started'));

--- a/src/app/cartography/widgets/interface-status.ts
+++ b/src/app/cartography/widgets/interface-status.ts
@@ -8,11 +8,18 @@ import { Widget } from './widget';
 
 @Injectable()
 export class InterfaceStatusWidget implements Widget {
-  private mapSettingsService: MapSettingsService;
+  private static readonly LABEL_DISTANCE = 60;
+  private static readonly MIN_LINK_LENGTH_FOR_LABELS = 180;
+  private static readonly LABEL_HEIGHT = 18;
+  private static readonly LABEL_MIN_WIDTH = 34;
+  private static readonly LABEL_HORIZONTAL_PADDING = 2;
+  private static readonly LABEL_RADIUS = 8;
+  private static readonly LABEL_STROKE_WIDTH = 3;
+  private static readonly LABEL_FONT_SIZE = 10;
+  private static readonly LABEL_FONT_FAMILY = '"Noto Sans", "DejaVu Sans", "Segoe UI", sans-serif';
+  private static readonly LABEL_BACKGROUND_COLOR = '#E2E8FF';
 
-  constructor(private _mapSettingsService: MapSettingsService) {
-    this.mapSettingsService = _mapSettingsService;
-  }
+  constructor(private mapSettingsService: MapSettingsService) {}
 
   public draw(view: SVGSelection) {
     const self = this;
@@ -22,6 +29,7 @@ export class InterfaceStatusWidget implements Widget {
       mapLinks.push(l);
     });
     mapLinks.forEach((mapLink) => {
+      mapLink.isMultiplied = false;
       mapLinks.forEach((n) => {
         if (n.nodes[0].linkId !== mapLink.nodes[0].linkId) {
           if (
@@ -39,30 +47,31 @@ export class InterfaceStatusWidget implements Widget {
       const link_group = select<SVGGElement, MapLink>(this);
       const link_path = link_group.select<SVGPathElement>('path');
 
-      let statuses = [];
-      if (link_path.node()) {
-        const start_point: SVGPoint = link_path.node().getPointAtLength(80);
-        const end_point: SVGPoint = link_path.node().getPointAtLength(link_path.node().getTotalLength() - 80);
+      let statuses: LinkStatus[] = [];
+      const pathNode = link_path.node();
+      if (pathNode) {
+        const totalLength = pathNode.getTotalLength();
 
-        if (link_path.node().getTotalLength() > 2 * 45 + 130) {
-          if (l.source && l.target) {
-            let sourcePort = l.nodes.find((node) => node.nodeId === l.source.id).label.text;
-            let destinationPort = l.nodes.find((node) => node.nodeId === l.target.id).label.text;
-            statuses = [
-              new LinkStatus(
-                start_point.x,
-                start_point.y,
-               (( !l.capturing && l.suspend) || ( l.capturing && l.suspend)) ? 'suspended' : l.source.status,
-                sourcePort
-              ),
-              new LinkStatus(
-                end_point.x,
-                end_point.y,
-                (( !l.capturing && l.suspend) || ( l.capturing && l.suspend)) ? 'suspended' : l.target.status,
-                destinationPort
-              ),
-            ];
-          }
+        if (totalLength > InterfaceStatusWidget.MIN_LINK_LENGTH_FOR_LABELS && l.source && l.target) {
+          const start_point: SVGPoint = pathNode.getPointAtLength(InterfaceStatusWidget.LABEL_DISTANCE);
+          const end_point: SVGPoint = pathNode.getPointAtLength(totalLength - InterfaceStatusWidget.LABEL_DISTANCE);
+          const sourcePort = l.nodes.find((node) => node.nodeId === l.source.id)?.label?.text || '';
+          const destinationPort = l.nodes.find((node) => node.nodeId === l.target.id)?.label?.text || '';
+
+          statuses = [
+            new LinkStatus(
+              start_point.x,
+              start_point.y,
+              l.suspend ? 'suspended' : l.source.status,
+              sourcePort
+            ),
+            new LinkStatus(
+              end_point.x,
+              end_point.y,
+              l.suspend ? 'suspended' : l.target.status,
+              destinationPort
+            ),
+          ];
         }
       }
 
@@ -76,107 +85,57 @@ export class InterfaceStatusWidget implements Widget {
       link_group.selectAll<SVGTextElement, LinkStatus>('text.status_stopped_label').remove();
       link_group.selectAll<SVGRectElement, LinkStatus>('rect.status_suspended').remove();
       link_group.selectAll<SVGTextElement, LinkStatus>('text.status_suspended_label').remove();
+      link_group.selectAll<SVGGElement, LinkStatus>('g.status_label').remove();
 
       if (
         self.mapSettingsService.showInterfaceLabels &&
-        self.mapSettingsService.integrateLinkLabelsToLinks &&
-        !l.isMultiplied
+        self.mapSettingsService.integrateLinkLabelsToLinks
       ) {
-        const status_started = link_group
-          .selectAll<SVGRectElement, LinkStatus>('rect.status_started')
-          .data(statuses.filter((link_status: LinkStatus) => link_status.status === 'started'));
-        const status_started_enter = status_started.enter().append<SVGRectElement>('rect');
-        status_started
-          .merge(status_started_enter)
-          .attr('class', 'status_started')
-          .attr('width', (ls: LinkStatus) => {
-            return ls.port.length * 10 + 5;
-          })
-          .attr('height', 20)
-          .attr('x', (ls: LinkStatus) => ls.x - 30)
-          .attr('y', (ls: LinkStatus) => ls.y - 10)
-          .attr('rx', 8)
-          .attr('ry', 8)
-          .style('fill', 'white')
-          .attr('stroke', '#2ecc71')
-          .attr('stroke-width', 3);
-        status_started.exit().remove();
-        const status_started_label = link_group
-          .selectAll<SVGTextElement, LinkStatus>('text.status_started_label')
-          .data(statuses.filter((link_status: LinkStatus) => link_status.status === 'started'));
-        const status_started_label_enter = status_started_label.enter().append<SVGTextElement>('text');
-        status_started_label
-          .merge(status_started_label_enter)
-          .attr('class', 'status_started_label')
-          .text((ls: LinkStatus) => ls.port)
-          .attr('x', (ls: LinkStatus) => ls.x - 25)
-          .attr('y', (ls: LinkStatus) => ls.y + 5)
-          .attr('fill', `black`);
-        status_started_label.exit().remove();
+        const status_labels = link_group.selectAll<SVGGElement, LinkStatus>('g.status_label').data(statuses);
+        const status_labels_enter = status_labels.enter().append<SVGGElement>('g').attr('class', 'status_label');
 
-        const status_stopped = link_group
-          .selectAll<SVGRectElement, LinkStatus>('rect.status_stopped')
-          .data(statuses.filter((link_status: LinkStatus) => link_status.status === 'stopped'));
-        const status_stopped_enter = status_stopped.enter().append<SVGRectElement>('rect');
-        status_stopped
-          .merge(status_stopped_enter)
-          .attr('class', 'status_stopped')
-          .attr('width', (ls: LinkStatus) => {
-            return ls.port.length * 10 + 5;
-          })
-          .attr('height', 20)
-          .attr('x', (ls: LinkStatus) => ls.x - 30)
-          .attr('y', (ls: LinkStatus) => ls.y - 10)
-          .attr('rx', 8)
-          .attr('ry', 8)
-          .style('fill', 'white')
-          .attr('stroke', 'red')
-          .attr('stroke-width', 3);
-        status_stopped.exit().remove();
-        const status_stopped_label = link_group
-          .selectAll<SVGTextElement, LinkStatus>('text.status_stopped_label')
-          .data(statuses.filter((link_status: LinkStatus) => link_status.status === 'stopped'));
-        const status_stopped_label_enter = status_stopped_label.enter().append<SVGTextElement>('text');
-        status_stopped_label
-          .merge(status_stopped_label_enter)
-          .attr('class', 'status_stopped_label')
-          .text((ls: LinkStatus) => ls.port)
-          .attr('x', (ls: LinkStatus) => ls.x - 25)
-          .attr('y', (ls: LinkStatus) => ls.y + 5)
-          .attr('fill', `black`);
-        status_stopped_label.exit().remove();
+        const status_labels_merge = status_labels
+          .merge(status_labels_enter)
+          .attr('transform', (ls: LinkStatus) => `translate(${ls.x}, ${ls.y})`);
 
-        const status_suspended = link_group
-          .selectAll<SVGRectElement, LinkStatus>('rect.status_suspended')
-          .data(statuses.filter((link_status: LinkStatus) => link_status.status === 'suspended'));
-        const status_suspended_enter = status_suspended.enter().append<SVGRectElement>('rect');
-        status_suspended
-          .merge(status_suspended_enter)
-          .attr('class', 'status_suspended')
-          .attr('width', (ls: LinkStatus) => {
-            return ls.port.length * 10 + 5;
-          })
-          .attr('height', 20)
-          .attr('x', (ls: LinkStatus) => ls.x - 30)
-          .attr('y', (ls: LinkStatus) => ls.y - 10)
-          .attr('rx', 8)
-          .attr('ry', 8)
-          .style('fill', 'white')
-          .attr('stroke', '#FFFF00')
-          .attr('stroke-width', 3);
-        status_suspended.exit().remove();
-        const status_suspended_label = link_group
-          .selectAll<SVGTextElement, LinkStatus>('text.status_suspended_label')
-          .data(statuses.filter((link_status: LinkStatus) => link_status.status === 'suspended'));
-        const status_suspended_label_enter = status_suspended_label.enter().append<SVGTextElement>('text');
-        status_suspended_label
-          .merge(status_suspended_label_enter)
-          .attr('class', 'status_suspended_label')
-          .text((ls: LinkStatus) => ls.port)
-          .attr('x', (ls: LinkStatus) => ls.x - 25)
-          .attr('y', (ls: LinkStatus) => ls.y + 5)
-          .attr('fill', `black`);
-        status_suspended_label.exit().remove();
+        const status_rects = status_labels_merge.selectAll<SVGRectElement, LinkStatus>('rect').data((ls) => [ls]);
+        status_rects
+          .enter()
+          .append<SVGRectElement>('rect')
+          .merge(status_rects)
+          .attr('class', (ls: LinkStatus) => `status_${ls.status}`)
+          .attr('width', (ls: LinkStatus) => self.getLabelWidth(ls.port))
+          .attr('height', InterfaceStatusWidget.LABEL_HEIGHT)
+          .attr('x', (ls: LinkStatus) => -(self.getLabelWidth(ls.port) / 2))
+          .attr('y', -InterfaceStatusWidget.LABEL_HEIGHT / 2)
+          .attr('rx', InterfaceStatusWidget.LABEL_RADIUS)
+          .attr('ry', InterfaceStatusWidget.LABEL_RADIUS)
+          .style('fill', InterfaceStatusWidget.LABEL_BACKGROUND_COLOR)
+          .style('fill-opacity', 1)
+          .attr('stroke', (ls: LinkStatus) => self.getStatusStrokeColor(ls.status))
+          .attr('stroke-width', InterfaceStatusWidget.LABEL_STROKE_WIDTH);
+        status_rects.exit().remove();
+
+        const status_texts = status_labels_merge.selectAll<SVGTextElement, LinkStatus>('text').data((ls) => [ls]);
+        status_texts
+          .enter()
+          .append<SVGTextElement>('text')
+          .merge(status_texts)
+          .attr('class', (ls: LinkStatus) => `status_${ls.status}_label`)
+          .text((ls: LinkStatus) => ls.port || '')
+          .attr('x', 0)
+          .attr('y', 0)
+          .attr('dy', '0em')
+          .attr('text-anchor', 'middle')
+          .attr('dominant-baseline', 'central')
+          .attr('alignment-baseline', 'central')
+          .attr('fill', '#111111')
+          .style('font-family', InterfaceStatusWidget.LABEL_FONT_FAMILY)
+          .style('font-size', `${InterfaceStatusWidget.LABEL_FONT_SIZE}px`)
+          .style('font-weight', '500');
+        status_texts.exit().remove();
+
+        status_labels.exit().remove();
       } else {
         const status_started = link_group
           .selectAll<SVGCircleElement, LinkStatus>('circle.status_started')
@@ -190,7 +149,7 @@ export class InterfaceStatusWidget implements Widget {
           .attr('cx', (ls: LinkStatus) => ls.x)
           .attr('cy', (ls: LinkStatus) => ls.y)
           .attr('r', 6)
-          .attr('text', (ls: LinkStatus) => ls.port)
+          .attr('text', (ls: LinkStatus) => ls.port || '')
           .attr('fill', '#2ecc71');
 
         status_started.exit().remove();
@@ -231,5 +190,23 @@ export class InterfaceStatusWidget implements Widget {
         status_suspended.exit().remove();
       }
     });
+  }
+
+  private getLabelWidth(port?: string): number {
+    const text = port || '';
+    const averageCharacterWidth = InterfaceStatusWidget.LABEL_FONT_SIZE * 0.62;
+    const estimatedWidth = text.length * averageCharacterWidth + InterfaceStatusWidget.LABEL_HORIZONTAL_PADDING * 2;
+
+    return Math.max(InterfaceStatusWidget.LABEL_MIN_WIDTH, Math.ceil(estimatedWidth));
+  }
+
+  private getStatusStrokeColor(status: string): string {
+    if (status === 'started') {
+      return '#2ecc71';
+    }
+    if (status === 'stopped') {
+      return 'red';
+    }
+    return '#FFFF00';
   }
 }


### PR DESCRIPTION
## Description
In GNS3 Web UI, multiple links between the same two nodes (for example, port-channel style topologies) were rendered too close to each other, making interface labels difficult to read or not visible enough.

This pull request tries to improve  the bundled-link spacing and integrated label visibility on the GNS3 web UI

## Versions / Environment
- Observed in Web UI 3.0.x branch behavior
- OS: Linux (likely platform-independent)
- Browser: modern browsers (Chrome, Firefox, Brave)

## Steps to Reproduce (Before Improvement)
1. Open any project in Web UI.
2. Add two devices (for example, Switch to Switch).
3. Create 3 to 4 links between the same pair of devices.
4. Enable Show Interface Labels.
5. Enable Integrate Link Labels To Links.
6. Observe link spacing and label visibility.

## Actual Result (Before Improvement)
- Parallel links appear nearly stacked.
- Labels are crowded, overlap visually, or are hard to distinguish.
- Port-channel style topologies are difficult to read.

## Expected Result
- Parallel links are clearly separated and symmetric around the center line.
- Integrated interface labels remain visible and readable for multiplied links.
- Rendering stays consistent for horizontal, vertical, and diagonal node layouts.

## Impact
- Reduced usability for dense topologies.
- Harder interface identification during design and troubleshooting.

## Implemented Fix
1. Increased bundled-link spacing to 14 px.
2. Replaced translation math with normalized perpendicular-vector offseting for stable geometry.
3. Applied symmetric per-group distance assignment so links fan out around the center path.
4. Added guards for zero-length links and zero-distance cases.
5. Removed multiplied-link exclusion from integrated status label rendering logic.

Original configuration
<img width="1052" height="656" alt="Image" src="https://github.com/user-attachments/assets/c9f5500b-c32a-40bb-b97f-57ac97c13ae7" />

Updated configuration
<img width="1052" height="656" alt="Image" src="https://github.com/user-attachments/assets/648c64a1-84e3-4574-b138-1efffd431739" />

Please review and test if any issues which I did not see might appear.