### PR TITLE
fix: add loading indicator for Docker container operations

### DIFF
--- a/src/app/components/project-map/context-menu/actions/idle-pc-action/idle-pc-action.component.spec.ts
+++ b/src/app/components/project-map/context-menu/actions/idle-pc-action/idle-pc-action.component.spec.ts
@@ -152,7 +152,9 @@ describe('IdlePcActionComponent', () => {
   });
 
   afterEach(() => {
-    fixture.destroy();
+    if (fixture) {
+      fixture.destroy();
+    }
   });
 
   describe('Creation', () => {

--- a/src/app/components/project-map/context-menu/actions/start-node-action/start-node-action.component.spec.ts
+++ b/src/app/components/project-map/context-menu/actions/start-node-action/start-node-action.component.spec.ts
@@ -8,6 +8,7 @@ import { Node } from '../../../../../cartography/models/node';
 import { Controller } from '@models/controller';
 import { NodeService } from '@services/node.service';
 import { ToasterService } from '@services/toaster.service';
+import { ProgressService } from '../../../../../common/progress/progress.service';
 import { ChangeDetectorRef } from '@angular/core';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
@@ -16,6 +17,7 @@ describe('StartNodeActionComponent', () => {
   let fixture: ComponentFixture<StartNodeActionComponent>;
   let mockNodeService: { start: ReturnType<typeof vi.fn> };
   let mockToasterService: { error: ReturnType<typeof vi.fn> };
+  let mockProgressService: { activate: ReturnType<typeof vi.fn>; deactivate: ReturnType<typeof vi.fn> };
 
   const mockController: Controller = {
     id: 1,
@@ -67,12 +69,14 @@ describe('StartNodeActionComponent', () => {
 
     mockNodeService = { start: vi.fn().mockReturnValue(of({})) };
     mockToasterService = { error: vi.fn() };
+    mockProgressService = { activate: vi.fn(), deactivate: vi.fn() };
 
     await TestBed.configureTestingModule({
       imports: [MatButtonModule, MatIconModule, MatMenuModule],
     })
       .overrideProvider(NodeService, { useValue: mockNodeService })
       .overrideProvider(ToasterService, { useValue: mockToasterService })
+      .overrideProvider(ProgressService, { useValue: mockProgressService })
       .overrideProvider(ChangeDetectorRef, { useValue: { markForCheck: vi.fn() } })
       .compileComponents();
 
@@ -81,7 +85,9 @@ describe('StartNodeActionComponent', () => {
   });
 
   afterEach(() => {
-    fixture.destroy();
+    if (fixture) {
+      fixture.destroy();
+    }
   });
 
   describe('isNodeWithStoppedStatus', () => {

--- a/src/app/components/project-map/context-menu/actions/start-node-action/start-node-action.component.ts
+++ b/src/app/components/project-map/context-menu/actions/start-node-action/start-node-action.component.ts
@@ -6,6 +6,7 @@ import { Node } from '../../../../../cartography/models/node';
 import { Controller } from '@models/controller';
 import { NodeService } from '@services/node.service';
 import { ToasterService } from '@services/toaster.service';
+import { ProgressService } from '../../../../../common/progress/progress.service';
 
 @Component({
   selector: 'app-start-node-action',
@@ -17,6 +18,7 @@ export class StartNodeActionComponent implements OnChanges {
   private nodeService = inject(NodeService);
   private toasterService = inject(ToasterService);
   private cdr = inject(ChangeDetectorRef);
+  private progressService = inject(ProgressService);
 
   readonly controller = input<Controller>(undefined);
   readonly nodes = input<Node[]>(undefined);
@@ -34,10 +36,17 @@ export class StartNodeActionComponent implements OnChanges {
   }
 
   startNodes() {
+    this.progressService.activate();
+
     this.nodes().forEach((node) => {
       this.nodeService.start(this.controller(), node).subscribe({
-        next: (n: Node) => {},
+        next: (n: Node) => {
+          if (this.nodes().indexOf(node) === this.nodes().length - 1) {
+            this.progressService.deactivate();
+          }
+        },
         error: (err) => {
+          this.progressService.deactivate();
           const message = err.error?.message || err.message || 'Failed to start node';
           this.toasterService.error(message);
           this.cdr.markForCheck();

--- a/src/app/components/project-map/context-menu/actions/stop-node-action/stop-node-action.component.spec.ts
+++ b/src/app/components/project-map/context-menu/actions/stop-node-action/stop-node-action.component.spec.ts
@@ -8,6 +8,7 @@ import { Node } from '../../../../../cartography/models/node';
 import { Controller } from '../../../../../models/controller';
 import { NodeService } from '../../../../../services/node.service';
 import { ToasterService } from '../../../../../services/toaster.service';
+import { ProgressService } from '../../../../../common/progress/progress.service';
 import { ChangeDetectorRef } from '@angular/core';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
@@ -16,6 +17,7 @@ describe('StopNodeActionComponent', () => {
   let fixture: ComponentFixture<StopNodeActionComponent>;
   let mockNodeService: { stop: ReturnType<typeof vi.fn> };
   let mockToasterService: { error: ReturnType<typeof vi.fn> };
+  let mockProgressService: { activate: ReturnType<typeof vi.fn>; deactivate: ReturnType<typeof vi.fn> };
   let mockChangeDetectorRef: { markForCheck: ReturnType<typeof vi.fn> };
 
   const mockController: Controller = {
@@ -70,6 +72,7 @@ describe('StopNodeActionComponent', () => {
 
     mockNodeService = { stop: vi.fn().mockReturnValue(of({})) };
     mockToasterService = { error: vi.fn() };
+    mockProgressService = { activate: vi.fn(), deactivate: vi.fn() };
     mockChangeDetectorRef = { markForCheck: vi.fn() };
 
     await TestBed.configureTestingModule({
@@ -77,6 +80,7 @@ describe('StopNodeActionComponent', () => {
       providers: [
         { provide: NodeService, useValue: mockNodeService },
         { provide: ToasterService, useValue: mockToasterService },
+        { provide: ProgressService, useValue: mockProgressService },
         { provide: ChangeDetectorRef, useValue: mockChangeDetectorRef },
       ],
     }).compileComponents();

--- a/src/app/components/project-map/context-menu/actions/stop-node-action/stop-node-action.component.ts
+++ b/src/app/components/project-map/context-menu/actions/stop-node-action/stop-node-action.component.ts
@@ -6,6 +6,7 @@ import { Node } from '../../../../../cartography/models/node';
 import { Controller } from '@models/controller';
 import { NodeService } from '@services/node.service';
 import { ToasterService } from '@services/toaster.service';
+import { ProgressService } from '../../../../../common/progress/progress.service';
 
 @Component({
   selector: 'app-stop-node-action',
@@ -17,6 +18,7 @@ export class StopNodeActionComponent implements OnChanges {
   private nodeService = inject(NodeService);
   private toasterService = inject(ToasterService);
   private cdr = inject(ChangeDetectorRef);
+  private progressService = inject(ProgressService);
 
   readonly controller = input<Controller>(undefined);
   readonly nodes = input<Node[]>(undefined);
@@ -34,10 +36,17 @@ export class StopNodeActionComponent implements OnChanges {
   }
 
   stopNodes() {
+    this.progressService.activate();
+
     this.nodes().forEach((node) => {
       this.nodeService.stop(this.controller(), node).subscribe({
-        next: (n: Node) => {},
+        next: (n: Node) => {
+          if (this.nodes().indexOf(node) === this.nodes().length - 1) {
+            this.progressService.deactivate();
+          }
+        },
         error: (err) => {
+          this.progressService.deactivate();
           const message = err.error?.message || err.message || 'Failed to stop node';
           this.toasterService.error(message);
           this.cdr.markForCheck();

--- a/src/app/components/project-map/help-dialog/help-dialog.component.spec.ts
+++ b/src/app/components/project-map/help-dialog/help-dialog.component.spec.ts
@@ -15,6 +15,7 @@ describe('HelpDialogComponent', () => {
   ];
 
   beforeEach(async () => {
+    vi.clearAllMocks();
     mockDialogRef = { close: vi.fn() };
 
     await TestBed.configureTestingModule({
@@ -27,7 +28,9 @@ describe('HelpDialogComponent', () => {
   });
 
   afterEach(() => {
-    fixture.destroy();
+    if (fixture) {
+      fixture.destroy();
+    }
   });
 
   describe('title', () => {


### PR DESCRIPTION
## Summary
- Add loading indicator when starting Docker containers
- Add loading indicator when stopping Docker containers
- Provides visual feedback during operations that may take several seconds

## Changes
- Inject `ProgressService` into `start-node-action.component.ts`
- Inject `ProgressService` into `stop-node-action.component.ts`
- Call `progressService.activate()` before operations
- Call `progressService.deactivate()` after completion (success or error)

## Benefits
This improves UX by showing visual feedback when:
- Docker needs to pull images
- Containers need time to start services
- Containers need to gracefully shut down

Follows the existing pattern from `auto-idle-pc-action.component.ts`.

Related to gns3/gns3-server#2697