### PR TITLE
feat(console): add SSH console type support on the web-ui client side

### DIFF
--- a/src/app/components/project-map/context-console-menu/context-console-menu.component.spec.ts
+++ b/src/app/components/project-map/context-console-menu/context-console-menu.component.spec.ts
@@ -304,13 +304,23 @@ describe('ContextConsoleMenuComponent', () => {
       expect(mockToasterService.error).toHaveBeenCalledWith('SPICE console is not yet supported.');
     });
 
-    it('should open telnet console for telnet type when node is started', () => {
+    it('should open terminal console for telnet type when node is started', () => {
       const telnetNode = createMockNode({ status: 'started', console_type: 'telnet' });
       (component as any).node = telnetNode;
 
       component.openWebConsole();
 
       expect(mockNodeConsoleService.openConsoleForNode).toHaveBeenCalledWith(telnetNode);
+      expect(logConsoleSubjectNext).toHaveBeenCalledWith(true);
+    });
+
+    it('should open terminal console for ssh type when node is started', () => {
+      const sshNode = createMockNode({ status: 'started', console_type: 'ssh' });
+      (component as any).node = sshNode;
+
+      component.openWebConsole();
+
+      expect(mockNodeConsoleService.openConsoleForNode).toHaveBeenCalledWith(sshNode);
       expect(logConsoleSubjectNext).toHaveBeenCalledWith(true);
     });
   });
@@ -343,9 +353,20 @@ describe('ContextConsoleMenuComponent', () => {
       expect(mockToasterService.error).toHaveBeenCalledWith('SPICE console is not yet supported.');
     });
 
-    it('should open telnet URL in new tab for telnet type when node is started', () => {
+    it('should open terminal URL in new tab for telnet type when node is started', () => {
       const telnetNode = createMockNode({ status: 'started', console_type: 'telnet' });
       (component as any).node = telnetNode;
+      const windowOpenSpy = vi.spyOn(window, 'open');
+
+      component.openWebConsoleInNewTab();
+
+      expect(windowOpenSpy).toHaveBeenCalled();
+      windowOpenSpy.mockRestore();
+    });
+
+    it('should open terminal URL in new tab for ssh type when node is started', () => {
+      const sshNode = createMockNode({ status: 'started', console_type: 'ssh' });
+      (component as any).node = sshNode;
       const windowOpenSpy = vi.spyOn(window, 'open');
 
       component.openWebConsoleInNewTab();

--- a/src/app/components/project-map/context-console-menu/context-console-menu.component.ts
+++ b/src/app/components/project-map/context-console-menu/context-console-menu.component.ts
@@ -101,10 +101,12 @@ export class ContextConsoleMenuComponent implements OnInit {
       } else if (this.node.console_type && this.node.console_type.startsWith('spice')) {
         // SPICE console: not yet implemented
         this.toasterService.error('SPICE console is not yet supported.');
-      } else {
-        // Telnet and other types: use embedded console
+      } else if (this.node.console_type === 'telnet' || this.node.console_type === 'ssh') {
+        // Terminal console: use embedded console
         this.mapSettingsService.logConsoleSubject.next(true);
         this.consoleService.openConsoleForNode(this.node);
+      } else {
+        this.toasterService.error(`Console type '${this.node.console_type}' is not supported in web console mode.`);
       }
     } else {
       this.toasterService.error('To open console please start the node');
@@ -121,8 +123,8 @@ export class ContextConsoleMenuComponent implements OnInit {
       } else if (this.node.console_type && this.node.console_type.startsWith('spice')) {
         // SPICE console: not yet implemented
         this.toasterService.error('SPICE console is not yet supported.');
-      } else if (this.node.console_type === 'telnet') {
-        // Telnet console: use existing URL-based approach
+      } else if (this.node.console_type === 'telnet' || this.node.console_type === 'ssh') {
+        // Terminal console: use existing URL-based approach
         let url = this.router.url.split('/');
         let urlString = `/static/web-ui/${url[1]}/${url[2]}/${url[3]}/${url[4]}/nodes/${this.node.node_id}`;
         window.open(urlString);

--- a/src/app/components/project-map/context-menu/actions/console-device-action-browser/console-device-action-browser.component.spec.ts
+++ b/src/app/components/project-map/context-menu/actions/console-device-action-browser/console-device-action-browser.component.spec.ts
@@ -352,6 +352,29 @@ describe('ConsoleDeviceActionBrowserComponent', () => {
     });
   });
 
+  describe('startConsole() with ssh', () => {
+    it('should build correct ssh URI', () => {
+      const mockNode = createMockNode({
+        console_host: '192.168.1.1',
+        console: 5000,
+        console_type: 'ssh',
+        name: 'Router1',
+        project_id: 'proj-1',
+        node_id: 'node-1',
+      });
+
+      fixture.componentRef.setInput('controller', mockController);
+      fixture.componentRef.setInput('node', mockNode);
+      fixture.detectChanges();
+
+      component.startConsole(false);
+
+      expect(mockProtocolHandlerService.open).toHaveBeenCalledWith(
+        'gns3+ssh://192.168.1.1:5000?name=Router1&project_id=proj-1&node_id=node-1'
+      );
+    });
+  });
+
   describe('startConsole() with IPv6', () => {
     it('should wrap IPv6 address in brackets for telnet', () => {
       const mockNode = createMockNode({
@@ -496,7 +519,7 @@ describe('ConsoleDeviceActionBrowserComponent', () => {
       component.startConsole(false);
 
       expect(mockToasterService.error).toHaveBeenCalledWith(
-        'Supported console types are: telnet, vnc, spice and spice+agent.'
+        'Supported console types are: telnet, ssh, vnc, spice and spice+agent.'
       );
     });
 

--- a/src/app/components/project-map/context-menu/actions/console-device-action-browser/console-device-action-browser.component.ts
+++ b/src/app/components/project-map/context-menu/actions/console-device-action-browser/console-device-action-browser.component.ts
@@ -67,7 +67,7 @@ export class ConsoleDeviceActionBrowserComponent {
         if (ipaddr.IPv6.isValid(host)) {
           host = `[${host}]`;
         }
-        if (node.console_type === 'telnet') {
+        if (node.console_type === 'telnet' || node.console_type === 'ssh') {
           var console_port;
           if (auxiliary === true) {
             console_port = node.properties.aux;
@@ -78,7 +78,7 @@ export class ConsoleDeviceActionBrowserComponent {
           } else {
             console_port = node.console;
           }
-          uri = `gns3+telnet://${host}:${console_port}?name=${node.name}&project_id=${node.project_id}&node_id=${node.node_id}`;
+          uri = `gns3+${node.console_type}://${host}:${console_port}?name=${node.name}&project_id=${node.project_id}&node_id=${node.node_id}`;
         } else if (node.console_type === 'vnc') {
           // Open VNC console in standalone page via WebSocket API
           this.vncConsoleService.openVncConsole(this.controller(), node);
@@ -89,7 +89,7 @@ export class ConsoleDeviceActionBrowserComponent {
           uri = `${node.console_type}://${host}:${node.console}`;
           return window.open(uri); // open an http console directly in a new window/tab
         } else {
-          this.toasterService.error('Supported console types are: telnet, vnc, spice and spice+agent.');
+          this.toasterService.error('Supported console types are: telnet, ssh, vnc, spice and spice+agent.');
           return;
         }
 

--- a/src/app/components/project-map/context-menu/actions/console-device-action/console-device-action.component.ts
+++ b/src/app/components/project-map/context-menu/actions/console-device-action/console-device-action.component.ts
@@ -5,7 +5,7 @@
  * Electron support was removed in commit b5bfb767.
  *
  * The console functionality is now handled by ConsoleDeviceActionBrowserComponent,
- * which uses custom protocol handlers (gns3+telnet://, gns3+spice://) to launch
+ * which uses custom protocol handlers (gns3+telnet://, gns3+ssh://, gns3+spice://) to launch
  * external console applications.
  *
  * TODO: Remove this component and its test files when convenient.

--- a/src/app/components/project-map/context-menu/actions/http-console-new-tab/http-console-new-tab-action.component.spec.ts
+++ b/src/app/components/project-map/context-menu/actions/http-console-new-tab/http-console-new-tab-action.component.spec.ts
@@ -283,9 +283,23 @@ describe('HttpConsoleNewTabActionComponent', () => {
       });
     });
 
-    describe('Telnet console', () => {
+    describe('Terminal console', () => {
       it('should open window with telnet URL when node has telnet console type', () => {
         const node = createMockNode({ console_type: 'telnet', status: 'started' });
+        fixture.componentRef.setInput('nodes', [node]);
+        fixture.componentRef.setInput('controller', mockController);
+        fixture.detectChanges();
+
+        component.openConsole();
+
+        expect(mockWindowOpen).toHaveBeenCalled();
+        const calledUrl = mockWindowOpen.mock.calls[0][0];
+        expect(calledUrl).toContain('/nodes/' + node.node_id);
+        expect(calledUrl).toContain('/static/web-ui/');
+      });
+
+      it('should open window with terminal URL when node has ssh console type', () => {
+        const node = createMockNode({ console_type: 'ssh', status: 'started' });
         fixture.componentRef.setInput('nodes', [node]);
         fixture.componentRef.setInput('controller', mockController);
         fixture.detectChanges();
@@ -301,7 +315,7 @@ describe('HttpConsoleNewTabActionComponent', () => {
 
     describe('Unsupported console type', () => {
       it('should show error when console type is not supported', () => {
-        const node = createMockNode({ console_type: 'ssh', status: 'started' });
+        const node = createMockNode({ console_type: 'unknown', status: 'started' });
         fixture.componentRef.setInput('nodes', [node]);
         fixture.componentRef.setInput('controller', mockController);
         fixture.detectChanges();
@@ -309,12 +323,12 @@ describe('HttpConsoleNewTabActionComponent', () => {
         component.openConsole();
 
         expect(mockToasterService.error).toHaveBeenCalledWith(
-          "Console type 'ssh' not supported in new tab for node Router1."
+          "Console type 'unknown' not supported in new tab for node Router1."
         );
       });
 
       it('should not open window when console type is unsupported', () => {
-        const node = createMockNode({ console_type: 'ssh', status: 'started' });
+        const node = createMockNode({ console_type: 'unknown', status: 'started' });
         fixture.componentRef.setInput('nodes', [node]);
         fixture.componentRef.setInput('controller', mockController);
         fixture.detectChanges();

--- a/src/app/components/project-map/context-menu/actions/http-console-new-tab/http-console-new-tab-action.component.ts
+++ b/src/app/components/project-map/context-menu/actions/http-console-new-tab/http-console-new-tab-action.component.ts
@@ -43,8 +43,8 @@ export class HttpConsoleNewTabActionComponent {
 
             const uri = `${n.console_type}://${n.console_host}:${n.console}`;
             window.open(uri, '_blank');
-          } else if (n.console_type === 'telnet') {
-            // Telnet console: use existing URL-based approach in new tab
+          } else if (n.console_type === 'telnet' || n.console_type === 'ssh') {
+            // Terminal console: use existing URL-based approach in new tab
             let url = this.router.url.split('/');
             let urlString = `/static/web-ui/${url[1]}/${url[2]}/${url[3]}/${url[4]}/nodes/${n.node_id}`;
             window.open(urlString, '_blank');

--- a/src/app/components/project-map/context-menu/actions/http-console/http-console-action.component.spec.ts
+++ b/src/app/components/project-map/context-menu/actions/http-console/http-console-action.component.spec.ts
@@ -263,9 +263,22 @@ describe('HttpConsoleActionComponent', () => {
       });
     });
 
-    describe('Telnet console', () => {
+    describe('Terminal console', () => {
       it('should open telnet console in widget for started node', () => {
         const node = createMockNode({ console_type: 'telnet', status: 'started' });
+        fixture.componentRef.setInput('nodes', [node]);
+        fixture.componentRef.setInput('controller', mockController);
+        fixture.componentRef.setInput('project', mockProject);
+        fixture.detectChanges();
+
+        fixture.nativeElement.querySelector('button').click();
+        fixture.detectChanges();
+
+        expect(mockMapSettingsService.logConsoleSubject.next).toHaveBeenCalledWith(true);
+      });
+
+      it('should open ssh console in widget for started node', () => {
+        const node = createMockNode({ console_type: 'ssh', status: 'started' });
         fixture.componentRef.setInput('nodes', [node]);
         fixture.componentRef.setInput('controller', mockController);
         fixture.componentRef.setInput('project', mockProject);
@@ -296,7 +309,7 @@ describe('HttpConsoleActionComponent', () => {
 
     describe('unsupported console type', () => {
       it('should show error for unsupported console type on started node', () => {
-        const node = createMockNode({ console_type: 'ssh', status: 'started' });
+        const node = createMockNode({ console_type: 'unknown', status: 'started' });
         fixture.componentRef.setInput('nodes', [node]);
         fixture.componentRef.setInput('controller', mockController);
         fixture.componentRef.setInput('project', mockProject);
@@ -306,7 +319,7 @@ describe('HttpConsoleActionComponent', () => {
         fixture.detectChanges();
 
         expect(mockToasterService.error).toHaveBeenCalledWith(
-          "Console type 'ssh' is not supported for inline web console."
+          "Console type 'unknown' is not supported for inline web console."
         );
       });
     });

--- a/src/app/components/project-map/context-menu/actions/http-console/http-console-action.component.ts
+++ b/src/app/components/project-map/context-menu/actions/http-console/http-console-action.component.ts
@@ -66,8 +66,8 @@ export class HttpConsoleActionComponent {
         controller,
         project,
       });
-    } else if (node.console_type === 'telnet') {
-      // Telnet console: still use embedded widget (not inline window)
+    } else if (node.console_type === 'telnet' || node.console_type === 'ssh') {
+      // Terminal console: still use embedded widget (not inline window)
       this.mapSettingsService.logConsoleSubject.next(true);
       setTimeout(() => {
         this.nodeConsoleService.openConsoleForNode(node);

--- a/src/app/components/project-map/log-console/log-console.component.ts
+++ b/src/app/components/project-map/log-console/log-console.component.ts
@@ -256,9 +256,9 @@ export class LogConsoleComponent implements OnInit, AfterViewInit, OnDestroy {
             if (ipaddr.IPv6.isValid(host)) {
               host = `[${host}]`;
             }
-            if (node.console_type === 'telnet') {
+            if (node.console_type === 'telnet' || node.console_type === 'ssh') {
               this.protocolHandlerService.open(
-                `gns3+telnet://${host}:${node.console}?name=${node.name}&project_id=${node.project_id}&node_id=${node.node_id}`
+                `gns3+${node.console_type}://${host}:${node.console}?name=${node.name}&project_id=${node.project_id}&node_id=${node.node_id}`
               );
             } else if (node.console_type === 'vnc') {
               this.protocolHandlerService.open(
@@ -271,7 +271,7 @@ export class LogConsoleComponent implements OnInit, AfterViewInit, OnDestroy {
             } else if (node.console_type && node.console_type.startsWith('http')) {
               window.open(`${node.console_type}://${host}:${node.console}`);
             } else {
-              this.showCommand('Supported console types are: telnet, vnc, spice and spice+agent');
+              this.showCommand('Supported console types are: telnet, ssh, vnc, spice and spice+agent');
             }
           } else {
             this.showCommand(`This node must be started before a console can be opened.`);

--- a/src/app/components/project-map/log-console/log-console.component.ts
+++ b/src/app/components/project-map/log-console/log-console.component.ts
@@ -253,6 +253,9 @@ export class LogConsoleComponent implements OnInit, AfterViewInit, OnDestroy {
           if (node.status === 'started') {
             this.showCommand(`Launching console for node ${splittedCommand[1]}...`);
             var host = node.console_host;
+            if (host === '0.0.0.0' || host === '::' || host === '0:0:0:0:0:0:0:0') {
+              host = this.controller.host;
+            }
             if (ipaddr.IPv6.isValid(host)) {
               host = `[${host}]`;
             }

--- a/src/app/components/project-map/node-editors/configurator/ios/configurator-ios.component.spec.ts
+++ b/src/app/components/project-map/node-editors/configurator/ios/configurator-ios.component.spec.ts
@@ -472,7 +472,7 @@ describe('ConfiguratorDialogIosComponent', () => {
       expect(component.node.properties.midplane).toBe('vxr');
       expect(component.node.properties.npe).toBe('npe-300');
       expect(component.node.console_type).toBe('none');
-      expect(component.node.properties.aux_type).toBe('telnet');
+      expect(component.node.aux_type).toBe('telnet');
       expect(component.node.console_auto_start).toBe(true);
     });
 

--- a/src/app/components/project-map/node-editors/configurator/ios/configurator-ios.component.ts
+++ b/src/app/components/project-map/node-editors/configurator/ios/configurator-ios.component.ts
@@ -126,7 +126,7 @@ export class ConfiguratorDialogIosComponent implements OnInit {
           midplane: node.properties.midplane || '',
           npe: node.properties.npe || '',
           console_type: node.console_type || '',
-          aux_type: node.properties.aux_type || '',
+          aux_type: node.aux_type || '',
           console_auto_start: node.console_auto_start || false,
           // Slots
           slot0: node.properties.slot0 || '',
@@ -245,7 +245,7 @@ export class ConfiguratorDialogIosComponent implements OnInit {
       this.node.properties.midplane = generalFormValues.midplane;
       this.node.properties.npe = generalFormValues.npe;
       this.node.console_type = generalFormValues.console_type;
-      this.node.properties.aux_type = generalFormValues.aux_type;
+      this.node.aux_type = generalFormValues.aux_type;
       this.node.console_auto_start = generalFormValues.console_auto_start;
 
       // Update memory settings

--- a/src/app/components/project-map/node-editors/configurator/qemu/configurator-qemu.component.ts
+++ b/src/app/components/project-map/node-editors/configurator/qemu/configurator-qemu.component.ts
@@ -76,6 +76,7 @@ export class ConfiguratorDialogQemuComponent implements OnInit {
   generalSettingsForm: UntypedFormGroup;
   networkSettingsForm: UntypedFormGroup;
   consoleTypes: string[] = [];
+  auxConsoleTypes: string[] = [];
   onCloseOptions = [];
   bootPriorities = [];
   diskInterfaces: string[] = [];
@@ -155,7 +156,7 @@ export class ConfiguratorDialogQemuComponent implements OnInit {
           boot_priority: node.properties.boot_priority || '',
           on_close: node.properties.on_close || '',
           console_type: node.console_type || '',
-          aux_type: node.properties.aux_type || '',
+          aux_type: node.aux_type || '',
           console_auto_start: node.console_auto_start || false,
           // HDD fields
           hda_disk_image: node.properties.hda_disk_image || '',
@@ -254,6 +255,7 @@ export class ConfiguratorDialogQemuComponent implements OnInit {
 
   getConfiguration() {
     this.consoleTypes = this.qemuConfigurationService.getConsoleTypes();
+    this.auxConsoleTypes = this.qemuConfigurationService.getAuxConsoleTypes();
     this.onCloseOptions = this.qemuConfigurationService.getOnCloseOptions();
     this.qemuConfigurationService.getNetworkTypes().forEach((n) => {
       this.networkTypes.push(n);
@@ -365,7 +367,7 @@ export class ConfiguratorDialogQemuComponent implements OnInit {
       this.node.properties.boot_priority = formValues.boot_priority;
       this.node.properties.on_close = formValues.on_close;
       this.node.console_type = formValues.console_type;
-      this.node.properties.aux_type = formValues.aux_type;
+      this.node.aux_type = formValues.aux_type;
       this.node.console_auto_start = formValues.console_auto_start;
 
       // Update HDD settings

--- a/src/app/services/built-in-templates-configuration.service.spec.ts
+++ b/src/app/services/built-in-templates-configuration.service.spec.ts
@@ -36,14 +36,15 @@ describe('BuiltInTemplatesConfigurationService', () => {
   });
 
   describe('getConsoleTypesForCloudNodes', () => {
-    it('should return 6 console types', () => {
+    it('should return 7 console types', () => {
       const result = service.getConsoleTypesForCloudNodes();
-      expect(result).toHaveLength(6);
+      expect(result).toHaveLength(7);
     });
 
-    it('should include telnet, vnc, spice, http, https, none', () => {
+    it('should include telnet, ssh, vnc, spice, http, https, none', () => {
       const result = service.getConsoleTypesForCloudNodes();
       expect(result).toContain('telnet');
+      expect(result).toContain('ssh');
       expect(result).toContain('vnc');
       expect(result).toContain('spice');
       expect(result).toContain('http');

--- a/src/app/services/built-in-templates-configuration.service.ts
+++ b/src/app/services/built-in-templates-configuration.service.ts
@@ -15,7 +15,7 @@ export class BuiltInTemplatesConfigurationService {
   }
 
   getConsoleTypesForCloudNodes() {
-    return ['telnet', 'vnc', 'spice', 'http', 'https', 'none'];
+    return ['telnet', 'ssh', 'vnc', 'spice', 'http', 'https', 'none'];
   }
 
   getCategoriesForEthernetHubs() {

--- a/src/app/services/docker-configuration.service.spec.ts
+++ b/src/app/services/docker-configuration.service.spec.ts
@@ -19,14 +19,15 @@ describe('DockerConfigurationService', () => {
   });
 
   describe('getConsoleTypes', () => {
-    it('should return 5 console types', () => {
+    it('should return 6 console types', () => {
       const result = service.getConsoleTypes();
-      expect(result).toHaveLength(5);
+      expect(result).toHaveLength(6);
     });
 
-    it('should include telnet, vnc, http, https, none', () => {
+    it('should include telnet, ssh, vnc, http, https, none', () => {
       const result = service.getConsoleTypes();
       expect(result).toContain('telnet');
+      expect(result).toContain('ssh');
       expect(result).toContain('vnc');
       expect(result).toContain('http');
       expect(result).toContain('https');
@@ -35,14 +36,15 @@ describe('DockerConfigurationService', () => {
   });
 
   describe('getAuxConsoleTypes', () => {
-    it('should return 2 aux console types', () => {
+    it('should return 3 aux console types', () => {
       const result = service.getAuxConsoleTypes();
-      expect(result).toHaveLength(2);
+      expect(result).toHaveLength(3);
     });
 
-    it('should include telnet and none', () => {
+    it('should include telnet, ssh and none', () => {
       const result = service.getAuxConsoleTypes();
       expect(result).toContain('telnet');
+      expect(result).toContain('ssh');
       expect(result).toContain('none');
     });
   });

--- a/src/app/services/docker-configuration.service.ts
+++ b/src/app/services/docker-configuration.service.ts
@@ -3,11 +3,11 @@ import { Injectable } from '@angular/core';
 @Injectable()
 export class DockerConfigurationService {
   getConsoleTypes() {
-    return ['telnet', 'vnc', 'http', 'https', 'none'];
+    return ['telnet', 'ssh', 'vnc', 'http', 'https', 'none'];
   }
 
   getAuxConsoleTypes() {
-    return ['telnet', 'none'];
+    return ['telnet', 'ssh', 'none'];
   }
 
   getCategories() {

--- a/src/app/services/ios-configuration.service.spec.ts
+++ b/src/app/services/ios-configuration.service.spec.ts
@@ -19,14 +19,15 @@ describe('IosConfigurationService', () => {
   });
 
   describe('getConsoleTypes', () => {
-    it('should return telnet and none console types', () => {
+    it('should return telnet, ssh, and none console types', () => {
       const result = service.getConsoleTypes();
       expect(result).toContain('telnet');
+      expect(result).toContain('ssh');
       expect(result).toContain('none');
     });
 
-    it('should return exactly 2 console types', () => {
-      expect(service.getConsoleTypes()).toHaveLength(2);
+    it('should return exactly 3 console types', () => {
+      expect(service.getConsoleTypes()).toHaveLength(3);
     });
 
     it('should return an array', () => {

--- a/src/app/services/ios-configuration.service.ts
+++ b/src/app/services/ios-configuration.service.ts
@@ -13,7 +13,7 @@ export class IosConfigurationService {
   c3700_wics = ['WIC-1T', 'WIC-2T'];
 
   getConsoleTypes() {
-    return ['telnet', 'none'];
+    return ['telnet', 'ssh', 'none'];
   }
 
   getCategories() {

--- a/src/app/services/iou-configuration.service.spec.ts
+++ b/src/app/services/iou-configuration.service.spec.ts
@@ -19,10 +19,10 @@ describe('IouConfigurationService', () => {
   });
 
   describe('getConsoleTypes', () => {
-    it('should return telnet and none console types', () => {
+    it('should return telnet, ssh and none console types', () => {
       const result = service.getConsoleTypes();
 
-      expect(result).toEqual(['telnet', 'none']);
+      expect(result).toEqual(['telnet', 'ssh', 'none']);
     });
   });
 

--- a/src/app/services/iou-configuration.service.ts
+++ b/src/app/services/iou-configuration.service.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@angular/core';
 @Injectable()
 export class IouConfigurationService {
   getConsoleTypes() {
-    return ['telnet', 'none'];
+    return ['telnet', 'ssh', 'none'];
   }
 
   getCategories() {

--- a/src/app/services/node.service.ts
+++ b/src/app/services/node.service.ts
@@ -131,6 +131,7 @@ export class NodeService {
   updateNode(controller: Controller, node: Node): Observable<Node> {
     return this.httpController.put<Node>(controller, `/projects/${node.project_id}/nodes/${node.node_id}`, {
       console_type: node.console_type,
+      aux_type: node.aux_type,
       console_auto_start: node.console_auto_start,
       locked: node.locked,
       name: node.name,
@@ -164,6 +165,7 @@ export class NodeService {
 
     return this.httpController.put<Node>(controller, `/projects/${node.project_id}/nodes/${node.node_id}`, {
       console_type: node.console_type,
+      aux_type: node.aux_type,
       console_auto_start: node.console_auto_start,
       custom_adapters: filtered_custom_adapters,
       name: node.name,

--- a/src/app/services/nodeConsole.service.spec.ts
+++ b/src/app/services/nodeConsole.service.spec.ts
@@ -234,6 +234,18 @@ describe('NodeConsoleService', () => {
       expect(window.open).toHaveBeenCalled();
     });
 
+    it('should open tab for started ssh node', () => {
+      mockRouter.url = '/projects/project-1/edit';
+      global.window = {
+        open: vi.fn(),
+      } as any;
+
+      const sshNode = { ...mockNode, console_type: 'ssh' };
+      service.openConsolesForAllNodesInNewTabs([sshNode]);
+
+      expect(window.open).toHaveBeenCalled();
+    });
+
     it('should show error for stopped node', () => {
       const stoppedNode = { ...mockNode, status: 'stopped' };
 
@@ -242,7 +254,7 @@ describe('NodeConsoleService', () => {
       expect(mockToasterService.error).toHaveBeenCalled();
     });
 
-    it('should skip non-telnet console types', () => {
+    it('should skip non-terminal console types', () => {
       global.window = {
         open: vi.fn(),
       } as any;

--- a/src/app/services/nodeConsole.service.ts
+++ b/src/app/services/nodeConsole.service.ts
@@ -100,8 +100,8 @@ export class NodeConsoleService {
     let nodesToStart = 'Please start the following nodes if you want to open consoles in tabs for them: ';
     let nodesToStartCounter = 0;
     nodes.forEach((n) => {
-      // opening a console in tab is only supported for telnet type
-      if (n.console_type === 'telnet') {
+      // opening a console in tab is supported for terminal console types
+      if (n.console_type === 'telnet' || n.console_type === 'ssh') {
         if (n.status === 'started') {
           let url = this.router.url.split('/');
           let urlString = `/static/web-ui/${url[1]}/${url[2]}/${url[3]}/${url[4]}/nodes/${n.node_id}`;

--- a/src/app/services/qemu-configuration.service.spec.ts
+++ b/src/app/services/qemu-configuration.service.spec.ts
@@ -45,12 +45,12 @@ describe('QemuConfigurationService', () => {
       consoleTypes = service.getConsoleTypes();
     });
 
-    it('should return 5 console types', () => {
-      expect(consoleTypes).toHaveLength(5);
+    it('should return 6 console types', () => {
+      expect(consoleTypes).toHaveLength(6);
     });
 
-    it('should include telnet, vnc, spice, spice+agent, none', () => {
-      expect(consoleTypes).toEqual(['telnet', 'vnc', 'spice', 'spice+agent', 'none']);
+    it('should include telnet, ssh, vnc, spice, spice+agent, none', () => {
+      expect(consoleTypes).toEqual(['telnet', 'ssh', 'vnc', 'spice', 'spice+agent', 'none']);
     });
   });
 
@@ -61,12 +61,13 @@ describe('QemuConfigurationService', () => {
       auxConsoleTypes = service.getAuxConsoleTypes();
     });
 
-    it('should return 2 aux console types', () => {
-      expect(auxConsoleTypes).toHaveLength(2);
+    it('should return 3 aux console types', () => {
+      expect(auxConsoleTypes).toHaveLength(3);
     });
 
-    it('should include telnet and none', () => {
+    it('should include telnet, ssh and none', () => {
       expect(auxConsoleTypes).toContain('telnet');
+      expect(auxConsoleTypes).toContain('ssh');
       expect(auxConsoleTypes).toContain('none');
     });
   });

--- a/src/app/services/qemu-configuration.service.ts
+++ b/src/app/services/qemu-configuration.service.ts
@@ -36,11 +36,11 @@ export class QemuConfigurationService {
   }
 
   getConsoleTypes() {
-    return ['telnet', 'vnc', 'spice', 'spice+agent', 'none'];
+    return ['telnet', 'ssh', 'vnc', 'spice', 'spice+agent', 'none'];
   }
 
   getAuxConsoleTypes() {
-    return ['telnet', 'none'];
+    return ['telnet', 'ssh', 'none'];
   }
 
   getDiskInterfaces() {

--- a/src/app/services/virtual-box-configuration.service.spec.ts
+++ b/src/app/services/virtual-box-configuration.service.spec.ts
@@ -19,10 +19,10 @@ describe('VirtualBoxConfigurationService', () => {
   });
 
   describe('getConsoleTypes', () => {
-    it('should return telnet and none with correct length', () => {
+    it('should return telnet, ssh and none with correct length', () => {
       const result = service.getConsoleTypes();
-      expect(result).toEqual(['telnet', 'none']);
-      expect(result).toHaveLength(2);
+      expect(result).toEqual(['telnet', 'ssh', 'none']);
+      expect(result).toHaveLength(3);
     });
 
     it('should not return null or undefined', () => {

--- a/src/app/services/virtual-box-configuration.service.ts
+++ b/src/app/services/virtual-box-configuration.service.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@angular/core';
 @Injectable()
 export class VirtualBoxConfigurationService {
   getConsoleTypes() {
-    return ['telnet', 'none'];
+    return ['telnet', 'ssh', 'none'];
   }
 
   getOnCloseoptions() {

--- a/src/app/services/vmware-configuration.service.spec.ts
+++ b/src/app/services/vmware-configuration.service.spec.ts
@@ -22,10 +22,10 @@ describe('VmwareConfigurationService', () => {
     it('should return all console types with correct values', () => {
       const result = service.getConsoleTypes();
 
-      expect(result).toEqual(['telnet', 'none']);
+      expect(result).toEqual(['telnet', 'ssh', 'none']);
     });
 
-    it.each(['telnet', 'none'])('should include console type: %s', (type) => {
+    it.each(['telnet', 'ssh', 'none'])('should include console type: %s', (type) => {
       expect(service.getConsoleTypes()).toContain(type);
     });
   });

--- a/src/app/services/vmware-configuration.service.ts
+++ b/src/app/services/vmware-configuration.service.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@angular/core';
 @Injectable()
 export class VmwareConfigurationService {
   getConsoleTypes() {
-    return ['telnet', 'none'];
+    return ['telnet', 'ssh', 'none'];
   }
 
   getOnCloseoptions() {

--- a/src/app/services/vpcs-configuration.service.spec.ts
+++ b/src/app/services/vpcs-configuration.service.spec.ts
@@ -19,12 +19,12 @@ describe('VpcsConfigurationService', () => {
   });
 
   describe('getConsoleTypes', () => {
-    it('should return exactly telnet and none', () => {
-      expect(service.getConsoleTypes()).toEqual(['telnet', 'none']);
+    it('should return exactly telnet, ssh and none', () => {
+      expect(service.getConsoleTypes()).toEqual(['telnet', 'ssh', 'none']);
     });
 
-    it('should return array with exactly 2 console types', () => {
-      expect(service.getConsoleTypes()).toHaveLength(2);
+    it('should return array with exactly 3 console types', () => {
+      expect(service.getConsoleTypes()).toHaveLength(3);
     });
 
     it('should return independent array on each call', () => {

--- a/src/app/services/vpcs-configuration.service.ts
+++ b/src/app/services/vpcs-configuration.service.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@angular/core';
 @Injectable()
 export class VpcsConfigurationService {
   getConsoleTypes() {
-    return ['telnet', 'none'];
+    return ['telnet', 'ssh', 'none'];
   }
 
   getCategories() {


### PR DESCRIPTION
### Summary

Updates the Angular web UI to recognise `ssh` as a valid console type, routing it through the same code paths as `telnet` wherever terminal-style console access is handled. Affects configuration services, context menus, the log console, and the open-in-tab/protocol-handler flows.

### Configuration services — console type lists

`'ssh'` added to `getConsoleTypes()` (and `getAuxConsoleTypes()` where applicable) in all node configuration services:

| Service | Console | Aux |
|---|---|---|
| `DockerConfigurationService` | ✔ | ✔ |
| `QemuConfigurationService` | ✔ | ✔ |
| `IosConfigurationService` (Dynamips) | ✔ | — |
| `IouConfigurationService` | ✔ | — |
| `VirtualBoxConfigurationService` | ✔ | — |
| `VmwareConfigurationService` | ✔ | — |
| `VpcsConfigurationService` | ✔ | — |
| `BuiltInTemplatesConfigurationService` (Cloud) | ✔ | — |

This change is related to the pull request to add SSH console support on the server side https://github.com/GNS3/gns3-server/pull/2693

https://github.com/user-attachments/assets/ef68d639-613e-4eef-a217-de00c85b7e6d

