### PR TITLE
fix(docker): add environment placeholder hint in add-docker-template

### DIFF
--- a/src/app/components/preferences/docker/add-docker-template/add-docker-template.component.html
+++ b/src/app/components/preferences/docker/add-docker-template/add-docker-template.component.html
@@ -161,6 +161,7 @@
                 type="text"
                 [value]="environment()"
                 (input)="environment.set($event.target.value)"
+                placeholder="Environment variables (one per line, KEY=VALUE format). Supports: %vm-name%, %vm-id%, %project-id%, %project-path%"
               ></textarea>
             </mat-form-field>
           </div>


### PR DESCRIPTION
## Summary
- Add placeholder attribute to Environment textarea in `add-docker-template.component.html`
- Guide users on expected format (KEY=VALUE, one per line) and supported template variables (%vm-name%, %vm-id%, %project-id%, %project-path%)
- Improve consistency with existing implementations in `docker-template-details` and `configurator-docker`

Fixes #1686