### PR TITLE
feat(ai-profile): remove deepseek-chat model from DeepSeek preset

### DIFF
--- a/src/app/components/user-management/user-detail/ai-profile-tab/ai-profile-dialog/ai-profile-dialog.component.ts
+++ b/src/app/components/user-management/user-detail/ai-profile-tab/ai-profile-dialog/ai-profile-dialog.component.ts
@@ -87,10 +87,9 @@ export const PROVIDER_PRESETS: ProviderPreset[] = [
     label: 'DeepSeek',
     provider: 'deepseek',
     baseUrl: 'https://api.deepseek.com/v1',
-    models: ['deepseek-chat', 'deepseek-v4-flash', 'deepseek-v4-pro'],
+    models: ['deepseek-v4-flash', 'deepseek-v4-pro'],
     defaultTemperature: 0.3,
     modelContextLimits: {
-      'deepseek-chat': 1000,
       'deepseek-v4-flash': 1000,
       'deepseek-v4-pro': 1000,
     },

--- a/src/app/components/user-management/user-detail/ai-profile-tab/ai-profile-dialog/model-type-help-dialog/model-type-help-dialog.component.html
+++ b/src/app/components/user-management/user-detail/ai-profile-tab/ai-profile-dialog/model-type-help-dialog/model-type-help-dialog.component.html
@@ -52,7 +52,7 @@
       </ul>
       <p>
         <strong>Examples:</strong> <code>gpt-4o</code>, <code>claude-3-5-sonnet-20241022</code>,
-        <code>deepseek-chat</code>
+        <code>deepseek-v4-pro</code>
       </p>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- Remove `deepseek-chat` model from the DeepSeek provider preset configuration
- Update help dialog example to use `deepseek-v4-pro` instead

## Changes
- **ai-profile-dialog.component.ts**: Remove `deepseek-chat` from DeepSeek preset's `models` array and `modelContextLimits` configuration
- **model-type-help-dialog.component.html**: Update example from `deepseek-chat` to `deepseek-v4-pro`

## Related
Relates to gns3/gns3-server#2723

## Motivation
Aligns with the latest DeepSeek API configuration where `deepseek-chat` is no longer recommended. The preset now focuses on the newer `deepseek-v4-flash` and `deepseek-v4-pro` models.