### PR TITLE
fix: add loading state to Update from online registry button

### DIFF
--- a/src/app/components/project-map/new-template-dialog/new-template-dialog.component.html
+++ b/src/app/components/project-map/new-template-dialog/new-template-dialog.component.html
@@ -143,7 +143,14 @@
     <mat-dialog-actions class="new-template__actions">
       <button mat-button matStepperPrevious>Back</button>
       @if (action === 'install') {
-      <button mat-button (click)="updateAppliances()">Update from online registry</button>
+      <button mat-button class="new-template__update-button" (click)="updateAppliances()" [disabled]="isUpdatingAppliances">
+        @if (isUpdatingAppliances) {
+        <mat-spinner diameter="20"></mat-spinner>
+        <span>Updating...</span>
+        } @else {
+        <span>Update from online registry</span>
+        }
+      </button>
       }
       <button mat-button (click)="onCloseClick()">Cancel</button>
     </mat-dialog-actions>

--- a/src/app/components/project-map/new-template-dialog/new-template-dialog.component.scss
+++ b/src/app/components/project-map/new-template-dialog/new-template-dialog.component.scss
@@ -430,6 +430,18 @@
     padding: 4px 8px;
     font-size: 12px;
   }
+
+  &__update-button {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 200px;
+    justify-content: center;
+
+    mat-spinner {
+      display: inline-block;
+    }
+  }
 }
 
 // Progress spinner animation

--- a/src/app/components/project-map/new-template-dialog/new-template-dialog.component.ts
+++ b/src/app/components/project-map/new-template-dialog/new-template-dialog.component.ts
@@ -141,6 +141,7 @@ export class NewTemplateDialogComponent implements OnInit, AfterViewInit {
   uploadProgress: number = 0;
   uploadingImageName: string = '';
   isUploading: boolean = false;
+  isUpdatingAppliances: boolean = false;
 
   readonly paginator = viewChild(MatPaginator);
   readonly stepper = viewChild<MatStepper>('stepper');
@@ -363,17 +364,20 @@ export class NewTemplateDialogComponent implements OnInit, AfterViewInit {
   }
 
   updateAppliances() {
+    this.isUpdatingAppliances = true;
     this.progressService.activate();
     this.applianceService.updateAppliances(this.controller).subscribe({
       next: (appliances) => {
         this.appliances = appliances;
         this.progressService.deactivate();
+        this.isUpdatingAppliances = false;
         this.toasterService.success('Appliances are up-to-date.');
         this.changeDetectorRef.markForCheck();
       },
       error: (err) => {
         const message = err.error?.message || err.message || 'Failed to update appliances';
         this.progressService.deactivate();
+        this.isUpdatingAppliances = false;
         this.toasterService.error(message);
         this.changeDetectorRef.markForCheck();
       },


### PR DESCRIPTION
## Summary
- Added visual loading feedback (spinner + "Updating..." text) to the "Update from online registry" button
- Button is disabled during the update operation to prevent duplicate clicks
- Users now have clear visual feedback when the API request is in progress

## Changes
- Added `isUpdatingAppliances` boolean flag to track loading state
- Modified `updateAppliances()` method to set/clear loading state
- Updated button template to show spinner and updating text when loading
- Added CSS styles for the update button layout