### PR TITLE
fix: prevent single 403 from cancelling other pending batch delete requests

### DIFF
--- a/src/app/components/projects/confirmation-delete-all-projects/confirmation-delete-all-projects.component.html
+++ b/src/app/components/projects/confirmation-delete-all-projects/confirmation-delete-all-projects.component.html
@@ -18,18 +18,22 @@
 </div>
 } @if (isDelete() && isUsedFiles()) {
 <div mat-dialog-content>
-  @if (deleteFliesDetails().length > 0) {
-  <h5>Project can't be deleted because image used in one or more template.</h5>
-  @for (message of deleteFliesDetails(); track $index; let i = $index) {
-  <p [ngClass]="{ 'deleted-error-text': message?.error?.message }">
-    @if (message !== null) {<span>{{ i + 1 }}. {{ message?.error?.message }}</span
-    >}
+  @if (successfulDeletions().length > 0) {
+  <h2 mat-dialog-title>✓ {{ successfulDeletions().length }} {{ successfulDeletions().length === 1 ? 'Project' : 'Projects' }} deleted successfully</h2>
+  @for (project of successfulDeletions(); track project; let i = $index) {
+  <p>{{ i + 1 }}. {{ project?.filename || project?.project_id }}</p>
+  } }
+
+  @if (failedDeletions().length > 0) {
+  <h2 mat-dialog-title class="mat-error">✗ {{ failedDeletions().length }} {{ failedDeletions().length === 1 ? 'Project' : 'Projects' }} failed to delete</h2>
+  @for (failure of failedDeletions(); track $index; let i = $index) {
+  <p>
+    {{ i + 1 }}. <strong>{{ failure.project?.filename || failure.project?.project_id }}</strong><br>
+    <span class="mat-error">{{ failure.error?.error?.message || failure.error?.message || 'Unknown error' }}</span>
   </p>
-  } } @if (fileNotDeleted().length > 0) {
-  <h5 class="delete-text">{{ fileNotDeleted().length }} Projects deleted successfully.</h5>
-  }
+  } }
 </div>
 <div mat-dialog-actions align="end">
-  <button mat-raised-button color="primary" (click)="dialogRef.close(false)">Close</button>
+  <button mat-raised-button color="primary" (click)="dialogRef.close(successfulDeletions().length > 0)">Close</button>
 </div>
 }

--- a/src/app/components/projects/confirmation-delete-all-projects/confirmation-delete-all-projects.component.spec.ts
+++ b/src/app/components/projects/confirmation-delete-all-projects/confirmation-delete-all-projects.component.spec.ts
@@ -94,25 +94,46 @@ describe('ConfirmationDeleteAllProjectsComponent', () => {
       expect(mockProjectService.delete).toHaveBeenCalledWith('test-controller', 'project-2');
     });
 
-    it('should set isUsedFiles to true after deletions complete', () => {
+    it('should set isUsedFiles to true after successful deletions (null = 204 No Content)', () => {
       mockProjectService.delete.mockReturnValue(of(null));
 
       fixture.componentInstance.deleteFile();
       fixture.detectChanges();
 
       expect(fixture.componentInstance.isUsedFiles()).toBeTruthy();
-      expect(fixture.componentInstance.fileNotDeleted()).toEqual([null, null]);
+      // null response means successful deletion (204 No Content)
+      expect(fixture.componentInstance.deleteFliesDetails().length).toBe(2);
+      expect(fixture.componentInstance.fileNotDeleted().length).toBe(0);
     });
 
-    it('should set deleteFliesDetails when some deletions fail', () => {
+    it('should set fileNotDeleted when some deletions fail (non-null response)', () => {
       const errorResponse = { error: { message: 'File in use' } };
       mockProjectService.delete.mockReturnValue(of(errorResponse));
 
       fixture.componentInstance.deleteFile();
       fixture.detectChanges();
 
-      expect(fixture.componentInstance.deleteFliesDetails().length).toBe(2);
+      // Non-null response indicates potential error
+      expect(fixture.componentInstance.fileNotDeleted().length).toBe(2);
+      expect(fixture.componentInstance.deleteFliesDetails().length).toBe(0);
       expect(fixture.componentInstance.isUsedFiles()).toBeTruthy();
+    });
+
+    it('should correctly handle mixed success and failure deletions', () => {
+      let callCount = 0;
+      mockProjectService.delete.mockImplementation(() => {
+        callCount++;
+        // First call succeeds (null), second fails (error response)
+        return callCount === 1 ? of(null) : of({ error: { message: 'File in use' } });
+      });
+
+      fixture.componentInstance.deleteFile();
+      fixture.detectChanges();
+
+      expect(fixture.componentInstance.deleteFliesDetails().length).toBe(1);
+      expect(fixture.componentInstance.fileNotDeleted().length).toBe(1);
+      expect(fixture.componentInstance.deleteFliesDetails()[0]).toEqual(mockDialogData.deleteFilesPaths[0]);
+      expect(fixture.componentInstance.fileNotDeleted()[0].project).toEqual(mockDialogData.deleteFilesPaths[1]);
     });
   });
 

--- a/src/app/components/projects/confirmation-delete-all-projects/confirmation-delete-all-projects.component.spec.ts
+++ b/src/app/components/projects/confirmation-delete-all-projects/confirmation-delete-all-projects.component.spec.ts
@@ -102,38 +102,41 @@ describe('ConfirmationDeleteAllProjectsComponent', () => {
 
       expect(fixture.componentInstance.isUsedFiles()).toBeTruthy();
       // null response means successful deletion (204 No Content)
-      expect(fixture.componentInstance.deleteFliesDetails().length).toBe(2);
-      expect(fixture.componentInstance.fileNotDeleted().length).toBe(0);
+      expect(fixture.componentInstance.successfulDeletions().length).toBe(2);
+      expect(fixture.componentInstance.failedDeletions().length).toBe(0);
     });
 
-    it('should set fileNotDeleted when some deletions fail (non-null response)', () => {
-      const errorResponse = { error: { message: 'File in use' } };
-      mockProjectService.delete.mockReturnValue(of(errorResponse));
+    it('should set failedDeletions when HTTP errors occur', () => {
+      const httpError = { status: 403, error: { message: 'Forbidden' } };
+      mockProjectService.delete.mockReturnValue(throwError(() => httpError));
 
       fixture.componentInstance.deleteFile();
       fixture.detectChanges();
 
-      // Non-null response indicates potential error
-      expect(fixture.componentInstance.fileNotDeleted().length).toBe(2);
-      expect(fixture.componentInstance.deleteFliesDetails().length).toBe(0);
+      // HTTP errors are caught and added to failedDeletions
+      expect(fixture.componentInstance.failedDeletions().length).toBe(2);
+      expect(fixture.componentInstance.successfulDeletions().length).toBe(0);
       expect(fixture.componentInstance.isUsedFiles()).toBeTruthy();
     });
 
-    it('should correctly handle mixed success and failure deletions', () => {
+    it('should correctly handle mixed success and failure deletions independently', () => {
       let callCount = 0;
       mockProjectService.delete.mockImplementation(() => {
         callCount++;
-        // First call succeeds (null), second fails (error response)
-        return callCount === 1 ? of(null) : of({ error: { message: 'File in use' } });
+        // First call succeeds (null), second fails with HTTP error
+        return callCount === 1
+          ? of(null)
+          : throwError(() => ({ status: 403, error: { message: 'Forbidden' } }));
       });
 
       fixture.componentInstance.deleteFile();
       fixture.detectChanges();
 
-      expect(fixture.componentInstance.deleteFliesDetails().length).toBe(1);
-      expect(fixture.componentInstance.fileNotDeleted().length).toBe(1);
-      expect(fixture.componentInstance.deleteFliesDetails()[0]).toEqual(mockDialogData.deleteFilesPaths[0]);
-      expect(fixture.componentInstance.fileNotDeleted()[0].project).toEqual(mockDialogData.deleteFilesPaths[1]);
+      // Each request is handled independently
+      expect(fixture.componentInstance.successfulDeletions().length).toBe(1);
+      expect(fixture.componentInstance.failedDeletions().length).toBe(1);
+      expect(fixture.componentInstance.successfulDeletions()[0]).toEqual(mockDialogData.deleteFilesPaths[0]);
+      expect(fixture.componentInstance.failedDeletions()[0].project).toEqual(mockDialogData.deleteFilesPaths[1]);
     });
   });
 
@@ -142,29 +145,20 @@ describe('ConfirmationDeleteAllProjectsComponent', () => {
       vi.clearAllMocks();
     });
 
-    it('should show error toaster when deleteFile fails with error.message', async () => {
+    it('should handle HTTP errors gracefully without throwing', async () => {
       mockProjectService.delete.mockReturnValue(
         throwError(() => ({ error: { message: 'Delete failed' } }))
       );
 
       fixture.componentInstance.deleteFile();
       fixture.detectChanges();
-      await vi.runAllTimersAsync();
 
-      expect(mockToasterService.error).toHaveBeenCalledWith('Delete failed');
+      // Errors are caught per-request, forkJoin doesn't fail
+      expect(mockToasterService.error).not.toHaveBeenCalled();
+      expect(fixture.componentInstance.isUsedFiles()).toBeTruthy();
     });
 
-    it('should use fallback message when deleteFile error has no message', async () => {
-      mockProjectService.delete.mockReturnValue(throwError(() => ({})));
-
-      fixture.componentInstance.deleteFile();
-      fixture.detectChanges();
-      await vi.runAllTimersAsync();
-
-      expect(mockToasterService.error).toHaveBeenCalledWith('Failed to delete projects');
-    });
-
-    it('should call markForCheck when deleteFile fails', async () => {
+    it('should call markForCheck when handling errors', async () => {
       mockProjectService.delete.mockReturnValue(
         throwError(() => ({ error: { message: 'Delete failed' } }))
       );
@@ -172,7 +166,6 @@ describe('ConfirmationDeleteAllProjectsComponent', () => {
       const cdrSpy = vi.spyOn(fixture.componentInstance['cd'], 'markForCheck');
       fixture.componentInstance.deleteFile();
       fixture.detectChanges();
-      await vi.runAllTimersAsync();
 
       expect(cdrSpy).toHaveBeenCalled();
     });

--- a/src/app/components/projects/confirmation-delete-all-projects/confirmation-delete-all-projects.component.ts
+++ b/src/app/components/projects/confirmation-delete-all-projects/confirmation-delete-all-projects.component.ts
@@ -5,7 +5,8 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { ProjectService } from '@services/project.service';
 import { ToasterService } from '@services/toaster.service';
-import { forkJoin } from 'rxjs';
+import { forkJoin, of, throwError } from 'rxjs';
+import { catchError } from 'rxjs/operators';
 
 @Component({
   selector: 'app-confirmation-delete-all-projects',
@@ -33,25 +34,34 @@ export class ConfirmationDeleteAllProjectsComponent {
   }
 
   deleteFile() {
-    const calls = [];
-    this.deleteData.deleteFilesPaths.forEach((project) => {
-      calls.push(
-        this.projectService.delete(this.deleteData.controller, project.project_id)
+    // Wrap each request to handle errors independently
+    // This prevents a single 403 from cancelling other pending requests
+    const calls = this.deleteData.deleteFilesPaths.map((project, index) => {
+      return this.projectService.delete(this.deleteData.controller, project.project_id).pipe(
+        catchError((error) => {
+          // Return error info instead of throwing, so forkJoin doesn't fail
+          return of({ error: true, data: error, projectIndex: index });
+        })
       );
     });
+
     forkJoin(calls).subscribe({
-      next: (responses) => {
-        // For HTTP DELETE with 204 No Content, Angular HttpClient returns null
-        // null = successful deletion, non-null = potential error response
+      next: (responses: any[]) => {
         const successfulDeletions: any[] = [];
         const failedDeletions: any[] = [];
 
         responses.forEach((response, index) => {
-          if (response === null || response === undefined) {
+          if (response && (response as any).error === true) {
+            // Request failed with HTTP error (403, 404, etc.)
+            failedDeletions.push({
+              project: this.deleteData.deleteFilesPaths[index],
+              error: (response as any).data
+            });
+          } else if (response === null || response === undefined) {
             // 204 No Content - successful deletion
             successfulDeletions.push(this.deleteData.deleteFilesPaths[index]);
           } else {
-            // Non-null response - may indicate an error
+            // Non-null response - treat as potential error
             failedDeletions.push({
               project: this.deleteData.deleteFilesPaths[index],
               error: response
@@ -66,6 +76,7 @@ export class ConfirmationDeleteAllProjectsComponent {
         this.cd.markForCheck();
       },
       error: (err) => {
+        // This should rarely be reached since we handle errors per-request
         const message = err.error?.message || err.message || 'Failed to delete projects';
         this.toasterService.error(message);
         this.cd.markForCheck();

--- a/src/app/components/projects/confirmation-delete-all-projects/confirmation-delete-all-projects.component.ts
+++ b/src/app/components/projects/confirmation-delete-all-projects/confirmation-delete-all-projects.component.ts
@@ -23,8 +23,8 @@ export class ConfirmationDeleteAllProjectsComponent {
 
   isDelete = signal(false);
   isUsedFiles = signal(false);
-  deleteFliesDetails = signal<any[]>([]);
-  fileNotDeleted = signal<any[]>([]);
+  successfulDeletions = signal<any[]>([]);
+  failedDeletions = signal<any[]>([]);
 
   constructor(@Inject(MAT_DIALOG_DATA) public deleteData: any) {}
 
@@ -47,30 +47,30 @@ export class ConfirmationDeleteAllProjectsComponent {
 
     forkJoin(calls).subscribe({
       next: (responses: any[]) => {
-        const successfulDeletions: any[] = [];
-        const failedDeletions: any[] = [];
+        const successful: any[] = [];
+        const failed: any[] = [];
 
         responses.forEach((response, index) => {
           if (response && (response as any).error === true) {
             // Request failed with HTTP error (403, 404, etc.)
-            failedDeletions.push({
+            failed.push({
               project: this.deleteData.deleteFilesPaths[index],
               error: (response as any).data
             });
           } else if (response === null || response === undefined) {
             // 204 No Content - successful deletion
-            successfulDeletions.push(this.deleteData.deleteFilesPaths[index]);
+            successful.push(this.deleteData.deleteFilesPaths[index]);
           } else {
             // Non-null response - treat as potential error
-            failedDeletions.push({
+            failed.push({
               project: this.deleteData.deleteFilesPaths[index],
               error: response
             });
           }
         });
 
-        this.deleteFliesDetails.set(successfulDeletions);
-        this.fileNotDeleted.set(failedDeletions);
+        this.successfulDeletions.set(successful);
+        this.failedDeletions.set(failed);
         this.isUsedFiles.set(true);
         this.isDelete.set(true);
         this.cd.markForCheck();

--- a/src/app/components/projects/confirmation-delete-all-projects/confirmation-delete-all-projects.component.ts
+++ b/src/app/components/projects/confirmation-delete-all-projects/confirmation-delete-all-projects.component.ts
@@ -41,8 +41,26 @@ export class ConfirmationDeleteAllProjectsComponent {
     });
     forkJoin(calls).subscribe({
       next: (responses) => {
-        this.deleteFliesDetails.set(responses.filter((x) => x !== null));
-        this.fileNotDeleted.set(responses.filter((x) => x === null));
+        // For HTTP DELETE with 204 No Content, Angular HttpClient returns null
+        // null = successful deletion, non-null = potential error response
+        const successfulDeletions: any[] = [];
+        const failedDeletions: any[] = [];
+
+        responses.forEach((response, index) => {
+          if (response === null || response === undefined) {
+            // 204 No Content - successful deletion
+            successfulDeletions.push(this.deleteData.deleteFilesPaths[index]);
+          } else {
+            // Non-null response - may indicate an error
+            failedDeletions.push({
+              project: this.deleteData.deleteFilesPaths[index],
+              error: response
+            });
+          }
+        });
+
+        this.deleteFliesDetails.set(successfulDeletions);
+        this.fileNotDeleted.set(failedDeletions);
         this.isUsedFiles.set(true);
         this.isDelete.set(true);
         this.cd.markForCheck();


### PR DESCRIPTION
## Problem

When deleting multiple projects simultaneously, if one project returns a 403 Forbidden error (e.g., remote compute node), the browser immediately closes TCP connections for other pending requests, causing successful deletions (204 No Content) to never reach the client.

### Timeline of the Bug
```
10:07:42.320  Browser sends DELETE for project-1 (remote) and project-2 (local)
10:07:42.330  Server returns 403 Forbidden for project-1
10:07:42.335  Browser closes TCP connection for project-2 (5ms after 403!)
10:07:42.445  Server sends 204 for project-2, but connection already closed
```

### Root Cause

`forkJoin` cancels all pending requests when one fails. This behavior, combined with how Angular HttpClient handles errors, causes the browser to abort other in-flight HTTP requests.

## Solution

Wrap each DELETE request with `catchError` to handle errors independently. This prevents a single failure from cancelling other pending requests.

### Changes

1. **Add per-request error handling**: Each delete request is wrapped with `catchError` that returns error info instead of throwing
2. **Fix 204 No Content handling**: Correctly identify `null` response as successful deletion (HTTP 204)
3. **Improve result messages**: Display successful and failed deletions separately with clear counts
4. **Rename variables**: Use clear naming (`successfulDeletions`, `failedDeletions`)

## Result

- ✅ HTTP errors (403, 404) no longer cancel other pending requests
- ✅ All requests complete independently
- ✅ Clear success/failure UI: "✓ 1 Project deleted successfully" + "✗ 1 Project failed to delete"

## Related

- Mentioned in gns3/gns3-server#2706