### PR TITLE
docs(inventory): refactor error handling documentation

### DIFF
--- a/docs/inventory/components-by-feature.md
+++ b/docs/inventory/components-by-feature.md
@@ -2,7 +2,7 @@
 
 > Complete catalog of all components categorized by feature area
 
-**Last Updated**: 2026-04-22
+**Last Updated**: 2026-04-26
 **Total Components**: 249
 
 ---
@@ -27,9 +27,86 @@
 
 ---
 
+## Component Distribution Architecture
+
+```mermaid
+pie title Component Distribution by Feature Area
+    "Project Map/Topology" : 119
+    "Preferences/Settings" : 49
+    "User/Permission Management" : 23
+    "Project Management" : 11
+    "Other" : 13
+    "Cartography/Map Rendering" : 10
+    "Controller/Compute Management" : 5
+    "AI Chat" : 5
+    "Console/Terminal" : 4
+    "Dialogs (Common)" : 3
+    "Image Manager" : 3
+    "Common/Utilities" : 3
+    "Help/About" : 1
+```
+
+---
+
 ## 1. Project Map/Topology (119 components)
 
 The largest feature area, containing the main project map visualization, context menu actions, node configurators, and console interfaces.
+
+### Project Map Architecture
+
+```mermaid
+graph TB
+    subgraph "Project Map/Topology (119 components)"
+        A[project-map.component<br/>Core Map Component]
+
+        subgraph "AI Chat Integration (6)"
+            B1[ai-chat.component]
+            B2[chat-input-area.component]
+            B3[chat-message-list.component]
+            B4[chat-session-list.component]
+            B5[code-block-dialog.component]
+            B6[tool-details-dialog.component]
+        end
+
+        subgraph "Context Menu Actions (38)"
+            C1[context-menu.component]
+            C2[Node Actions - 20]
+            C3[Link Actions - 8]
+            C4[Layer Actions - 4]
+            C5[Style Actions - 6]
+        end
+
+        subgraph "Node Configurators (17)"
+            D1[config-editor.component]
+            D2[Platform Configurators - 7]
+            D3[Virtualization Configurators - 9]
+        end
+
+        subgraph "Console/Terminal (6)"
+            E1[console-wrapper.component]
+            E2[web-console.component]
+            E3[xterm integration]
+        end
+
+        subgraph "Drawing Editors (3)"
+            F1[link-style-editor.component]
+            F2[style-editor.component]
+            F3[text-editor.component]
+        end
+    end
+
+    A --> B1
+    A --> C1
+    A --> D1
+    A --> E1
+    A --> F1
+
+    style A fill:#ff6b6b
+    style B1 fill:#ffd93d
+    style C1 fill:#4ecdc4
+    style D1 fill:#95e1d3
+    style E1 fill:#f38181
+```
 
 ### Core Map Component
 - `project-map.component.ts` - Main project map view with D3.js rendering

--- a/docs/inventory/components-by-feature.md
+++ b/docs/inventory/components-by-feature.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: CC-BY-SA-4.0
+See LICENSE file for licensing information.
+-->
+
+  > AI-assisted documentation. [See disclaimer](../README.md). 
+
+
 # GNS3 Web UI - Component Inventory by Feature
 
 > Complete catalog of all components categorized by feature area

--- a/docs/inventory/service-dependency-analysis-report.md
+++ b/docs/inventory/service-dependency-analysis-report.md
@@ -1,10 +1,10 @@
 # GNS3 Web UI - Service Dependency Analysis Report
 
-**Analysis Date**: 2026-04-22
+**Analysis Date**: 2026-04-26
 **Total Components Analyzed**: 249
-**Total Services in Codebase**: 73
+**Total Services in Codebase**: 75
 **Services Used by Components**: 69
-**Services with Special Usage**: 4
+**Services with Special Usage**: 6
 **Total Service Dependencies**: 541
 **Average Dependencies per Component**: 2.17
 
@@ -47,7 +47,122 @@
 
 ---
 
-## 2. Key Insights
+## 2. Service Dependency Architecture
+
+### Overall Architecture
+
+```mermaid
+graph TB
+    subgraph "Component Layer (249 components)"
+        A[Components]
+    end
+
+    subgraph "Critical Services (High Impact)"
+        B[ToasterService<br/>121 components]
+        C[ControllerService<br/>62 components]
+        D[NodeService<br/>45 components]
+    end
+
+    subgraph "High-Impact Services (10-19 components)"
+        E[ThemeService<br/>17 components]
+        F[ProjectService<br/>16 components]
+        G[DialogConfigService<br/>16 components]
+        H[LinkService<br/>15 components]
+        I[DrawingService<br/>15 components]
+        J[ComputeService<br/>13 components]
+        K[ProgressService<br/>12 components]
+    end
+
+    subgraph "Infrastructure Services (Not used by components)"
+        L[ControllerErrorHandler]
+        M[ToasterErrorHandler]
+        N[DefaultConsoleService]
+        O[ExternalSoftwareDefinitionService]
+        P[GoogleAnalyticsService]
+        Q[PlatformService]
+    end
+
+    subgraph "Service-to-Service Dependencies"
+        R[HttpController]
+        S[ConsoleService]
+        T[InstalledSoftwareService]
+        U[ProtocolHandlerService]
+    end
+
+    A -->|48.6%| B
+    A -->|24.9%| C
+    A -->|18.1%| D
+    A -->|6.8%| E
+    A -->|6.4%| F
+    A -->|6.4%| G
+    A -->|6.0%| H
+    A -->|6.0%| I
+    A -->|5.2%| J
+    A -->|4.8%| K
+
+    R -->|Error Handling| L
+    M -->|Display Errors| B
+    S -->|Console Commands| N
+    T -->|Software Definitions| O
+    U -->|Platform Detection| Q
+    A -.->|Unhandled Errors| M
+
+    style B fill:#ff6b6b
+    style C fill:#ff6b6b
+    style D fill:#ff6b6b
+    style L fill:#ffd93d
+    style M fill:#ffd93d
+```
+
+### Special Usage Patterns Architecture
+
+```mermaid
+graph LR
+    subgraph "Module-Level Initialization"
+        A[AppModule]
+        B[GoogleAnalyticsService]
+        C[ToasterErrorHandler]
+    end
+
+    subgraph "Service-to-Service Chains"
+        D[ConsoleComponent]
+        E[ConsoleService]
+        F[DefaultConsoleService]
+
+        G[InstalledSoftwareComponent]
+        H[InstalledSoftwareService]
+        I[ExternalSoftwareDefinitionService]
+        J[PlatformService]
+
+        K[ProtocolHandlerService]
+    end
+
+    subgraph "Infrastructure Services"
+        L[HttpController]
+        M[ControllerErrorHandler]
+    end
+
+    A -->|Auto-init| B
+    A -->|Register| C
+    D --> E
+    E --> F
+    G --> H
+    H --> I
+    I --> J
+    K --> J
+    L --> M
+
+    style C fill:#ff6b6b
+    style M fill:#ff6b6b
+    style B fill:#ffd93d
+    style F fill:#ffd93d
+    style I fill:#ffd93d
+    style J fill:#ffd93d
+```
+
+---
+
+## 3. Key Insights
 
 ### Critical Findings
 
@@ -61,16 +176,30 @@
 
 ### Top 10 Most Critical Services
 
-1. **ToasterService** - 121 components (48.6% of all components)
-2. **ControllerService** - 62 components (24.9%)
-3. **NodeService** - 45 components (18.1%)
-4. **ThemeService** - 17 components (6.8%)
-5. **ProjectService** - 16 components (6.4%)
-6. **DialogConfigService** - 16 components (6.4%)
-7. **LinkService** - 15 components (6.0%)
-8. **DrawingService** - 15 components (6.0%)
-9. **ComputeService** - 13 components (5.2%)
-10. **ProgressService** - 12 components (4.8%)
+| Rank | Service | Components | Percentage | Impact Level |
+|------|---------|------------|------------|--------------|
+| 1 | **ToasterService** | 121 | 48.6% | 🔴 Critical |
+| 2 | **ControllerService** | 62 | 24.9% | 🔴 Critical |
+| 3 | **NodeService** | 45 | 18.1% | 🔴 Critical |
+| 4 | **ThemeService** | 17 | 6.8% | 🟡 High |
+| 5 | **ProjectService** | 16 | 6.4% | 🟡 High |
+| 6 | **DialogConfigService** | 16 | 6.4% | 🟡 High |
+| 7 | **LinkService** | 15 | 6.0% | 🟡 High |
+| 8 | **DrawingService** | 15 | 6.0% | 🟡 High |
+| 9 | **ComputeService** | 13 | 5.2% | 🟡 High |
+| 10 | **ProgressService** | 12 | 4.8% | 🟡 High |
+
+### Service Impact Distribution
+
+```mermaid
+pie title Service Impact Distribution
+    "Critical (>20 components)" : 3
+    "High (10-19 components)" : 7
+    "Medium (5-9 components)" : 14
+    "Low (2-4 components)" : 36
+    "Single-use (1 component)" : 9
+    "Infrastructure (0 components)" : 6
+```
 
 ### Service Distribution Analysis
 
@@ -102,7 +231,7 @@ These services are only used by one component each:
 8. **DeviceDetectorService** - `console-device-action-browser.component`
 9. **ControllerSettingsService** - `qemu-preferences.component`
 
-### Services Not Used by Components (4 services)
+### Services Not Used by Components (6 services)
 
 These services exist in the codebase but are **not directly used by any component**. They serve special purposes:
 
@@ -112,61 +241,46 @@ These services exist in the codebase but are **not directly used by any componen
 | **ExternalSoftwareDefinitionService** | `external-software-definition.service.ts` | Service-to-service dependency: Used only by `InstalledSoftwareService` | 🟢 Low - Software detection definitions |
 | **GoogleAnalyticsService** | `google-analytics.service.ts` | Module-level initialization: Auto-initialized in `app.module.ts` for route tracking | 🟢 Low - Analytics only |
 | **PlatformService** | `platform.service.ts` | Service-to-service dependency: Used by `ExternalSoftwareDefinitionService` and `ProtocolHandlerService` | 🟡 Medium - Platform detection utility |
+| **ControllerErrorHandler** | `http-controller.service.ts` | Service-to-service dependency: Used only by `HttpController` for centralized HTTP error handling | 🔴 Critical - Core error handling infrastructure |
+| **ToasterErrorHandler** | `common/error-handlers/toaster-error-handler.ts` | Global error handler: Registered as Angular's global `ErrorHandler` in `app.module.ts` | 🔴 Critical - Global error handling |
 
 #### Detailed Usage Patterns
 
 **1. DefaultConsoleService**
-```typescript
-// Indirect dependency chain
-@Component({...})
-export class ConsoleComponent {
-  constructor(consoleService: ConsoleService) {
-    // ConsoleService internally uses DefaultConsoleService
-  }
-}
-
-@Service({providedIn: 'root'})
-export class ConsoleService {
-  constructor(defaultConsole: DefaultConsoleService) {}
-}
-```
+- **Pattern**: Service-to-service dependency chain
+- **Flow**: Component → ConsoleService → DefaultConsoleService
+- **Purpose**: Provides default console command detection
+- **Impact**: Indirect - used by ConsoleService which is used by ConsoleComponent
 
 **2. ExternalSoftwareDefinitionService**
-```typescript
-// Two-level dependency chain
-@Component({...})
-export class InstalledSoftwareComponent {
-  constructor(installedSoftware: InstalledSoftwareService) {
-    // InstalledSoftwareService → ExternalSoftwareDefinitionService
-  }
-}
-```
+- **Pattern**: Two-level service-to-service dependency
+- **Flow**: Component → InstalledSoftwareService → ExternalSoftwareDefinitionService
+- **Purpose**: Defines external software detection rules
+- **Impact**: Indirect - software detection definitions
 
 **3. GoogleAnalyticsService**
-```typescript
-// Module-level initialization (not component injection)
-@NgModule({...})
-export class AppModule {
-  constructor(ga: GoogleAnalyticsService) {
-    // Auto-initializes on app bootstrap
-    // Subscribes to Router events for page tracking
-  }
-}
-```
+- **Pattern**: Module-level initialization
+- **Flow**: AppModule constructor → GoogleAnalyticsService initialization
+- **Purpose**: Auto-initializes on app bootstrap, subscribes to Router events
+- **Impact**: Analytics only, no component dependencies
 
 **4. PlatformService**
-```typescript
-// Used by multiple services, but not components
-@Service({providedIn: 'root'})
-export class ExternalSoftwareDefinitionService {
-  constructor(platform: PlatformService) {}
-}
+- **Pattern**: Multi-service utility dependency
+- **Flow**: Used by ExternalSoftwareDefinitionService and ProtocolHandlerService
+- **Purpose**: Platform detection (Windows/Linux/Mac)
+- **Impact**: Medium - platform detection utility for multiple services
 
-@Service({providedIn: 'root'})
-export class ProtocolHandlerService {
-  constructor(platform: PlatformService) {}
-}
-```
+**5. ControllerErrorHandler**
+- **Pattern**: Infrastructure service dependency
+- **Flow**: HttpController → ControllerErrorHandler
+- **Purpose**: Centralized HTTP error handling for all API calls
+- **Impact**: Critical - wraps all HttpController methods with error transformation
+
+**6. ToasterErrorHandler**
+- **Pattern**: Global error handler registration
+- **Flow**: AppModule providers → Angular ErrorHandler → ToasterErrorHandler
+- **Purpose**: Catches all unhandled errors and displays via ToasterService
+- **Impact**: Critical - global error handling safety net
 
 #### Why These Services Weren't Counted
 
@@ -423,14 +537,15 @@ The average component has 2.17 service dependencies, which indicates:
 **Limitations**:
 - Only analyzes **component-to-service dependencies** (direct `inject()` calls)
 - Does not include **service-to-service dependencies** (e.g., `DefaultConsoleService` → `ConsoleService`)
-- Does not track **module-level service initialization** (e.g., `GoogleAnalyticsService` in `app.module.ts`)
+- Does not track **module-level service initialization** (e.g., `GoogleAnalyticsService`, `ToasterErrorHandler` in `app.module.ts`)
 - Does not track usage frequency, only injection count
-- **Total services**: 73 (69 analyzed + 4 with special usage patterns)
+- **Total services**: 75 (69 analyzed + 6 with special usage patterns)
 
 **Special Usage Patterns Not Captured**:
 1. **Service-to-service chains**: Service A depends on Service B, which depends on Service C
-2. **Module-level initialization**: Services auto-initialized in module constructors
+2. **Module-level initialization**: Services auto-initialized in module constructors (e.g., global error handlers)
 3. **Indirect dependencies**: Services used by other services but not directly by components
+4. **Infrastructure services**: Critical services used by other services but not components (e.g., error handlers)
 
 **Tools Used**:
 - Python 3 script with regex pattern matching

--- a/docs/inventory/service-dependency-analysis-report.md
+++ b/docs/inventory/service-dependency-analysis-report.md
@@ -1,3 +1,11 @@
+<!--
+SPDX-License-Identifier: CC-BY-SA-4.0
+See LICENSE file for licensing information.
+-->
+
+  > AI-assisted documentation. [See disclaimer](../README.md). 
+
+
 # GNS3 Web UI - Service Dependency Analysis Report
 
 **Analysis Date**: 2026-04-26

--- a/docs/inventory/services-by-domain.md
+++ b/docs/inventory/services-by-domain.md
@@ -3,6 +3,9 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 See LICENSE file for licensing information.
 -->
 
+  > AI-assisted documentation. [See disclaimer](../README.md). 
+
+
 # GNS3 Web UI - Service Inventory by Domain
 
 > Complete catalog of all services categorized by functional domain

--- a/docs/inventory/services-by-domain.md
+++ b/docs/inventory/services-by-domain.md
@@ -7,8 +7,8 @@ See LICENSE file for licensing information.
 
 > Complete catalog of all services categorized by functional domain
 
-**Last Updated**: 2026-04-22
-**Total Services**: 73
+**Last Updated**: 2026-04-26
+**Total Services**: 75
 
 ---
 
@@ -24,7 +24,7 @@ See LICENSE file for licensing information.
 | Virtualization | 12 | Docker, QEMU, VirtualBox, VMware, IOS, IOU |
 | Network Simulation | 3 | VPCS, packet capture |
 | AI Features | 2 | AI chat and profile management |
-| System/Utilities | 19 | Settings, theme, notifications, progress |
+| System/Utilities | 21 | Settings, theme, notifications, progress, error handling |
 | Other/Utilities | 6 | Platform, version, external software |
 
 ---
@@ -71,7 +71,7 @@ Services for controller and compute node management.
 | **ControllerManagementService** | `controller-management.service.ts` | Local controller lifecycle (web stub) | None |
 | **ComputeService** | `compute.service.ts` | Compute node CRUD, connections, statistics | HttpController |
 | **ConnectionManagerService** | `connection-manager.service.ts` | WebSocket connection lifecycle for notifications | NotificationService |
-| **HttpController** | `http-controller.service.ts` | HTTP client wrapper with auth, error handling, URL construction | HttpClient, ControllerErrorHandler |
+| **HttpController** | `http-controller.service.ts` | HTTP client wrapper with auth, centralized error handling, URL construction | HttpClient, ControllerErrorHandler |
 
 ---
 
@@ -170,15 +170,15 @@ Services for AI-powered features (GNS3 Copilot).
 
 ---
 
-## 9. System/Utilities (19 services)
+## 9. System/Utilities (21 services)
 
-Core system services for settings, UI, notifications, and utilities.
+Core system services for settings, UI, notifications, error handling, and utilities.
 
 | Service | File | Description | Dependencies |
 |---------|------|-------------|--------------|
 | **SettingsService** | `settings.service.ts` | Application settings (crash reports, stats, console) | None |
 | **ThemeService** | `theme.service.ts` | Material Design 3 theme, light/dark mode | None |
-| **ToasterService** | `toaster.service.ts` | Toast notifications (success/warning/error) | MatSnackBar |
+| **ToasterService** | `toaster.service.ts` | Toast notifications (success/warning/error) - **Used by 121 components (48.6%)** | MatSnackBar |
 | **NotificationService** | `notification.service.ts` | WebSocket notifications for compute events | None |
 | **ProgressService** | `progress.service.ts` | Progress dialog state | None |
 | **ProgressDialogService** | `progress-dialog.service.ts` | Progress dialog display | MatDialog |
@@ -196,6 +196,8 @@ Core system services for settings, UI, notifications, and utilities.
 | **ProtocolHandlerService** | `protocol-handler.service.ts` | Custom protocol handler invocation | ToasterService, DeviceDetectorService, LoginService |
 | **VersionService** | `version.service.ts` | Controller version information | HttpController |
 | **UpdatesService** | `updates.service.ts` | GNS3 version update checks | HttpClient |
+| **ControllerErrorHandler** | `http-controller.service.ts` | HTTP error handling and transformation | None |
+| **ToasterErrorHandler** | `common/error-handlers/toaster-error-handler.ts` | Global error handler with toast notifications | ToasterService |
 
 ---
 
@@ -270,6 +272,186 @@ Miscellaneous utility services.
 - **Signal-based State**: Modern services use Signals for state management
 - **Centralized Configuration**: Dialog and settings configurations are centralized
 - **Modular Design**: Virtualization platforms follow consistent patterns
+
+---
+
+## Error Handling Architecture
+
+GNS3 Web UI implements a **two-tier error handling system** for robust error management.
+
+### Architecture Diagram
+
+```mermaid
+graph TB
+    subgraph "Component Layer"
+        A[Component]
+        B[ToasterService]
+    end
+
+    subgraph "Service Layer"
+        C[Business Service]
+        D[HttpController]
+    end
+
+    subgraph "HTTP Error Handling"
+        E[ControllerErrorHandler]
+    end
+
+    subgraph "Global Error Handling"
+        F[ToasterErrorHandler]
+    end
+
+    subgraph "External Systems"
+        G[GNS3 Controller API]
+    end
+
+    A -->|HTTP Request| C
+    C -->|Wrapped Call| D
+    D -->|HTTP Call| G
+    D -->|Error Transformation| E
+    E -->|ControllerError| D
+    D -->|Error Observable| C
+    C -->|Error| A
+    A -->|Display Error| B
+    A -->|Unhandled Error| F
+    F -->|Display Error| B
+
+    style E fill:#ffcccc
+    style F fill:#ffcccc
+    style B fill:#ccffcc
+```
+
+### Tier 1: HTTP Layer Error Handling
+
+**ControllerErrorHandler** provides centralized HTTP error handling:
+
+| Responsibility | Description |
+|----------------|-------------|
+| Error Transformation | Converts `HttpErrorResponse` to `ControllerError` |
+| Unreachable Controller Detection | Handles status 0 (network failures) |
+| Message Extraction | Extracts server error messages from response bodies |
+| Automatic Wrapping | Applied to all `HttpController` methods |
+
+**Error Types Handled**:
+
+| Error Type | Source | Transformation |
+|------------|--------|----------------|
+| Status 0 | Network failure | "Controller is unreachable" |
+| Server Error | API response | Extract `error.message` |
+| HTTP Error | Angular HTTP | Wrap in `ControllerError` |
+
+### Tier 2: Global Application Error Handler
+
+**ToasterErrorHandler** implements Angular's global error handling:
+
+| Responsibility | Description |
+|----------------|-------------|
+| Global Error Capture | Catches all unhandled errors via Angular's `ErrorHandler` |
+| Error Message Extraction | Extracts messages from various error types |
+| User Notification | Displays errors via `ToasterService` |
+| Console Logging | Logs errors (excludes 400, 403, 404, 409) |
+
+**Error Message Extraction Priority**:
+
+1. `error.error.message` - Server response body message
+2. `error.message` - Error object message
+3. `error.error` - Raw error object
+4. Fallback to "Handled unknown error"
+
+### Error Handling Flow
+
+```mermaid
+sequenceDiagram
+    participant C as Component
+    participant S as Service
+    participant H as HttpController
+    participant E as ControllerErrorHandler
+    participant G as ToasterErrorHandler
+    participant T as ToasterService
+    participant API as GNS3 API
+
+    C->>S: Call Service Method
+    S->>H: HTTP Request
+    H->>API: HTTP Call
+
+    alt HTTP Error
+        API-->>H: HttpErrorResponse
+        H->>E: handleError()
+        E->>E: Transform to ControllerError
+        E-->>H: ControllerError Observable
+        H-->>S: Error Observable
+        S-->>C: Error
+
+        alt Component Handles Error
+            C->>T: Display Error
+        else Component Doesn't Handle
+            C->>G: Unhandled Error
+            G->>T: Display Error
+        end
+    else HTTP Success
+        API-->>H: Response Data
+        H-->>S: Data Observable
+        S-->>C: Data
+    end
+```
+
+### Error Handling by Layer
+
+| Layer | Responsibility | Error Handler |
+|-------|----------------|---------------|
+| **HTTP Layer** | API call errors | `ControllerErrorHandler` |
+| **Service Layer** | Business logic errors | None (propagates to component) |
+| **Component Layer** | User-facing errors | `ToasterService` |
+| **Global Layer** | Unhandled errors | `ToasterErrorHandler` |
+
+---
+
+## ToasterService Architecture
+
+**Most Critical Service** - Used by 121 components (48.6% of all components)
+
+### Notification Types
+
+| Type | Duration | Panel Class | Use Case |
+|------|----------|-------------|----------|
+| Success | 4 seconds | `snackabar-success` | Operation completed successfully |
+| Warning | 4 seconds | `snackabar-warning` | Non-critical issues |
+| Error | 10 seconds | `snackabar-error` | Operation failures |
+
+### Notification Configuration
+
+| Property | Value |
+|----------|-------|
+| Horizontal Position | Center |
+| Vertical Position | Bottom |
+| Action Button | Close |
+| Auto-dismiss | Yes |
+| Styling | Material Design 3 themed |
+
+### ToasterService Integration Flow
+
+```mermaid
+graph LR
+    A[Component] -->|Direct Call| B[ToasterService]
+    A -->|Subscription Error| B
+    C[ToasterErrorHandler] -->|Unhandled Error| B
+    B -->|Display| D[Material Snackbar]
+
+    style B fill:#ccffcc
+    style D fill:#ccccff
+```
+
+### Usage Patterns
+
+| Pattern | Description | Components |
+|---------|-------------|------------|
+| **Direct Success** | Show success message after operation | 121 components |
+| **Direct Warning** | Show warning for non-critical issues | 121 components |
+| **Direct Error** | Show error message after failure | 121 components |
+| **Subscription Error** | Handle observable errors | Most components |
+| **Global Handler** | Automatic via `ToasterErrorHandler` | All components |
+
+---
 
 ---
 


### PR DESCRIPTION
## Summary

- Refactor inventory documentation to follow gns3-documentation standard
- Remove code examples, replace with Mermaid architecture diagrams and tables
- Add comprehensive error handling architecture documentation
- Update service counts (73 → 75 services)

## Changes

- **services-by-domain.md**: Add error handling architecture (two-tier system)
- **service-dependency-analysis-report.md**: Add service dependency diagrams
- **components-by-feature.md**: Add component distribution diagrams