### PR TITLE
feature: add font size control to text editor

### DIFF
--- a/src/app/components/project-map/drawings-editors/text-editor/text-editor.component.html
+++ b/src/app/components/project-map/drawings-editors/text-editor/text-editor.component.html
@@ -6,6 +6,11 @@
     <input matInput type="color" [value]="element.fill" (input)="changeTextColor($event.target.value)" />
   </mat-form-field>
 
+  <mat-form-field class="form-field">
+    <mat-label>Font size</mat-label>
+    <input matInput type="number" [value]="element.font_size" (input)="changeFontSize($event.target.value)" min="1" max="200" step="0.5" />
+  </mat-form-field>
+
   <form [formGroup]="formGroup">
     <mat-form-field class="form-field">
       <mat-label>Rotation</mat-label>

--- a/src/app/components/project-map/drawings-editors/text-editor/text-editor.component.ts
+++ b/src/app/components/project-map/drawings-editors/text-editor/text-editor.component.ts
@@ -232,6 +232,15 @@ export class TextEditorDialogComponent implements OnInit {
     this.cdr.markForCheck();
   }
 
+  changeFontSize(value: string) {
+    const fontSize = parseFloat(value);
+    if (!isNaN(fontSize) && fontSize > 0) {
+      this.element.font_size = fontSize;
+      this.renderer.setStyle(this.textArea().nativeElement, 'font-size', `${fontSize}pt`);
+      this.cdr.markForCheck();
+    }
+  }
+
   onTextChange(value: string) {
     this.element.text = value;
     this.cdr.markForCheck();


### PR DESCRIPTION
## Summary
- Added font size input field to the text editor dialog
- Users can now adjust font size for text drawings, node labels, and link labels
- Real-time preview of font size changes in the editor

## Changes
- Added number input field for font size control (range: 1-200pt, step: 0.5pt)
- Implemented changeFontSize() method to handle font size changes
- Updates both the element model and textarea preview in real-time