### PR TITLE
Reworked some project-map code

### DIFF
--- a/src/app/cartography/components/d3-map/d3-map.component.ts
+++ b/src/app/cartography/components/d3-map/d3-map.component.ts
@@ -176,6 +176,59 @@ export class D3MapComponent implements OnInit, OnChanges, OnDestroy {
 
     this.gridVisibility = localStorage.getItem('gridVisibility') === 'true' ? 1 : 0;
     this.mapSettingsService.isScrollDisabled.subscribe((val) => this.resize(val));
+
+    // Recalculate canvas size live during node drags so scrollbars appear as
+    // content moves. Strategy: only GROW during drag (never shrink), which
+    // prevents the browser from clamping scroll and injecting spurious D3 dx.
+    // On drag end do a full recalculate + scroll compensation so the viewport
+    // stays on the same content after the canvas origin shifts.
+    let dragStartCenterX: number | null = null;
+    let dragStartCenterY: number | null = null;
+
+    this.subscriptions.push(
+      this.graphLayout.getNodesWidget().draggable.start.subscribe(() => {
+        const pt = this.context.getZeroZeroTransformationPoint();
+        dragStartCenterX = pt.x;
+        dragStartCenterY = pt.y;
+      })
+    );
+
+    this.subscriptions.push(
+      this.graphLayout.getNodesWidget().draggable.drag.subscribe(() => {
+        const newSize = this.getSize();
+        // Lock origin back to drag-start so the canvas <g> transform doesn't
+        // shift under the pointer while dragging.
+        this.context.centerX = dragStartCenterX;
+        this.context.centerY = dragStartCenterY;
+        // Only GROW the canvas during drag — never shrink it. Shrinking reduces
+        // the max scroll, the browser clamps the scroll position, which shifts
+        // the SVG's bounding rect, and D3 picks that up as a spurious dx/dy on
+        // the next drag event (the "exponential movement" bug).
+        if (newSize.width > this.context.size.width || newSize.height > this.context.size.height) {
+          this.context.size = newSize;
+          this.svg.attr('width', newSize.width).attr('height', newSize.height);
+        }
+      })
+    );
+
+    this.subscriptions.push(
+      this.graphLayout.getNodesWidget().draggable.end.subscribe(() => {
+        const prevCX = dragStartCenterX ?? this.context.size.width  / 2;
+        const prevCY = dragStartCenterY ?? this.context.size.height / 2;
+        const newSize = this.getSize();
+        const newCX  = this.context.centerX ?? newSize.width  / 2;
+        const newCY  = this.context.centerY ?? newSize.height / 2;
+        // Scroll BEFORE resizing the SVG so the browser never clamps the scroll
+        // position first (which would nullify the compensation for the cases
+        // where centerX/centerY shift, e.g. nodes returning from the left).
+        window.scrollBy(newCX - prevCX, newCY - prevCY);
+        this.context.size = newSize;
+        this.svg.attr('width', newSize.width).attr('height', newSize.height);
+        this.graphLayout.draw(this.svg, this.context);
+        dragStartCenterX = null;
+        dragStartCenterY = null;
+      })
+    );
   }
 
   ngOnDestroy() {
@@ -199,7 +252,55 @@ export class D3MapComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   public getSize(): Size {
-    return this.canvasSizeDetector.getOptimalSize(this.width, this.height);
+    const viewportWidth  = document.documentElement.clientWidth;
+    const viewportHeight = document.documentElement.clientHeight;
+
+    // Use live MapNode positions from graphDataManager so size is correct during
+    // active drags (where this.nodes hasn't been updated yet).
+    const mapNodes    = this.graphDataManager.getNodes();
+    const mapDrawings = this.graphDataManager.getDrawings();
+
+    if (mapNodes.length === 0 && mapDrawings.length === 0) {
+      this.context.centerX = null;
+      this.context.centerY = null;
+      return new Size(viewportWidth, viewportHeight);
+    }
+
+    const scale  = this.context.transformation.k;
+    const margin = 100;
+    let minX = 0, maxX = 0, minY = 0, maxY = 0;
+
+    for (const node of mapNodes) {
+      const nodeWidth  = (node.width  || 60) * scale;
+      const nodeHeight = (node.height || 60) * scale;
+      const nx = node.width ? node.x * scale : (node.x - 30) * scale;
+      const ny = node.width ? node.y * scale : (node.y - 30) * scale;
+      minX = Math.min(minX, nx);
+      maxX = Math.max(maxX, nx + nodeWidth);
+      minY = Math.min(minY, ny);
+      maxY = Math.max(maxY, ny + nodeHeight);
+    }
+
+    for (const drawing of mapDrawings) {
+      minX = Math.min(minX, drawing.x * scale);
+      maxX = Math.max(maxX, drawing.x * scale);
+      minY = Math.min(minY, drawing.y * scale);
+      maxY = Math.max(maxY, drawing.y * scale);
+    }
+
+    // Asymmetric canvas: allocate exactly the space needed on each side of the
+    // scene origin so scrollbars only appear in the direction content extends.
+    const halfViewW = viewportWidth  / 2;
+    const halfViewH = viewportHeight / 2;
+    const leftSpace   = Math.max(halfViewW, (-minX) + margin);
+    const rightSpace  = Math.max(halfViewW, maxX    + margin);
+    const topSpace    = Math.max(halfViewH, (-minY) + margin);
+    const bottomSpace = Math.max(halfViewH, maxY    + margin);
+
+    this.context.centerX = leftSpace;
+    this.context.centerY = topSpace;
+
+    return this.canvasSizeDetector.getOptimalSize(leftSpace + rightSpace, topSpace + bottomSpace);
   }
 
   private changeLayout() {
@@ -220,6 +321,8 @@ export class D3MapComponent implements OnInit, OnChanges, OnDestroy {
     this.graphDataManager.setNodes(this.nodes);
     this.graphDataManager.setLinks(this.links);
     this.graphDataManager.setDrawings(this.drawings);
+    // Recalculate after setNodes/Drawings so graphDataManager has current positions.
+    this.context.size = this.getSize();
     this.graphLayout.draw(this.svg, this.context);
     this.textEditor.activateTextEditingForDrawings();
     this.textEditor.activateTextEditingForNodeLabels();

--- a/src/app/cartography/models/context.ts
+++ b/src/app/cartography/models/context.ts
@@ -11,6 +11,10 @@ export class Context {
   public transformation: Transformation;
   public size: Size;
   public centerZeroZeroPoint = true;
+  /** Explicit SVG x-coordinate of the scene origin (0,0). Null = use size.width/2. */
+  public centerX: number | null = null;
+  /** Explicit SVG y-coordinate of the scene origin (0,0). Null = use size.height/2. */
+  public centerY: number | null = null;
 
   constructor() {
     this.size = new Size(0, 0);
@@ -19,7 +23,10 @@ export class Context {
 
   public getZeroZeroTransformationPoint() {
     if (this.centerZeroZeroPoint) {
-      return new Point(this.size.width / 2, this.size.height / 2);
+      return new Point(
+        this.centerX !== null ? this.centerX : this.size.width  / 2,
+        this.centerY !== null ? this.centerY : this.size.height / 2
+      );
     }
     return new Point(0, 0);
   }

--- a/src/app/components/login/login.component.html
+++ b/src/app/components/login/login.component.html
@@ -12,7 +12,7 @@
         </div>
       </div>
 
-      <form [formGroup]="loginForm">
+      <form [formGroup]="loginForm" (ngSubmit)="login()">
         <mat-form-field>
           <input matInput formControlName="username" placeholder="Username" />
           <mat-error *ngIf="loginForm.get('username').hasError('required')">You must enter username</mat-error>

--- a/src/app/components/project-map/project-map.component.ts
+++ b/src/app/components/project-map/project-map.component.ts
@@ -2,6 +2,7 @@ import {
   ChangeDetectorRef,
   Component,
   ComponentRef,
+  NgZone,
   OnDestroy,
   OnInit,
   ViewChild,
@@ -129,9 +130,6 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
 
   protected settings: Settings;
   private inReadOnlyMode = false;
-  private scrollX: number = 0;
-  private scrollY: number = 0;
-  private scrollEnabled: boolean = false;
   public isLightThemeEnabled: boolean = false;
   public isGlobalLightTheme: boolean = false;
 
@@ -192,7 +190,8 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
     private cd: ChangeDetectorRef,
     // private cfr: ComponentFactoryResolver,
     // private injector: Injector,
-    private viewContainerRef: ViewContainerRef
+    private viewContainerRef: ViewContainerRef,
+    private ngZone: NgZone
   ) {}
 
   // constructor(private viewContainerRef: ViewContainerRef) {}
@@ -258,12 +257,6 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
   }
 
   addSubscriptions() {
-    this.projectMapSubscription.add(
-      this.mapSettingsService.mapRenderedEmitter.subscribe((value: boolean) => {
-        if (this.scrollEnabled) this.centerCanvas();
-      })
-    );
-
     this.projectMapSubscription.add(
       this.drawingsDataSource.changes.subscribe((drawings: Drawing[]) => {
         this.drawings = drawings;
@@ -465,7 +458,7 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
 
     Mousetrap.bind('del', (event: Event) => {
       event.preventDefault();
-      this.deleteItems();
+      this.ngZone.run(() => this.deleteItems());
     });
   }
 
@@ -683,162 +676,18 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
       );
   }
 
-  public fitInView() {
-    this.drawings.forEach((drawing) => {
-      let splittedSvg = drawing.svg.split('"');
-      let height: number = parseInt(splittedSvg[1], 10);
-      let width: number = parseInt(splittedSvg[3], 10);
-
-      drawing.element = {
-        width: width,
-        height: height,
-      };
-    });
-
-    if (this.nodes.length === 0 && this.drawings.length === 0) {
-      return;
-    }
-    let minX: number, maxX: number, minY: number, maxY: number;
-
-    let borderedNodes: BorderedNode[] = [];
-    this.nodes.forEach((n) => {
-      let borderedNode: BorderedNode = new BorderedNode();
-      borderedNode.node = n;
-      borderedNode.top = n.y;
-      borderedNode.left = n.x;
-      borderedNode.bottom = n.y + n.height;
-      borderedNode.right = n.x + n.width;
-
-      if (n.y + n.label.y < borderedNode.top) {
-        borderedNode.top = n.y + n.label.y;
-      }
-
-      if (n.x + n.label.x < borderedNode.left) {
-        borderedNode.left = n.x + n.label.x;
-      }
-
-      if (n.y + n.label.y > borderedNode.bottom) {
-        borderedNode.bottom = n.y + n.label.y;
-      }
-
-      if (n.x + n.label.x > borderedNode.right) {
-        borderedNode.right = n.x + n.label.x;
-      }
-
-      borderedNodes.push(borderedNode);
-    });
-
-    let nodeMinX = borderedNodes.sort((n, m) => n.left - m.left)[0];
-    let nodeMaxX = borderedNodes.sort((n, m) => n.right - m.right)[borderedNodes.length - 1];
-    let nodeMinY = borderedNodes.sort((n, m) => n.top - m.top)[0];
-    let nodeMaxY = borderedNodes.sort((n, m) => n.bottom - m.bottom)[borderedNodes.length - 1];
-
-    let borderedDrawings: BorderedDrawing[] = [];
-    this.drawings.forEach((n) => {
-      let borderedDrawing: BorderedDrawing = new BorderedDrawing();
-      borderedDrawing.drawing = n;
-      borderedDrawing.top = n.y;
-      borderedDrawing.left = n.x;
-      borderedDrawing.bottom = n.y + n.element.height;
-      borderedDrawing.right = n.x + n.element.width;
-
-      borderedDrawings.push(borderedDrawing);
-    });
-
-    let drawingMinX = borderedDrawings.sort((n, m) => n.left - m.left)[0];
-    let drawingMaxX = borderedDrawings.sort((n, m) => n.right - m.right)[borderedDrawings.length - 1];
-    let drawingMinY = borderedDrawings.sort((n, m) => n.top - m.top)[0];
-    let drawingMaxY = borderedDrawings.sort((n, m) => n.bottom - m.bottom)[borderedDrawings.length - 1];
-
-    if (drawingMinX && nodeMinX) {
-      if (nodeMinX.left < drawingMinX.left) {
-        minX = nodeMinX.left;
-      } else {
-        minX = drawingMinX.left;
-      }
-
-      if (nodeMaxX.right > drawingMaxX.right) {
-        maxX = nodeMaxX.right;
-      } else {
-        maxX = drawingMaxX.right;
-      }
-
-      if (nodeMinY.top < drawingMinY.top) {
-        minY = nodeMinY.top;
-      } else {
-        minY = drawingMinY.top;
-      }
-
-      if (nodeMaxY.bottom > drawingMaxY.bottom) {
-        maxY = nodeMaxY.bottom;
-      } else {
-        maxY = drawingMaxY.bottom;
-      }
-    } else if (nodeMinX && !drawingMinX) {
-      minX = nodeMinX.left;
-      maxX = nodeMaxX.right;
-      minY = nodeMinY.top;
-      maxY = nodeMaxY.bottom;
-    } else if (drawingMinX && !nodeMinX) {
-      minX = drawingMinX.left;
-      maxX = drawingMaxX.right;
-      minY = drawingMinY.top;
-      maxY = drawingMaxY.bottom;
-    } else {
-      minX = 0;
-      maxX = 0;
-      minY = 0;
-      maxY = 0;
-    }
-
-    let margin: number = 20;
-    minX = minX - margin;
-    maxX = maxX + margin;
-    minY = minY - margin;
-    maxY = maxY + margin;
-
-    let windowWidth = window.innerWidth || document.documentElement.clientWidth || document.body.clientWidth;
-    let windowHeight = window.innerHeight || document.documentElement.clientHeight || document.body.clientHeight;
-    let widthOfAreaToShow = maxX - minX;
-    let heightOfAreaToShow = maxY - minY;
-    let widthToSceneWidthRatio = widthOfAreaToShow / windowWidth;
-    let heightToSceneHeightRatio = heightOfAreaToShow / windowHeight;
-
-    let scale = 1 / Math.max(widthToSceneWidthRatio, heightToSceneHeightRatio);
-
-    if (scale !== this.mapScaleService.currentScale) {
-      this.mapScaleService.setScale(scale);
-      this.project.scene_width = this.project.scene_width * scale;
-      this.project.scene_height = this.project.scene_height * scale;
-      if (heightToSceneHeightRatio < widthOfAreaToShow) {
-        this.scrollX = minX * scale - (windowWidth - widthOfAreaToShow * scale) / 2 + this.project.scene_width / 2;
-        this.scrollY = minY * scale + this.project.scene_height / 2;
-      } else {
-        this.scrollX = minX * scale + this.project.scene_width / 2;
-        this.scrollY = minY * scale - (windowHeight - heightOfAreaToShow * scale) / 2 + this.project.scene_height / 2;
-      }
-    } else {
-      this.scrollX = minX * scale + this.project.scene_width / 2;
-      this.scrollY = minY * scale + this.project.scene_height / 2;
-    }
-    this.scrollEnabled = true;
-  }
-
-  public centerCanvas() {
-    window.scrollTo(this.scrollX, this.scrollY);
-    this.scrollEnabled = false;
-  }
-
   public centerView() {
     if (this.project) {
-      let scrollX: number =
-        this.project.scene_width - document.documentElement.clientWidth > 0
-          ? (this.project.scene_width - document.documentElement.clientWidth) / 2
-          : 0;
-      let scrollY: number =
-        this.project.scene_height - document.documentElement.clientHeight > 0
-          ? (this.project.scene_height - document.documentElement.clientHeight) / 2
-          : 0;
+      const ctx = this.mapChild?.context;
+      const viewportWidth  = document.documentElement.clientWidth;
+      const viewportHeight = document.documentElement.clientHeight;
+      // With an asymmetric canvas the scene origin sits at (centerX, centerY)
+      // in SVG space. Scrolling to centerX - halfViewport puts the origin in
+      // the middle of the screen, which is the natural "home" position.
+      const svgCenterX = ctx ? (ctx.centerX !== null ? ctx.centerX : ctx.size.width  / 2) : this.project.scene_width  / 2;
+      const svgCenterY = ctx ? (ctx.centerY !== null ? ctx.centerY : ctx.size.height / 2) : this.project.scene_height / 2;
+      const scrollX = Math.max(0, svgCenterX - viewportWidth  / 2);
+      const scrollY = Math.max(0, svgCenterY - viewportHeight / 2);
 
       window.scrollTo(scrollX, scrollY);
     } else {
@@ -1172,20 +1021,4 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
     }
     this.projectMapSubscription.unsubscribe();
   }
-}
-
-export class BorderedNode {
-  top: number;
-  left: number;
-  bottom: number;
-  right: number;
-  node: Node;
-}
-
-export class BorderedDrawing {
-  top: number;
-  left: number;
-  bottom: number;
-  right: number;
-  drawing: Drawing;
 }

--- a/src/app/components/template/template.component.ts
+++ b/src/app/components/template/template.component.ts
@@ -127,12 +127,13 @@ export class TemplateComponent implements OnInit, OnDestroy {
       const svgRect = svgElement ? svgElement.getBoundingClientRect() : { left: 0, top: 0 };
       const k = this.context.transformation.k;
 
+      const origin = this.context.getZeroZeroTransformationPoint();
       let nodeAddedEvent: NodeAddedEvent = {
         template: template,
         controller: 'local',
         numberOfNodes: 1,
-        x: (dropClientX - svgRect.left - this.context.size.width / 2 - this.context.transformation.x) / k - width / 2,
-        y: (dropClientY - svgRect.top - this.context.size.height / 2 - this.context.transformation.y) / k,
+        x: (dropClientX - svgRect.left - origin.x - this.context.transformation.x) / k - width / 2,
+        y: (dropClientY - svgRect.top - origin.y - this.context.transformation.y) / k,
       };
       this.onNodeCreation.emit(nodeAddedEvent);
     });


### PR DESCRIPTION
## Summary
This PR refactors the canvas sizing and scrolling logic to properly handle viewport centering and prevent scroll clamping issues during node drag operations. The changes introduce an asymmetric canvas model where the scene origin can be positioned at an explicit point rather than always at the canvas center.

## Key Changes

- **Removed legacy scroll management**: Deleted `fitInView()`, `centerCanvas()`, and related scroll state variables (`scrollX`, `scrollY`, `scrollEnabled`) from ProjectMapComponent that were causing stale scroll positions.

- **Implemented asymmetric canvas sizing**: Modified `D3MapComponent.getSize()` to calculate canvas dimensions based on actual node/drawing positions with margins, allocating space asymmetrically around the scene origin. This prevents unnecessary scrollbars and keeps content properly framed.

- **Added explicit canvas origin tracking**: Introduced `centerX` and `centerY` properties to the Context model to explicitly track where the scene origin (0,0) is positioned in SVG space, replacing the implicit center-based approach.

- **Added drag-aware canvas resizing**: Implemented subscription handlers for node drag start/during/end events that:
  - Lock the canvas origin during drag to prevent pointer drift
  - Only grow the canvas during drag (never shrink) to avoid browser scroll clamping
  - Compensate scroll position on drag end to keep viewport on the same content after origin shifts

- **Improved centerView() logic**: Rewrote to use the explicit canvas origin from context, properly calculating scroll positions based on viewport dimensions and the asymmetric canvas layout.

- **Fixed login form UX**: Added form submission on Enter key and ngSubmit handler to the login form.

- **Updated template component**: Modified coordinate calculations to use the explicit canvas origin point instead of implicit size-based calculations.

- **Added NgZone integration**: Injected NgZone and wrapped `deleteItems()` call in `ngZone.run()` to ensure proper change detection for keyboard shortcuts.

## Implementation Details

The core issue was that the old `fitInView()` approach calculated scroll positions once and stored them, but these became stale when the canvas was resized or content moved. The new approach:

1. Calculates canvas size dynamically based on current node/drawing positions
2. Positions the canvas origin asymmetrically to minimize unnecessary scrollbars
3. During drags, grows the canvas only as needed while keeping the origin fixed
4. On drag end, compensates the scroll position for any origin shifts before finalizing the resize

This ensures smooth dragging without exponential movement bugs and proper viewport centering at all times.