### PR TITLE
fix: correct extra_volumes type and improve Docker configuration UX

### DIFF
--- a/src/app/cartography/models/node.ts
+++ b/src/app/cartography/models/node.ts
@@ -96,7 +96,7 @@ export class Properties {
   console_resolution?: string;
   console_http_port?: number;
   console_http_path?: string;
-  extra_volumes?: string;
+  extra_volumes?: string[];
 }
 
 export class Node {

--- a/src/app/components/preferences/docker/add-docker-template/add-docker-template.component.html
+++ b/src/app/components/preferences/docker/add-docker-template/add-docker-template.component.html
@@ -161,6 +161,7 @@
                 type="text"
                 [value]="environment()"
                 (input)="environment.set($event.target.value)"
+                placeholder="KEY1=value1&#10;KEY2=value2"
               ></textarea>
             </mat-form-field>
           </div>

--- a/src/app/components/preferences/docker/add-docker-template/add-docker-template.component.html
+++ b/src/app/components/preferences/docker/add-docker-template/add-docker-template.component.html
@@ -166,6 +166,21 @@
             </mat-form-field>
           </div>
         </mat-step>
+
+        <mat-step label="Additional volumes">
+          <div class="docker-add__step-content">
+            <mat-form-field appearance="fill" class="docker-add__field">
+              <mat-label>Additional volumes</mat-label>
+              <textarea
+                matInput
+                type="text"
+                [value]="extraVolumes()"
+                (input)="extraVolumes.set($event.target.value)"
+                placeholder="/data&#10;/config&#10;/logs"
+              ></textarea>
+            </mat-form-field>
+          </div>
+        </mat-step>
       </mat-vertical-stepper>
     </section>
 

--- a/src/app/components/preferences/docker/add-docker-template/add-docker-template.component.ts
+++ b/src/app/components/preferences/docker/add-docker-template/add-docker-template.component.ts
@@ -72,6 +72,7 @@ export class AddDockerTemplateComponent implements OnInit {
   consoleType = model('');
   auxConsoleType = model('');
   environment = model('');
+  extraVolumes = model('');
 
   ngOnInit() {
     const controller_id = this.route.snapshot.paramMap.get('controller_id');
@@ -149,6 +150,9 @@ export class AddDockerTemplateComponent implements OnInit {
       this.dockerTemplate.console_type = this.consoleType() || 'none';
       this.dockerTemplate.aux_type = this.auxConsoleType() || 'none';
       this.dockerTemplate.environment = this.environment();
+      this.dockerTemplate.extra_volumes = this.extraVolumes()
+        ? this.extraVolumes().split('\n').filter((v: string) => v.trim() !== '')
+        : [];
 
       this.dockerService.addTemplate(this.controller, this.dockerTemplate).subscribe({
         next: (template: DockerTemplate) => {

--- a/src/app/components/preferences/docker/docker-template-details/docker-template-details.component.html
+++ b/src/app/components/preferences/docker/docker-template-details/docker-template-details.component.html
@@ -170,17 +170,6 @@
             placeholder="HTTP path"
           />
         </mat-form-field>
-        <h6 class="docker-details__section-subtitle">Environment</h6>
-        <mat-form-field appearance="fill" class="docker-details__field docker-details__field--full">
-          <mat-label>Environment</mat-label>
-          <textarea
-            matInput
-            [value]="environment()"
-            (input)="environment.set($event.target.value)"
-            type="text"
-            placeholder="KEY1=value1&#10;KEY2=value2"
-          ></textarea>
-        </mat-form-field>
       </form>
       }
     </section>
@@ -192,6 +181,17 @@
       </div>
       @if (advancedExpanded) {
       <div class="docker-details__form">
+        <h6 class="docker-details__section-subtitle">Environment</h6>
+        <mat-form-field appearance="fill" class="docker-details__field docker-details__field--full">
+          <mat-label>Environment</mat-label>
+          <textarea
+            matInput
+            [value]="environment()"
+            (input)="environment.set($event.target.value)"
+            type="text"
+            placeholder="KEY1=value1&#10;KEY2=value2"
+          ></textarea>
+        </mat-form-field>
         <h6 class="docker-details__section-subtitle">Extra hosts</h6>
         <mat-form-field appearance="fill" class="docker-details__field docker-details__field--full">
           <mat-label>Extra hosts</mat-label>

--- a/src/app/components/preferences/docker/docker-template-details/docker-template-details.component.html
+++ b/src/app/components/preferences/docker/docker-template-details/docker-template-details.component.html
@@ -203,6 +203,17 @@
             placeholder="myhost=192.168.1.10&#10;database=172.17.0.5"
           ></textarea>
         </mat-form-field>
+        <h6 class="docker-details__section-subtitle">Additional volumes</h6>
+        <mat-form-field appearance="fill" class="docker-details__field docker-details__field--full">
+          <mat-label>Additional volumes</mat-label>
+          <textarea
+            matInput
+            [value]="extraVolumes()"
+            (input)="extraVolumes.set($event.target.value)"
+            type="text"
+            placeholder="/data&#10;/config&#10;/logs"
+          ></textarea>
+        </mat-form-field>
       </div>
       }
     </section>

--- a/src/app/components/preferences/docker/docker-template-details/docker-template-details.component.html
+++ b/src/app/components/preferences/docker/docker-template-details/docker-template-details.component.html
@@ -178,6 +178,7 @@
             [value]="environment()"
             (input)="environment.set($event.target.value)"
             type="text"
+            placeholder="KEY1=value1&#10;KEY2=value2"
           ></textarea>
         </mat-form-field>
       </form>
@@ -199,6 +200,7 @@
             [value]="extraHosts()"
             (input)="extraHosts.set($event.target.value)"
             type="text"
+            placeholder="myhost=192.168.1.10&#10;database=172.17.0.5"
           ></textarea>
         </mat-form-field>
       </div>

--- a/src/app/components/preferences/docker/docker-template-details/docker-template-details.component.ts
+++ b/src/app/components/preferences/docker/docker-template-details/docker-template-details.component.ts
@@ -84,6 +84,7 @@ export class DockerTemplateDetailsComponent implements OnInit {
   consoleHttpPath = model('');
   environment = model('');
   extraHosts = model('');
+  extraVolumes = model('');
   usage = model('');
 
   constructor() {}
@@ -117,6 +118,7 @@ export class DockerTemplateDetailsComponent implements OnInit {
             this.consoleHttpPath.set(dockerTemplate.console_http_path || '');
             this.environment.set(dockerTemplate.environment || '');
             this.extraHosts.set(dockerTemplate.extra_hosts || '');
+            this.extraVolumes.set((dockerTemplate.extra_volumes || []).join('\n'));
             this.usage.set(dockerTemplate.usage || '');
             this.cd.markForCheck();
           },
@@ -178,6 +180,9 @@ export class DockerTemplateDetailsComponent implements OnInit {
     this.dockerTemplate.console_http_path = this.consoleHttpPath();
     this.dockerTemplate.environment = this.environment();
     this.dockerTemplate.extra_hosts = this.extraHosts();
+    this.dockerTemplate.extra_volumes = this.extraVolumes()
+      ? this.extraVolumes().split('\n').filter((v: string) => v.trim() !== '')
+      : [];
     this.dockerTemplate.usage = this.usage();
 
     this.dockerService.saveTemplate(this.controller, this.dockerTemplate).subscribe({

--- a/src/app/components/project-map/node-editors/configurator/docker/configurator-docker.component.html
+++ b/src/app/components/project-map/node-editors/configurator/docker/configurator-docker.component.html
@@ -122,13 +122,13 @@
               <h6>Extra hosts</h6>
               <mat-form-field class="form-field">
                 <mat-label>Extra hosts</mat-label>
-                <textarea matInput formControlName="extra_hosts"></textarea>
+                <textarea matInput formControlName="extra_hosts" placeholder="myhost=192.168.1.10&#10;database=172.17.0.5"></textarea>
               </mat-form-field>
 
               <h6>Additional volumes</h6>
               <mat-form-field class="form-field">
                 <mat-label>Additional volumes</mat-label>
-                <textarea matInput formControlName="extra_volumes"></textarea>
+                <textarea matInput formControlName="extra_volumes" placeholder="/data&#10;/config&#10;/logs"></textarea>
               </mat-form-field>
             </form>
           </mat-tab>

--- a/src/app/components/project-map/node-editors/configurator/docker/configurator-docker.component.spec.ts
+++ b/src/app/components/project-map/node-editors/configurator/docker/configurator-docker.component.spec.ts
@@ -92,7 +92,7 @@ describe('ConfiguratorDialogDockerComponent', () => {
     console_resolution: '',
     console_http_port: 0,
     console_http_path: '',
-    extra_volumes: '',
+    extra_volumes: [],
   });
 
   const mockController = { id: 1 } as unknown as Controller;
@@ -350,7 +350,7 @@ describe('ConfiguratorDialogDockerComponent', () => {
       expect(component.node.properties.console_http_port).toBe('8080');
       expect(component.node.properties.console_http_path).toBe('/');
       expect(component.node.properties.extra_hosts).toBe('host1.local');
-      expect(component.node.properties.extra_volumes).toBe('/data:/data');
+      expect(component.node.properties.extra_volumes).toEqual(['/data:/data']);
       expect(component.node.properties.usage).toBe('Test usage');
     });
 

--- a/src/app/components/project-map/node-editors/configurator/docker/configurator-docker.component.ts
+++ b/src/app/components/project-map/node-editors/configurator/docker/configurator-docker.component.ts
@@ -129,7 +129,7 @@ export class ConfiguratorDialogDockerComponent implements OnInit {
           consoleHttpPath: node.properties.console_http_path || '',
           environment: node.properties.environment || '',
           extra_hosts: node.properties.extra_hosts || '',
-          extra_volumes: node.properties.extra_volumes || '',
+          extra_volumes: (node.properties.extra_volumes || []).join('\n'),
           usage: node.properties.usage || '',
         });
 
@@ -186,7 +186,9 @@ export class ConfiguratorDialogDockerComponent implements OnInit {
       this.node.properties.console_http_path = formValues.consoleHttpPath;
       this.node.properties.environment = formValues.environment;
       this.node.properties.extra_hosts = formValues.extra_hosts;
-      this.node.properties.extra_volumes = formValues.extra_volumes;
+      this.node.properties.extra_volumes = formValues.extra_volumes
+        ? formValues.extra_volumes.split('\n').filter((v: string) => v.trim() !== '')
+        : [];
       this.node.properties.usage = formValues.usage;
 
       this.nodeService.updateNode(this.controller, this.node).subscribe({

--- a/src/app/components/project-map/node-editors/configurator/qemu/configurator-qemu.component.spec.ts
+++ b/src/app/components/project-map/node-editors/configurator/qemu/configurator-qemu.component.spec.ts
@@ -110,7 +110,7 @@ describe('ConfiguratorDialogQemuComponent', () => {
     console_resolution: '',
     console_http_port: 0,
     console_http_path: '',
-    extra_volumes: '',
+    extra_volumes: [],
   });
 
   const createMockNode = (): Node =>

--- a/src/app/models/templates/docker-template.ts
+++ b/src/app/models/templates/docker-template.ts
@@ -16,6 +16,7 @@ export class DockerTemplate {
   default_name_format: string;
   environment: string;
   extra_hosts: string;
+  extra_volumes: string[];
   image: string;
   name: string;
   start_command: string;

--- a/src/app/services/template-mocks.service.ts
+++ b/src/app/services/template-mocks.service.ts
@@ -254,6 +254,7 @@ export class TemplateMocksService {
       default_name_format: '{name}-{0}',
       environment: '',
       extra_hosts: '',
+      extra_volumes: [],
       image: '',
       name: '',
       start_command: '',


### PR DESCRIPTION
## Summary
- Fix type mismatch for `extra_volumes` property (string → string[])
- Add helpful placeholder examples for Docker configuration fields
- Reorganize Docker template layout to match node configurator

## Changes

### Bug Fix
- **extra_volumes type error**: Fixed 422 error "Input should be a valid list" when updating Docker nodes with `extra_volumes` configured
  - Changed `Properties.extra_volumes` type from `string` to `string[]` to match backend API expectations
  - Added array↔string conversion in node configurator (join for display, split on save)

### UI/UX Improvements
- **Placeholder examples**: Added format hints for all Docker configuration fields:
  - Environment variables: `KEY1=value1` (one per line)
  - Extra hosts: `hostname=IP.address` (one per line)  
  - Additional volumes: `/path` (one per line)
  
- **Template reorganization**: Moved Environment from General settings to Advanced section in Docker template details, maintaining consistency with node configurator layout

### Test Updates
- Fixed type assertions in Docker and QEMU configurator tests
- Updated mock data to use `string[]` for `extra_volumes`