### PR TITLE
fix(ios-router): display network adapters for platforms without chassis options

### DIFF
--- a/src/app/components/preferences/dynamips/add-ios-template/add-ios-template.component.html
+++ b/src/app/components/preferences/dynamips/add-ios-template/add-ios-template.component.html
@@ -135,10 +135,10 @@
 
         <mat-step label="Network adapters">
           <div class="ios-add__step-content">
-            @if (platform() && chassis() && adapterMatrix()[platform()] && adapterMatrix()[platform()][chassis()]) {
+            @if (platform() && adapterMatrix()[platform()] && adapterMatrix()[platform()][chassis() || '']) {
             <div class="ios-add__adapters">
               @for (index of [0, 1, 2, 3, 4, 5, 6]; track index) {
-              @if (adapterMatrix()[platform()][chassis()][index]) {
+              @if (adapterMatrix()[platform()][chassis() || ''][index]) {
               <mat-form-field appearance="fill" class="ios-add__field">
                 <mat-label>Slot {{ index }}</mat-label>
                 <mat-select
@@ -146,11 +146,11 @@
                   [value]="networkAdaptersForTemplate()[index] || ''"
                   (selectionChange)="onAdapterChange(index, $event.value)"
                 >
-                  @if (adapterMatrix()[platform()][chassis()][index].length > 1 &&
-                  !adapterMatrix()[platform()][chassis()][index][0].startsWith('C7200')) {
+                  @if (adapterMatrix()[platform()][chassis() || ''][index].length > 1 &&
+                  !adapterMatrix()[platform()][chassis() || ''][index][0].startsWith('C7200')) {
                   <mat-option [value]=""></mat-option>
                   }
-                  @for (option of adapterMatrix()[platform()][chassis()][index]; track option) {
+                  @for (option of adapterMatrix()[platform()][chassis() || ''][index]; track option) {
                   <mat-option [value]="option">
                     {{ option }}
                   </mat-option>


### PR DESCRIPTION
## Summary
- Fixed issue where the "Network adapters" section was empty for platforms without chassis options (c7200, c2691, c3725, c3745)
- Updated template condition to properly handle empty string as valid matrix lookup key

## Root Cause
The template condition checked `chassis()` which is falsy when set to empty string for platforms without chassis options. However, `adapterMatrix` uses `''` as a valid lookup key for these platforms.

## Solution
Changed all `adapterMatrix()[platform()][chassis()]` references to `adapterMatrix()[platform()][chassis() || '']` to handle both cases:
- **Platforms with chassis** (c1700, c2600, c3600): uses the selected chassis value
- **Platforms without chassis** (c7200, c2691, c3725, c3745): uses empty string as matrix key

This aligns with the existing `fillDefaultSlots()` logic which already handles this correctly.

## Fixes
Fixes #1684