### PR TITLE
feat: add arrow support and freeform mode to line drawings

### DIFF
--- a/src/app/cartography/converters/map/map-drawing-to-svg-converter.ts
+++ b/src/app/cartography/converters/map/map-drawing-to-svg-converter.ts
@@ -41,11 +41,14 @@ export class MapDrawingToSvgConverter implements Converter<MapDrawing, string> {
           : `<ellipse fill=\"${mapDrawing.element.fill}\" fill-opacity=\"${mapDrawing.element.fill_opacity}\" cx=\"${mapDrawing.element.cx}\" cy=\"${mapDrawing.element.cy}\" rx=\"${mapDrawing.element.rx}\" ry=\"${mapDrawing.element.ry}\" stroke=\"${mapDrawing.element.stroke}\" stroke-width=\"${mapDrawing.element.stroke_width}\" stroke-dasharray=\"${mapDrawing.element.stroke_dasharray}\" />`
       }`;
     } else if (mapDrawing.element instanceof LineElement) {
-      elem = `<line stroke=\"${mapDrawing.element.stroke}\" stroke-width=\"${mapDrawing.element.stroke_width}\" x1=\"${
-        mapDrawing.element.x1
-      }\" x2=\"${mapDrawing.element.x2}\" y1=\"${mapDrawing.element.y1}\" y2=\"${
-        mapDrawing.element.y2
-      }\" stroke-dasharray=\"${mapDrawing.element.stroke_dasharray ?? 'none'}\" />`;
+      const line = mapDrawing.element;
+      const markerStart = line.arrow_start ? ' marker-start="url(#line-start)"' : '';
+      const markerEnd = line.arrow_end ? ' marker-end="url(#line-end)"' : '';
+      elem = `<line stroke=\"${line.stroke}\" stroke-width=\"${line.stroke_width}\" x1=\"${
+        line.x1
+      }\" x2=\"${line.x2}\" y1=\"${line.y1}\" y2=\"${
+        line.y2
+      }\" stroke-dasharray=\"${line.stroke_dasharray ?? 'none'}\"${markerStart}${markerEnd} data-drawing-type=\"${line.drawing_type ?? 'straight'}\" data-arrow-start=\"${line.arrow_start ?? false}\" data-arrow-end=\"${line.arrow_end ?? false}\" />`;
     } else if (mapDrawing.element instanceof CurveElement) {
       // Generate path data from points
       const curve = mapDrawing.element;

--- a/src/app/cartography/converters/map/map-drawing-to-svg-converter.ts
+++ b/src/app/cartography/converters/map/map-drawing-to-svg-converter.ts
@@ -44,11 +44,12 @@ export class MapDrawingToSvgConverter implements Converter<MapDrawing, string> {
       const line = mapDrawing.element;
       const markerStart = line.arrow_start ? ' marker-start="url(#line-start)"' : '';
       const markerEnd = line.arrow_end ? ' marker-end="url(#line-end)"' : '';
+      const controlOffset = line.control_offset ? ` data-control-offset="${line.control_offset.join(',')}"` : '';
       elem = `<line stroke=\"${line.stroke}\" stroke-width=\"${line.stroke_width}\" x1=\"${
         line.x1
       }\" x2=\"${line.x2}\" y1=\"${line.y1}\" y2=\"${
         line.y2
-      }\" stroke-dasharray=\"${line.stroke_dasharray ?? 'none'}\"${markerStart}${markerEnd} data-drawing-type=\"${line.drawing_type ?? 'straight'}\" data-arrow-start=\"${line.arrow_start ?? false}\" data-arrow-end=\"${line.arrow_end ?? false}\" />`;
+      }\" stroke-dasharray=\"${line.stroke_dasharray ?? 'none'}\"${markerStart}${markerEnd} data-drawing-type=\"${line.drawing_type ?? 'straight'}\" data-arrow-start=\"${line.arrow_start ?? false}\" data-arrow-end=\"${line.arrow_end ?? false}\"${controlOffset} />`;
     } else if (mapDrawing.element instanceof CurveElement) {
       // Generate path data from points
       const curve = mapDrawing.element;

--- a/src/app/cartography/helpers/drawings-factory/line-element-factory.ts
+++ b/src/app/cartography/helpers/drawings-factory/line-element-factory.ts
@@ -15,6 +15,10 @@ export class LineElementFactory implements DrawingElementFactory {
     lineElement.y2 = 0;
     lineElement.width = 100;
     lineElement.height = 0;
+    lineElement.arrow_start = false;
+    lineElement.arrow_end = false;
+    lineElement.drawing_type = 'straight';
+    lineElement.control_offset = [0, 0];
     return lineElement;
   }
 }

--- a/src/app/cartography/helpers/svg-to-drawing-converter/line-converter.ts
+++ b/src/app/cartography/helpers/svg-to-drawing-converter/line-converter.ts
@@ -11,7 +11,7 @@ export class LineConverter implements SvgConverter {
     }
 
     const stroke_width = element.attributes.getNamedItem('stroke-width');
-    if (stroke) {
+    if (stroke_width) {
       drawing.stroke_width = parseInt(stroke_width.value, 10);
     }
 
@@ -39,6 +39,28 @@ export class LineConverter implements SvgConverter {
     if (y2) {
       drawing.y2 = parseInt(y2.value, 10);
     }
+
+    // Parse marker attributes for arrows
+    const marker_start = element.attributes.getNamedItem('marker-start');
+    const marker_end = element.attributes.getNamedItem('marker-end');
+
+    if (marker_start && marker_start.value.includes('line-start')) {
+      drawing.arrow_start = true;
+    } else {
+      drawing.arrow_start = false;
+    }
+
+    if (marker_end && marker_end.value.includes('line-end')) {
+      drawing.arrow_end = true;
+    } else {
+      drawing.arrow_end = false;
+    }
+
+    // Set default values
+    drawing.arrow_start = drawing.arrow_start ?? false;
+    drawing.arrow_end = drawing.arrow_end ?? false;
+    drawing.drawing_type = 'straight';
+    drawing.control_offset = [0, 0];
 
     return drawing;
   }

--- a/src/app/cartography/helpers/svg-to-drawing-converter/line-converter.ts
+++ b/src/app/cartography/helpers/svg-to-drawing-converter/line-converter.ts
@@ -56,11 +56,30 @@ export class LineConverter implements SvgConverter {
       drawing.arrow_end = false;
     }
 
+    // Parse data-drawing-type attribute
+    const drawing_type_attr = element.attributes.getNamedItem('data-drawing-type');
+    if (drawing_type_attr && (drawing_type_attr.value === 'straight' || drawing_type_attr.value === 'freeform')) {
+      drawing.drawing_type = drawing_type_attr.value;
+    } else {
+      drawing.drawing_type = 'straight';
+    }
+
+    // Parse data-control-offset attribute
+    const control_offset_attr = element.attributes.getNamedItem('data-control-offset');
+    if (control_offset_attr && control_offset_attr.value) {
+      const offsets = control_offset_attr.value.split(',');
+      if (offsets.length === 2) {
+        drawing.control_offset = [parseInt(offsets[0], 10), parseInt(offsets[1], 10)];
+      } else {
+        drawing.control_offset = [0, 0];
+      }
+    } else {
+      drawing.control_offset = [0, 0];
+    }
+
     // Set default values
     drawing.arrow_start = drawing.arrow_start ?? false;
     drawing.arrow_end = drawing.arrow_end ?? false;
-    drawing.drawing_type = 'straight';
-    drawing.control_offset = [0, 0];
 
     return drawing;
   }

--- a/src/app/cartography/models/drawings/line-element.ts
+++ b/src/app/cartography/models/drawings/line-element.ts
@@ -1,5 +1,7 @@
 import { DrawingElement } from './drawing-element';
 
+export type LineDrawingType = 'straight' | 'freeform';
+
 export class LineElement implements DrawingElement {
   height: number;
   width: number;
@@ -10,4 +12,8 @@ export class LineElement implements DrawingElement {
   x2: number;
   y1: number;
   y2: number;
+  arrow_start: boolean;
+  arrow_end: boolean;
+  drawing_type: LineDrawingType;
+  control_offset: [number, number]; // For freeform mode: [x, y] offset from midpoint
 }

--- a/src/app/cartography/models/drawings/line-element.ts
+++ b/src/app/cartography/models/drawings/line-element.ts
@@ -16,4 +16,13 @@ export class LineElement implements DrawingElement {
   arrow_end: boolean;
   drawing_type: LineDrawingType;
   control_offset: [number, number]; // For freeform mode: [x, y] offset from midpoint
+
+  // Text label properties
+  text: string;
+  text_font_family: string;
+  text_font_size: number;
+  text_font_weight: string;
+  text_fill: string;
+  text_x: number;
+  text_y: number;
 }

--- a/src/app/cartography/widgets/drawings.ts
+++ b/src/app/cartography/widgets/drawings.ts
@@ -363,6 +363,28 @@ export class DrawingsWidget implements Widget {
         this.resizingFinished.emit(this.createResizingEvent(datum));
       });
 
+    let controlPointMove = drag()
+      .on('start', () => {
+        document.body.style.cursor = 'move';
+      })
+      .on('drag', (event: any, datum: MapDrawing) => {
+        const evt = event;
+        if (datum.element instanceof LineElement && (datum.element as LineElement).drawing_type === 'freeform') {
+          const line = datum.element as LineElement;
+          // Update control offset based on drag movement
+          if (!line.control_offset) {
+            line.control_offset = [0, 0];
+          }
+          line.control_offset[0] += evt.dx;
+          line.control_offset[1] += evt.dy;
+          this.redrawDrawing(view, datum);
+        }
+      })
+      .on('end', (event: any, datum: MapDrawing) => {
+        document.body.style.cursor = 'initial';
+        this.resizingFinished.emit(this.createResizingEvent(datum));
+      });
+
     merge.select<SVGAElement>('line.bottom').call(bottom);
 
     merge.select<SVGAElement>('line.top').call(top);
@@ -374,6 +396,8 @@ export class DrawingsWidget implements Widget {
     merge.select<SVGAElement>('circle.right').call(circleMoveRight);
 
     merge.select<SVGAElement>('circle.left').call(circleMoveLeft);
+
+    merge.select<SVGCircleElement>('circle.control-point').call(controlPointMove);
   }
 
   private createResizingEvent(datum: MapDrawing) {

--- a/src/app/cartography/widgets/drawings.ts
+++ b/src/app/cartography/widgets/drawings.ts
@@ -381,7 +381,7 @@ export class DrawingsWidget implements Widget {
     merge.each((datum: MapDrawing) => {
       if (datum.element instanceof LineElement && (datum.element as LineElement).drawing_type === 'freeform') {
         const line = datum.element as LineElement;
-        const pathElement = select(merge.node()).select<SVGPathElement>('path.line_element_freeform');
+        const pathElement = view.select<SVGPathElement>(`g.drawing[drawing_id="${datum.id}"] path.line_element_freeform`);
 
         if (!pathElement.empty()) {
           const dragState = {

--- a/src/app/cartography/widgets/drawings.ts
+++ b/src/app/cartography/widgets/drawings.ts
@@ -1,5 +1,6 @@
 import { EventEmitter, Injectable } from '@angular/core';
 import { drag } from 'd3-drag';
+import { select } from 'd3-selection';
 
 import { Draggable } from '../events/draggable';
 import { DrawingContextMenu } from '../events/event-source';
@@ -14,6 +15,7 @@ import { MapDrawing } from '../models/map/map-drawing';
 import { SVGSelection } from '../models/types';
 import { DrawingWidget } from './drawing';
 import { Widget } from './widget';
+import { StyleTranslator } from './links/style-translator';
 
 @Injectable()
 export class DrawingsWidget implements Widget {
@@ -363,28 +365,6 @@ export class DrawingsWidget implements Widget {
         this.resizingFinished.emit(this.createResizingEvent(datum));
       });
 
-    let controlPointMove = drag()
-      .on('start', () => {
-        document.body.style.cursor = 'move';
-      })
-      .on('drag', (event: any, datum: MapDrawing) => {
-        const evt = event;
-        if (datum.element instanceof LineElement && (datum.element as LineElement).drawing_type === 'freeform') {
-          const line = datum.element as LineElement;
-          // Update control offset based on drag movement
-          if (!line.control_offset) {
-            line.control_offset = [0, 0];
-          }
-          line.control_offset[0] += evt.dx;
-          line.control_offset[1] += evt.dy;
-          this.redrawDrawing(view, datum);
-        }
-      })
-      .on('end', (event: any, datum: MapDrawing) => {
-        document.body.style.cursor = 'initial';
-        this.resizingFinished.emit(this.createResizingEvent(datum));
-      });
-
     merge.select<SVGAElement>('line.bottom').call(bottom);
 
     merge.select<SVGAElement>('line.top').call(top);
@@ -397,7 +377,66 @@ export class DrawingsWidget implements Widget {
 
     merge.select<SVGAElement>('circle.left').call(circleMoveLeft);
 
-    merge.select<SVGCircleElement>('circle.control-point').call(controlPointMove);
+    // Add drag behavior for freeform lines (similar to links)
+    merge.each((datum: MapDrawing) => {
+      if (datum.element instanceof LineElement && (datum.element as LineElement).drawing_type === 'freeform') {
+        const line = datum.element as LineElement;
+        const pathElement = select(merge.node()).select<SVGPathElement>('path.line_element_freeform');
+
+        if (!pathElement.empty()) {
+          const dragState = {
+            startX: 0,
+            startY: 0,
+            startOffset: [0, 0] as [number, number],
+          };
+
+          pathElement.call(
+            drag<SVGPathElement, MapDrawing>()
+              .on('start', (event: any) => {
+                document.body.style.cursor = 'grabbing';
+                dragState.startX = event.x;
+                dragState.startY = event.y;
+
+                if (line.control_offset) {
+                  dragState.startOffset = [line.control_offset[0], line.control_offset[1]];
+                } else {
+                  const midX = (line.x1 + line.x2) / 2;
+                  const midY = (line.y1 + line.y2) / 2;
+                  dragState.startOffset = [midX, midY];
+                }
+              })
+              .on('drag', (event: any) => {
+                const mousePos: [number, number] = [event.x, event.y];
+
+                const startX = dragState.startX;
+                const startY = dragState.startY;
+                const startOffset = dragState.startOffset;
+
+                const deltaX = mousePos[0] - startX;
+                const deltaY = mousePos[1] - startY;
+
+                const controlX = startOffset[0] + deltaX;
+                const controlY = startOffset[1] + deltaY;
+
+                // Update control offset (absolute coordinates like links)
+                line.control_offset = [controlX, controlY];
+
+                // Recalculate path
+                const source: [number, number] = [line.x1, line.y1];
+                const target: [number, number] = [line.x2, line.y2];
+                const newPath = StyleTranslator.getFreeformBezierPath(source, target, undefined, undefined, [controlX, controlY]);
+                pathElement.attr('d', newPath);
+
+                this.redrawDrawing(view, datum);
+              })
+              .on('end', (event: any) => {
+                document.body.style.cursor = 'initial';
+                this.resizingFinished.emit(this.createResizingEvent(datum));
+              })
+          );
+        }
+      }
+    });
   }
 
   private createResizingEvent(datum: MapDrawing) {

--- a/src/app/cartography/widgets/drawings/line-drawing.ts
+++ b/src/app/cartography/widgets/drawings/line-drawing.ts
@@ -35,6 +35,14 @@ export class LineDrawingWidget implements DrawingShapeWidget {
   }
 
   private drawLineElements(view: SVGSelection) {
+    const self = this;
+
+    // Ensure defs element exists for arrow markers
+    let defs = view.select('defs');
+    if (defs.empty()) {
+      defs = view.append('defs');
+    }
+
     const drawing = view.selectAll<SVGLineElement, LineElement>('line.line_element').data((d: MapDrawing) => {
       return d.element && d.element instanceof LineElement ? [d.element] : [];
     });
@@ -43,19 +51,90 @@ export class LineDrawingWidget implements DrawingShapeWidget {
 
     drawing.enter().append<SVGCircleElement>('circle').attr('class', 'left');
 
+    // Add control point circle for freeform mode
+    drawing.enter().append<SVGCircleElement>('circle').attr('class', 'control-point');
+
     const drawing_enter = drawing.enter().append<SVGLineElement>('line').attr('class', 'line_element noselect');
 
     const merge = drawing.merge(drawing_enter);
 
+    // Store original stroke color for hover effect
+    merge.each(function (line: LineElement) {
+      const originalStroke = line.stroke;
+
+      // Create arrow markers if needed
+      if (line.arrow_end) {
+        self.createOrUpdateArrowMarkerForLine(defs, 'end', line.stroke, line.stroke_width);
+      }
+      if (line.arrow_start) {
+        self.createOrUpdateArrowMarkerForLine(defs, 'start', line.stroke, line.stroke_width);
+      }
+
+      select(this)
+        .attr('stroke', line.stroke)
+        .attr('stroke-width', line.stroke_width)
+        .attr('stroke-dasharray', self.qtDasharrayFixer.fix(line.stroke_dasharray))
+        .attr('x1', line.x1)
+        .attr('x2', line.x2)
+        .attr('y1', line.y1)
+        .attr('y2', line.y2)
+        .attr('cursor', 'pointer')
+        .attr('marker-end', line.arrow_end ? 'url(#line-end)' : null)
+        .attr('marker-start', line.arrow_start ? 'url(#line-start)' : null)
+        .on('mouseenter', function () {
+          // Get the error color from CSS variable
+          const errorColor = getComputedStyle(document.documentElement)
+            .getPropertyValue('--mat-sys-error')
+            .trim();
+
+          // Update path stroke
+          select(this).attr('stroke', errorColor);
+
+          // Update arrow marker fills
+          if (line.arrow_end) {
+            defs.select('#line-end path').attr('fill', errorColor);
+          }
+          if (line.arrow_start) {
+            defs.select('#line-start path').attr('fill', errorColor);
+          }
+        })
+        .on('mouseleave', function () {
+          // Restore original stroke
+          select(this).attr('stroke', originalStroke);
+
+          // Restore arrow marker fills
+          if (line.arrow_end) {
+            defs.select('#line-end path').attr('fill', originalStroke);
+          }
+          if (line.arrow_start) {
+            defs.select('#line-start path').attr('fill', originalStroke);
+          }
+        });
+    });
+
+    // Update control point for freeform lines
     merge
-      .attr('stroke', (line) => line.stroke)
-      .attr('stroke-width', (line) => line.stroke_width)
-      .attr('stroke-dasharray', (line) => this.qtDasharrayFixer.fix(line.stroke_dasharray))
-      .attr('x1', (line) => line.x1)
-      .attr('x2', (line) => line.x2)
-      .attr('y1', (line) => line.y1)
-      .attr('y2', (line) => line.y2)
-      .attr('cursor', 'pointer');
+      .selectAll<SVGCircleElement, LineElement>('circle.control-point')
+      .attr('cx', (line) => {
+        if (line.drawing_type === 'freeform' && line.control_offset) {
+          const midX = (line.x1 + line.x2) / 2;
+          return midX + line.control_offset[0];
+        }
+        return (line.x1 + line.x2) / 2;
+      })
+      .attr('cy', (line) => {
+        if (line.drawing_type === 'freeform' && line.control_offset) {
+          const midY = (line.y1 + line.y2) / 2;
+          return midY + line.control_offset[1];
+        }
+        return (line.y1 + line.y2) / 2;
+      })
+      .attr('r', (line) => (line.drawing_type === 'freeform' ? 5 : 0))
+      .attr('fill', 'var(--mat-sys-primary)')
+      .attr('stroke', 'var(--mat-sys-on-primary)')
+      .attr('stroke-width', 2)
+      .attr('cursor', 'move')
+      .attr('display', (line) => (line.drawing_type === 'freeform' ? 'block' : 'none'));
 
     drawing.exit().remove();
   }
@@ -169,6 +248,35 @@ export class LineDrawingWidget implements DrawingShapeWidget {
         select(this).remove();
       }
     });
+  }
+
+  private createOrUpdateArrowMarkerForLine(
+    defs: any,
+    position: 'start' | 'end',
+    color: string,
+    strokeWidth: number
+  ) {
+    const markerId = `line-${position}`;
+    let marker = defs.select(`marker#${markerId}`);
+
+    if (marker.empty()) {
+      marker = defs
+        .append('marker')
+        .attr('id', markerId)
+        .attr('markerWidth', '4')
+        .attr('markerHeight', '4')
+        .attr('refX', position === 'end' ? '0' : '4')
+        .attr('refY', '2')
+        .attr('orient', 'auto')
+        .attr('markerUnits', 'strokeWidth');
+
+      marker
+        .append('path')
+        .attr('d', position === 'end' ? 'M0,0 L4,2 L0,4 z' : 'M4,0 L0,2 L4,4 z')
+        .attr('fill', color);
+    } else {
+      marker.select('path').attr('fill', color);
+    }
   }
 
   private createOrUpdateArrowMarker(

--- a/src/app/cartography/widgets/drawings/line-drawing.ts
+++ b/src/app/cartography/widgets/drawings/line-drawing.ts
@@ -7,6 +7,7 @@ import { LineElement } from '../../models/drawings/line-element';
 import { MapDrawing } from '../../models/map/map-drawing';
 import { SVGSelection } from '../../models/types';
 import { DrawingShapeWidget } from './drawing-shape-widget';
+import { StyleTranslator } from '../links/style-translator';
 
 @Injectable()
 export class LineDrawingWidget implements DrawingShapeWidget {
@@ -43,23 +44,21 @@ export class LineDrawingWidget implements DrawingShapeWidget {
       defs = view.append('defs');
     }
 
-    const drawing = view.selectAll<SVGLineElement, LineElement>('line.line_element').data((d: MapDrawing) => {
-      return d.element && d.element instanceof LineElement ? [d.element] : [];
+    // Draw straight lines
+    const straightLines = view.selectAll<SVGLineElement, LineElement>('line.line_element').data((d: MapDrawing) => {
+      return d.element && d.element instanceof LineElement && d.element.drawing_type !== 'freeform' ? [d.element] : [];
     });
 
-    drawing.enter().append<SVGCircleElement>('circle').attr('class', 'right');
+    straightLines.enter().append<SVGCircleElement>('circle').attr('class', 'right');
 
-    drawing.enter().append<SVGCircleElement>('circle').attr('class', 'left');
+    straightLines.enter().append<SVGCircleElement>('circle').attr('class', 'left');
 
-    // Add control point circle for freeform mode
-    drawing.enter().append<SVGCircleElement>('circle').attr('class', 'control-point');
+    const straightLinesEnter = straightLines.enter().append<SVGLineElement>('line').attr('class', 'line_element noselect');
 
-    const drawing_enter = drawing.enter().append<SVGLineElement>('line').attr('class', 'line_element noselect');
+    const straightLinesMerge = straightLines.merge(straightLinesEnter);
 
-    const merge = drawing.merge(drawing_enter);
-
-    // Store original stroke color for hover effect
-    merge.each(function (line: LineElement) {
+    // Draw straight lines
+    straightLinesMerge.each(function (line: LineElement) {
       const originalStroke = line.stroke;
 
       // Create arrow markers if needed
@@ -112,31 +111,50 @@ export class LineDrawingWidget implements DrawingShapeWidget {
         });
     });
 
-    // Update control point for freeform lines
-    merge
-      .selectAll<SVGCircleElement, LineElement>('circle.control-point')
-      .attr('cx', (line) => {
-        if (line.drawing_type === 'freeform' && line.control_offset) {
-          const midX = (line.x1 + line.x2) / 2;
-          return midX + line.control_offset[0];
-        }
-        return (line.x1 + line.x2) / 2;
-      })
-      .attr('cy', (line) => {
-        if (line.drawing_type === 'freeform' && line.control_offset) {
-          const midY = (line.y1 + line.y2) / 2;
-          return midY + line.control_offset[1];
-        }
-        return (line.y1 + line.y2) / 2;
-      })
-      .attr('r', (line) => (line.drawing_type === 'freeform' ? 5 : 0))
-      .attr('fill', 'var(--mat-sys-primary)')
-      .attr('stroke', 'var(--mat-sys-on-primary)')
-      .attr('stroke-width', 2)
-      .attr('cursor', 'move')
-      .attr('display', (line) => (line.drawing_type === 'freeform' ? 'block' : 'none'));
+    // Draw freeform lines as paths
+    const freeformLines = view
+      .selectAll<SVGPathElement, LineElement>('path.line_element_freeform')
+      .data((d: MapDrawing) => {
+        return d.element && d.element instanceof LineElement && d.element.drawing_type === 'freeform' ? [d.element] : [];
+      });
 
-    drawing.exit().remove();
+    freeformLines.enter().append<SVGCircleElement>('circle').attr('class', 'right');
+
+    freeformLines.enter().append<SVGCircleElement>('circle').attr('class', 'left');
+
+    const freeformLinesEnter = freeformLines.enter().append<SVGPathElement>('path').attr('class', 'line_element_freeform noselect');
+
+    const freeformLinesMerge = freeformLines.merge(freeformLinesEnter);
+
+    // Draw freeform lines (drag behavior will be added in drawings.ts)
+    freeformLinesMerge.each(function (line: LineElement) {
+      // Create arrow markers if needed
+      if (line.arrow_end) {
+        self.createOrUpdateArrowMarkerForLine(defs, 'end', line.stroke, line.stroke_width);
+      }
+      if (line.arrow_start) {
+        self.createOrUpdateArrowMarkerForLine(defs, 'start', line.stroke, line.stroke_width);
+      }
+
+      // Calculate path data
+      const source: [number, number] = [line.x1, line.y1];
+      const target: [number, number] = [line.x2, line.y2];
+      const controlOffset = line.control_offset || [(line.x1 + line.x2) / 2, (line.y1 + line.y2) / 2];
+      const pathData = StyleTranslator.getFreeformBezierPath(source, target, undefined, undefined, controlOffset);
+
+      select(this)
+        .attr('d', pathData)
+        .attr('stroke', line.stroke)
+        .attr('stroke-width', line.stroke_width)
+        .attr('stroke-dasharray', self.qtDasharrayFixer.fix(line.stroke_dasharray))
+        .attr('fill', 'none')
+        .attr('cursor', 'grab')
+        .attr('marker-end', line.arrow_end ? 'url(#line-end)' : null)
+        .attr('marker-start', line.arrow_start ? 'url(#line-start)' : null);
+    });
+
+    straightLines.exit().remove();
+    freeformLines.exit().remove();
   }
 
   private drawCurveElements(view: SVGSelection) {

--- a/src/app/cartography/widgets/drawings/line-drawing.ts
+++ b/src/app/cartography/widgets/drawings/line-drawing.ts
@@ -45,8 +45,8 @@ export class LineDrawingWidget implements DrawingShapeWidget {
     }
 
     // Draw straight lines
-    const straightLines = view.selectAll<SVGLineElement, LineElement>('line.line_element').data((d: MapDrawing) => {
-      return d.element && d.element instanceof LineElement && d.element.drawing_type !== 'freeform' ? [d.element] : [];
+    const straightLines = view.selectAll<SVGLineElement, MapDrawing>('line.line_element').data((d: MapDrawing) => {
+      return d.element && d.element instanceof LineElement && d.element.drawing_type !== 'freeform' ? [d] : [];
     });
 
     straightLines.enter().append<SVGCircleElement>('circle').attr('class', 'right');
@@ -55,18 +55,22 @@ export class LineDrawingWidget implements DrawingShapeWidget {
 
     const straightLinesEnter = straightLines.enter().append<SVGLineElement>('line').attr('class', 'line_element noselect');
 
+    // Add text label for straight lines
+    straightLinesEnter.append<SVGTextElement>('text').attr('class', 'line_text_label noselect');
+
     const straightLinesMerge = straightLines.merge(straightLinesEnter);
 
     // Draw straight lines
-    straightLinesMerge.each(function (line: LineElement) {
+    straightLinesMerge.each(function (mapDrawing: MapDrawing) {
+      const line = mapDrawing.element as LineElement;
       const originalStroke = line.stroke;
 
-      // Create arrow markers if needed
+      // Create arrow markers with unique IDs per drawing
       if (line.arrow_end) {
-        self.createOrUpdateArrowMarkerForLine(defs, 'end', line.stroke, line.stroke_width);
+        self.createOrUpdateArrowMarkerForLine(defs, mapDrawing.id, 'end', line.stroke, line.stroke_width);
       }
       if (line.arrow_start) {
-        self.createOrUpdateArrowMarkerForLine(defs, 'start', line.stroke, line.stroke_width);
+        self.createOrUpdateArrowMarkerForLine(defs, mapDrawing.id, 'start', line.stroke, line.stroke_width);
       }
 
       select(this)
@@ -78,8 +82,8 @@ export class LineDrawingWidget implements DrawingShapeWidget {
         .attr('y1', line.y1)
         .attr('y2', line.y2)
         .attr('cursor', 'pointer')
-        .attr('marker-end', line.arrow_end ? 'url(#line-end)' : null)
-        .attr('marker-start', line.arrow_start ? 'url(#line-start)' : null)
+        .attr('marker-end', line.arrow_end ? `url(#line-end-${mapDrawing.id})` : null)
+        .attr('marker-start', line.arrow_start ? `url(#line-start-${mapDrawing.id})` : null)
         .on('mouseenter', function () {
           // Get the error color from CSS variable
           const errorColor = getComputedStyle(document.documentElement)
@@ -91,10 +95,10 @@ export class LineDrawingWidget implements DrawingShapeWidget {
 
           // Update arrow marker fills
           if (line.arrow_end) {
-            defs.select('#line-end path').attr('fill', errorColor);
+            defs.select(`#line-end-${mapDrawing.id} path`).attr('fill', errorColor);
           }
           if (line.arrow_start) {
-            defs.select('#line-start path').attr('fill', errorColor);
+            defs.select(`#line-start-${mapDrawing.id} path`).attr('fill', errorColor);
           }
         })
         .on('mouseleave', function () {
@@ -103,19 +107,36 @@ export class LineDrawingWidget implements DrawingShapeWidget {
 
           // Restore arrow marker fills
           if (line.arrow_end) {
-            defs.select('#line-end path').attr('fill', originalStroke);
+            defs.select(`#line-end-${mapDrawing.id} path`).attr('fill', originalStroke);
           }
           if (line.arrow_start) {
-            defs.select('#line-start path').attr('fill', originalStroke);
+            defs.select(`#line-start-${mapDrawing.id} path`).attr('fill', originalStroke);
           }
         });
+
+      // Update text label
+      const textLabel = select(this.parentNode as SVGGElement).select<SVGTextElement>('text.line_text_label');
+      if (line.text && line.text.trim() !== '') {
+        textLabel
+          .text(line.text)
+          .attr('x', line.text_x)
+          .attr('y', line.text_y)
+          .attr('fill', line.text_fill)
+          .attr('font-family', line.text_font_family)
+          .attr('font-size', `${line.text_font_size}px`)
+          .attr('font-weight', line.text_font_weight)
+          .attr('visibility', 'visible')
+          .attr('class', 'line_text_label noselect');
+      } else {
+        textLabel.attr('visibility', 'hidden');
+      }
     });
 
     // Draw freeform lines as paths
     const freeformLines = view
-      .selectAll<SVGPathElement, LineElement>('path.line_element_freeform')
+      .selectAll<SVGPathElement, MapDrawing>('path.line_element_freeform')
       .data((d: MapDrawing) => {
-        return d.element && d.element instanceof LineElement && d.element.drawing_type === 'freeform' ? [d.element] : [];
+        return d.element && d.element instanceof LineElement && d.element.drawing_type === 'freeform' ? [d] : [];
       });
 
     freeformLines.enter().append<SVGCircleElement>('circle').attr('class', 'right');
@@ -124,16 +145,21 @@ export class LineDrawingWidget implements DrawingShapeWidget {
 
     const freeformLinesEnter = freeformLines.enter().append<SVGPathElement>('path').attr('class', 'line_element_freeform noselect');
 
+    // Add text label for freeform lines
+    freeformLinesEnter.append<SVGTextElement>('text').attr('class', 'line_text_label noselect');
+
     const freeformLinesMerge = freeformLines.merge(freeformLinesEnter);
 
     // Draw freeform lines (drag behavior will be added in drawings.ts)
-    freeformLinesMerge.each(function (line: LineElement) {
-      // Create arrow markers if needed
+    freeformLinesMerge.each(function (mapDrawing: MapDrawing) {
+      const line = mapDrawing.element as LineElement;
+
+      // Create arrow markers with unique IDs per drawing
       if (line.arrow_end) {
-        self.createOrUpdateArrowMarkerForLine(defs, 'end', line.stroke, line.stroke_width);
+        self.createOrUpdateArrowMarkerForLine(defs, mapDrawing.id, 'end', line.stroke, line.stroke_width);
       }
       if (line.arrow_start) {
-        self.createOrUpdateArrowMarkerForLine(defs, 'start', line.stroke, line.stroke_width);
+        self.createOrUpdateArrowMarkerForLine(defs, mapDrawing.id, 'start', line.stroke, line.stroke_width);
       }
 
       // Calculate path data
@@ -149,8 +175,25 @@ export class LineDrawingWidget implements DrawingShapeWidget {
         .attr('stroke-dasharray', self.qtDasharrayFixer.fix(line.stroke_dasharray))
         .attr('fill', 'none')
         .attr('cursor', 'grab')
-        .attr('marker-end', line.arrow_end ? 'url(#line-end)' : null)
-        .attr('marker-start', line.arrow_start ? 'url(#line-start)' : null);
+        .attr('marker-end', line.arrow_end ? `url(#line-end-${mapDrawing.id})` : null)
+        .attr('marker-start', line.arrow_start ? `url(#line-start-${mapDrawing.id})` : null);
+
+      // Update text label
+      const textLabel = select(this.parentNode as SVGGElement).select<SVGTextElement>('text.line_text_label');
+      if (line.text && line.text.trim() !== '') {
+        textLabel
+          .text(line.text)
+          .attr('x', line.text_x)
+          .attr('y', line.text_y)
+          .attr('fill', line.text_fill)
+          .attr('font-family', line.text_font_family)
+          .attr('font-size', `${line.text_font_size}px`)
+          .attr('font-weight', line.text_font_weight)
+          .attr('visibility', 'visible')
+          .attr('class', 'line_text_label noselect');
+      } else {
+        textLabel.attr('visibility', 'hidden');
+      }
     });
 
     straightLines.exit().remove();
@@ -270,11 +313,12 @@ export class LineDrawingWidget implements DrawingShapeWidget {
 
   private createOrUpdateArrowMarkerForLine(
     defs: any,
+    drawingId: string,
     position: 'start' | 'end',
     color: string,
     strokeWidth: number
   ) {
-    const markerId = `line-${position}`;
+    const markerId = `line-${position}-${drawingId}`;
     let marker = defs.select(`marker#${markerId}`);
 
     if (marker.empty()) {

--- a/src/app/components/project-map/drawings-editors/style-editor/style-editor.component.html
+++ b/src/app/components/project-map/drawings-editors/style-editor/style-editor.component.html
@@ -63,6 +63,25 @@
     </mat-form-field>
     }
 
+    @if (element.line_arrow_direction !== undefined) {
+    <mat-form-field class="form-field">
+      <mat-label>Arrow direction</mat-label>
+      <mat-select [value]="element.line_arrow_direction" (selectionChange)="onLineArrowDirectionChange($event.value)">
+        @for (dir of arrowDirections; track dir.value) {
+        <mat-option [value]="dir.value"> {{ dir.name }} </mat-option>
+        }
+      </mat-select>
+    </mat-form-field>
+    <mat-form-field class="form-field">
+      <mat-label>Drawing type</mat-label>
+      <mat-select [value]="element.line_drawing_type" (selectionChange)="onLineDrawingTypeChange($event.value)">
+        @for (type of lineDrawingTypes; track type.value) {
+        <mat-option [value]="type.value"> {{ type.name }} </mat-option>
+        }
+      </mat-select>
+    </mat-form-field>
+    }
+
     <mat-form-field class="form-field">
       <mat-label>Rotation</mat-label>
       <input matInput formControlName="rotation" type="number" />

--- a/src/app/components/project-map/drawings-editors/style-editor/style-editor.component.html
+++ b/src/app/components/project-map/drawings-editors/style-editor/style-editor.component.html
@@ -82,10 +82,12 @@
     </mat-form-field>
     }
 
+    @if (element.line_drawing_type === undefined || element.line_drawing_type === 'straight') {
     <mat-form-field class="form-field">
       <mat-label>Rotation</mat-label>
       <input matInput formControlName="rotation" type="number" />
     </mat-form-field>
+    }
   </form>
 </div>
 

--- a/src/app/components/project-map/drawings-editors/style-editor/style-editor.component.ts
+++ b/src/app/components/project-map/drawings-editors/style-editor/style-editor.component.ts
@@ -82,6 +82,10 @@ export class StyleEditorDialogComponent implements OnInit {
     { value: 'start', name: 'Start Arrow' },
     { value: 'both', name: 'Both Arrows' },
   ];
+  lineDrawingTypes = [
+    { value: 'straight', name: 'Straight Line' },
+    { value: 'freeform', name: 'Freeform (Control Point)' },
+  ];
 
   constructor() {
     this.formGroup = this.formBuilder.group({
@@ -110,6 +114,20 @@ export class StyleEditorDialogComponent implements OnInit {
           ? ''
           : this.drawing.element.stroke_dasharray ?? 'none';
       this.element.stroke_width = this.drawing.element.stroke_width;
+
+      // Initialize arrow direction for line
+      if (this.drawing.element.arrow_start && this.drawing.element.arrow_end) {
+        this.element.line_arrow_direction = 'both';
+      } else if (this.drawing.element.arrow_start) {
+        this.element.line_arrow_direction = 'start';
+      } else if (this.drawing.element.arrow_end) {
+        this.element.line_arrow_direction = 'end';
+      } else {
+        this.element.line_arrow_direction = 'none';
+      }
+
+      // Initialize drawing type
+      this.element.line_drawing_type = this.drawing.element.drawing_type || 'straight';
     } else if (this.drawing.element instanceof CurveElement) {
       this.element.stroke = this.drawing.element.stroke;
       this.element.stroke_dasharray =
@@ -179,6 +197,16 @@ export class StyleEditorDialogComponent implements OnInit {
     this.cd.markForCheck();
   }
 
+  onLineArrowDirectionChange(value: string) {
+    this.element.line_arrow_direction = value;
+    this.cd.markForCheck();
+  }
+
+  onLineDrawingTypeChange(value: string) {
+    this.element.line_drawing_type = value;
+    this.cd.markForCheck();
+  }
+
   onNoClick() {
     this.dialogRef.close();
   }
@@ -212,6 +240,20 @@ export class StyleEditorDialogComponent implements OnInit {
         this.drawing.element.stroke = this.element.stroke;
         this.drawing.element.stroke_dasharray = this.element.stroke_dasharray;
         this.drawing.element.stroke_width = this.element.stroke_width === 0 ? 2 : this.element.stroke_width;
+
+        // Update arrow properties
+        this.drawing.element.arrow_start =
+          this.element.line_arrow_direction === 'start' || this.element.line_arrow_direction === 'both';
+        this.drawing.element.arrow_end =
+          this.element.line_arrow_direction === 'end' || this.element.line_arrow_direction === 'both';
+
+        // Update drawing type
+        this.drawing.element.drawing_type = (this.element.line_drawing_type || 'straight') as any;
+
+        // Initialize control_offset if switching to freeform
+        if (this.drawing.element.drawing_type === 'freeform' && !this.drawing.element.control_offset) {
+          this.drawing.element.control_offset = [0, 0];
+        }
       } else if (this.drawing.element instanceof CurveElement) {
         this.drawing.element.stroke = this.element.stroke ?? '#000000';
         this.drawing.element.stroke_dasharray =
@@ -263,4 +305,6 @@ export class ElementData {
   ry: number;
   curve_type: string;
   arrow_direction: string;
+  line_arrow_direction: string;
+  line_drawing_type: string;
 }


### PR DESCRIPTION
## Summary

- Add arrow support (start/end/both) to straight line drawings
- Add freeform mode with draggable control point for curve adjustment
- Arrow markers use unique IDs per drawing for independent color handling
- Freeform lines use quadratic bezier curves, drag path directly (same as links)
- Hide rotation field when in freeform mode

## Technical Changes

- `LineElement` model: added `arrow_start`, `arrow_end`, `drawing_type`, `control_offset`
- `line-drawing.ts`: render arrows via SVG markers, freeform as `<path>`
- `drawings.ts`: drag behavior for freeform path (mirrors link implementation)
- `style-editor`: arrow direction and drawing type selectors
- `map-drawing-to-svg-converter`: serialize new attributes
- `line-converter`: parse arrow and freeform attributes from SVG