### PR TITLE
feat: Improve Edit Project dialog layout and readme editing experience

### DIFF
--- a/src/app/components/projects/edit-project-dialog/edit-project-dialog.component.html
+++ b/src/app/components/projects/edit-project-dialog/edit-project-dialog.component.html
@@ -1,35 +1,41 @@
 <h1 mat-dialog-title>Edit project</h1>
 
 <div class="modal-form-container">
-  <mat-tab-group>
+  <mat-tab-group (selectedTabChange)="onTabChange($event)">
     <mat-tab label="General">
       <form class="edit-project-form">
-        <mat-form-field appearance="fill" class="form-field">
-          <mat-label>Project name</mat-label>
-          <input matInput [value]="projectName()" (input)="projectName.set($event.target.value)" placeholder="My Project" type="text" />
-        </mat-form-field>
+        <!-- Two-column grid layout for form fields -->
+        <div class="form-grid">
+          <!-- Project name - full width -->
+          <mat-form-field appearance="fill" class="form-grid__full">
+            <mat-label>Project name</mat-label>
+            <input matInput [value]="projectName()" (input)="projectName.set($event.target.value)" placeholder="My Project" type="text" />
+          </mat-form-field>
 
-        <mat-form-field appearance="fill" class="form-field">
-          <mat-label>Scene width</mat-label>
-          <input matInput [value]="width()" (input)="width.set(+$event.target.value)" placeholder="1000" type="number" />
-          <span matTextSuffix>px</span>
-        </mat-form-field>
+          <!-- Scene dimensions - paired -->
+          <mat-form-field appearance="fill">
+            <mat-label>Scene width</mat-label>
+            <input matInput [value]="width()" (input)="width.set(+$event.target.value)" placeholder="1000" type="number" />
+            <span matTextSuffix>px</span>
+          </mat-form-field>
 
-        <mat-form-field appearance="fill" class="form-field">
-          <mat-label>Scene height</mat-label>
-          <input matInput [value]="height()" (input)="height.set(+$event.target.value)" placeholder="800" type="number" />
-          <span matTextSuffix>px</span>
-        </mat-form-field>
+          <mat-form-field appearance="fill">
+            <mat-label>Scene height</mat-label>
+            <input matInput [value]="height()" (input)="height.set(+$event.target.value)" placeholder="800" type="number" />
+            <span matTextSuffix>px</span>
+          </mat-form-field>
 
-        <mat-form-field appearance="fill" class="form-field">
-          <mat-label>Node grid size</mat-label>
-          <input matInput [value]="nodeGridSize()" (input)="nodeGridSize.set(+$event.target.value)" placeholder="25" type="number" />
-        </mat-form-field>
+          <!-- Grid sizes - paired -->
+          <mat-form-field appearance="fill">
+            <mat-label>Node grid size</mat-label>
+            <input matInput [value]="nodeGridSize()" (input)="nodeGridSize.set(+$event.target.value)" placeholder="25" type="number" />
+          </mat-form-field>
 
-        <mat-form-field appearance="fill" class="form-field">
-          <mat-label>Drawing grid size</mat-label>
-          <input matInput [value]="drawingGridSize()" (input)="drawingGridSize.set(+$event.target.value)" placeholder="25" type="number" />
-        </mat-form-field>
+          <mat-form-field appearance="fill">
+            <mat-label>Drawing grid size</mat-label>
+            <input matInput [value]="drawingGridSize()" (input)="drawingGridSize.set(+$event.target.value)" placeholder="25" type="number" />
+          </mat-form-field>
+        </div>
       </form>
 
       <mat-checkbox [checked]="auto_open()" (change)="auto_open.set($event.checked)">
@@ -51,7 +57,7 @@
 
     @if (controller && project) {
     <mat-tab label="Readme">
-      <app-readme-editor #editor [controller]="controller" [project]="project"></app-readme-editor>
+      <app-readme-editor #editor [controller]="controller" [project]="project" (isEditingChange)="onReadmeEditingChange($event)"></app-readme-editor>
     </mat-tab>
     }
 
@@ -103,6 +109,22 @@
 </div>
 
 <div mat-dialog-actions>
+  <!-- Default buttons (General and Global variables tabs) -->
+  @if (selectedTab() !== 1) {
   <button mat-button (click)="onNoClick()" color="accent">Cancel</button>
   <button mat-button (click)="onYesClick()" tabindex="2" mat-raised-button color="primary">Apply</button>
+  }
+
+  <!-- Readme tab buttons -->
+  @if (selectedTab() === 1) {
+  <!-- Editing mode (auto-save enabled, only Cancel button to revert) -->
+  @if (isReadmeEditing()) {
+  <button mat-button (click)="editor()?.cancelEdit()">Cancel</button>
+  } @else {
+  <!-- Preview mode -->
+  <button mat-button (click)="onNoClick()" color="accent">Cancel</button>
+  <button mat-button (click)="editor()?.enterEditMode()">Edit</button>
+  <button mat-button (click)="onYesClick()" tabindex="2" mat-raised-button color="primary">Apply</button>
+  }
+  }
 </div>

--- a/src/app/components/projects/edit-project-dialog/edit-project-dialog.component.scss
+++ b/src/app/components/projects/edit-project-dialog/edit-project-dialog.component.scss
@@ -2,5 +2,25 @@
  * GNS3 Edit Project Dialog Component Styles
  *
  * Main dialog styles are now in src/styles/_dialogs.scss
- * This file is kept for component-specific styles if needed
+ * This file contains component-specific styles for the General tab layout
  */
+
+/* =============================================
+// Two-column form grid layout
+// ============================================= */
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 12px 24px;
+  margin-bottom: 16px;
+
+  /* Full-width field in the grid */
+  &__full {
+    grid-column: 1 / -1;
+  }
+
+  /* Make form fields full width within their grid cells */
+  mat-form-field {
+    width: 100%;
+  }
+}

--- a/src/app/components/projects/edit-project-dialog/edit-project-dialog.component.ts
+++ b/src/app/components/projects/edit-project-dialog/edit-project-dialog.component.ts
@@ -78,6 +78,10 @@ export class EditProjectDialogComponent implements OnInit {
   readonly variableName = model('');
   readonly variableValue = model('');
 
+  // Readme editing state
+  readonly isReadmeEditing = signal(false);
+  readonly selectedTab = signal(0);
+
   // Form validity
   readonly isFormValid = computed(() => {
     return this.projectName().trim().length > 0 && +this.width() >= 0 && +this.height() >= 0 && +this.nodeGridSize() >= 0 && +this.drawingGridSize() >= 0;
@@ -100,6 +104,14 @@ export class EditProjectDialogComponent implements OnInit {
     this.auto_start.set(this.project.auto_start);
     this.auto_close.set(!this.project.auto_close);
     this.show_interface_labels.set(this.project.show_interface_labels);
+  }
+
+  onReadmeEditingChange(isEditing: boolean) {
+    this.isReadmeEditing.set(isEditing);
+  }
+
+  onTabChange(event: any) {
+    this.selectedTab.set(event.index);
   }
 
   addVariable(): void {

--- a/src/app/components/projects/edit-project-dialog/readme-editor/readme-editor.component.html
+++ b/src/app/components/projects/edit-project-dialog/readme-editor/readme-editor.component.html
@@ -1,19 +1,45 @@
-<mat-tab-group selectedIndex="1">
-  <mat-tab label="Edit">
-    <textarea
-      class="editorWrapper"
-      matInput
-      type="text"
-      [value]="markdown()"
-      (input)="markdown.set($event.target.value)"
-    ></textarea>
-  </mat-tab>
-
-  <mat-tab label="Preview">
+<!-- Preview mode -->
+@if (!isEditing()) {
+  <div class="readme-preview-container">
     @if (markdown()) {
     <div class="textWrapper markdown-body">
       <markdown [data]="markdown()"></markdown>
     </div>
+    } @else {
+    <div class="readme-empty-state">
+      <mat-icon class="readme-empty-icon">description</mat-icon>
+      <p class="readme-empty-text">No README content yet. Click Edit to add one.</p>
+    </div>
     }
-  </mat-tab>
-</mat-tab-group>
+  </div>
+}
+
+<!-- Edit mode -->
+@if (isEditing()) {
+  <div class="readme-edit-container">
+    <div class="editor-header">
+      <mat-label class="editor-label">Edit README (Markdown)</mat-label>
+      @if (saveStatus() !== 'idle') {
+      <div class="save-status" [class.save-status--saving]="saveStatus() === 'saving'" [class.save-status--saved]="saveStatus() === 'saved'" [class.save-status--error]="saveStatus() === 'error'">
+        @if (saveStatus() === 'saving') {
+        <mat-icon class="save-status-icon">sync</mat-icon>
+        <span>Saving...</span>
+        } @if (saveStatus() === 'saved') {
+        <mat-icon class="save-status-icon">check_circle</mat-icon>
+        <span>Saved</span>
+        } @if (saveStatus() === 'error') {
+        <mat-icon class="save-status-icon">error</mat-icon>
+        <span>Save failed</span>
+        }
+      </div>
+      }
+    </div>
+    <textarea
+      class="editorWrapper"
+      [value]="markdown()"
+      (input)="onMarkdownInput($event)"
+      placeholder="Write your project README in Markdown format..."
+    ></textarea>
+    <p class="editor-hint">Changes are auto-saved 2 seconds after you stop typing</p>
+  </div>
+}

--- a/src/app/components/projects/edit-project-dialog/readme-editor/readme-editor.component.scss
+++ b/src/app/components/projects/edit-project-dialog/readme-editor/readme-editor.component.scss
@@ -2,13 +2,151 @@
  * GNS3 Readme Editor Component Styles
  */
 
+/* =============================================
+// Preview container
+// ============================================= */
+.readme-preview-container {
+  margin-bottom: 16px;
+}
+
 .textWrapper {
-  height: 500px;
-  overflow-y: scroll;
+  min-height: 400px;
+  max-height: 500px;
+  overflow-y: auto;
+  padding: 16px;
+  background: var(--mat-sys-surface-container-low);
+  border-radius: 8px;
+}
+
+/* =============================================
+// Empty state
+// ============================================= */
+.readme-empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 300px;
+  padding: 48px 24px;
+  background: var(--mat-sys-surface-container-low);
+  border-radius: 8px;
+  border: 1px dashed var(--mat-sys-outline-variant);
+}
+
+.readme-empty-icon {
+  font-size: 48px;
+  width: 48px;
+  height: 48px;
+  color: var(--mat-sys-on-surface-variant);
+  margin-bottom: 16px;
+  opacity: 0.5;
+}
+
+.readme-empty-text {
+  font-size: 14px;
+  color: var(--mat-sys-on-surface-variant);
+  margin: 0;
+  text-align: center;
+}
+
+/* =============================================
+// Edit container
+// ============================================= */
+.readme-edit-container {
+  margin-bottom: 16px;
+}
+
+.editor-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.editor-label {
+  display: block;
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--mat-sys-on-surface-variant);
+  margin-bottom: 0;
 }
 
 .editorWrapper {
   width: 100%;
-  height: 500px;
-  overflow-y: scroll;
+  min-height: 400px;
+  max-height: 500px;
+  padding: 12px;
+  font-family: 'Roboto Mono', monospace;
+  font-size: 14px;
+  line-height: 1.6;
+  border: 1px solid var(--mat-sys-outline);
+  border-radius: 8px;
+  background: var(--mat-sys-surface);
+  color: var(--mat-sys-on-surface);
+  resize: vertical;
+
+  &:focus {
+    outline: none;
+    border-color: var(--mat-sys-primary);
+    box-shadow: 0 0 0 2px color-mix(in srgb, var(--mat-sys-primary) 20%, transparent);
+  }
+
+  &::placeholder {
+    color: var(--mat-sys-on-surface-variant);
+    opacity: 0.6;
+  }
+}
+
+.editor-hint {
+  font-size: 12px;
+  color: var(--mat-sys-on-surface-variant);
+  margin: 8px 0 0 0;
+  opacity: 0.7;
+}
+
+/* =============================================
+// Save status indicator
+// ============================================= */
+.save-status {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  padding: 4px 12px;
+  border-radius: 16px;
+  transition: all 0.3s ease;
+
+  .save-status-icon {
+    font-size: 16px;
+    width: 16px;
+    height: 16px;
+  }
+
+  &--saving {
+    background: var(--mat-sys-secondary-container);
+    color: var(--mat-sys-on-secondary-container);
+
+    .save-status-icon {
+      animation: spin 1s linear infinite;
+    }
+  }
+
+  &--saved {
+    background: var(--mat-sys-primary-container);
+    color: var(--mat-sys-on-primary-container);
+  }
+
+  &--error {
+    background: var(--mat-sys-error-container);
+    color: var(--mat-sys-on-error-container);
+  }
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
 }

--- a/src/app/components/projects/edit-project-dialog/readme-editor/readme-editor.component.spec.ts
+++ b/src/app/components/projects/edit-project-dialog/readme-editor/readme-editor.component.spec.ts
@@ -1,10 +1,10 @@
 import { ChangeDetectorRef, signal } from '@angular/core';
-import { of, throwError } from 'rxjs';
+import { of, throwError, Subject } from 'rxjs';
 import { ReadmeEditorComponent } from './readme-editor.component';
 import { ProjectService } from '@services/project.service';
 import { Controller } from '@models/controller';
 import { Project } from '@models/project';
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 
 describe('ReadmeEditorComponent', () => {
   let component: ReadmeEditorComponent;
@@ -63,6 +63,7 @@ describe('ReadmeEditorComponent', () => {
 
     mockProjectService = {
       getReadmeFile: vi.fn(),
+      postReadmeFile: vi.fn().mockReturnValue(of({})),
     };
 
     // Create component using Object.create to bypass constructor
@@ -89,6 +90,24 @@ describe('ReadmeEditorComponent', () => {
 
     // Initialize markdown signal
     (component as any).markdown = signal('');
+
+    // Initialize RxJS Subject for auto-save (missing from constructor bypass)
+    (component as any).markdownChange$ = new Subject<string>();
+    (component as any).destroy$ = new Subject<void>();
+    (component as any).isEditing = signal(false);
+    (component as any).saveStatus = signal<'idle' | 'saving' | 'saved' | 'error'>('idle');
+  });
+
+  afterEach(() => {
+    // Clean up subscriptions
+    if ((component as any).markdownChangeSubscription) {
+      (component as any).markdownChangeSubscription.unsubscribe();
+    }
+    if ((component as any).destroy$) {
+      (component as any).destroy$.next();
+      (component as any).destroy$.complete();
+    }
+    vi.clearAllMocks();
   });
 
   describe('initialization', () => {
@@ -151,6 +170,48 @@ describe('ReadmeEditorComponent', () => {
       component.markdown.set('# Content');
       component.markdown.set('');
       expect(component.markdown()).toBe('');
+    });
+  });
+
+  describe('edit mode', () => {
+    beforeEach(() => {
+      // Initialize isEditingChange output
+      (component as any).isEditingChange = {
+        emit: vi.fn(),
+      };
+    });
+
+    it('should enter edit mode when enterEditMode is called', () => {
+      component.enterEditMode();
+      expect((component as any).isEditing()).toBe(true);
+      expect((component as any).isEditingChange.emit).toHaveBeenCalledWith(true);
+    });
+
+    it('should exit edit mode when cancelEdit is called', () => {
+      (component as any).isEditing.set(true);
+      component.cancelEdit();
+      expect((component as any).isEditing()).toBe(false);
+      expect((component as any).isEditingChange.emit).toHaveBeenCalledWith(false);
+    });
+
+    it('should trigger auto-save on markdown input', () => {
+      mockProjectService.postReadmeFile.mockReturnValue(of({}));
+
+      const mockEvent = {
+        target: { value: '# New content' },
+      } as unknown as Event;
+
+      component.onMarkdownInput(mockEvent);
+
+      expect(component.markdown()).toBe('# New content');
+      // Auto-save is debounced, so we need to wait for it
+    });
+  });
+
+  describe('ngOnDestroy', () => {
+    it('should clean up subscriptions', () => {
+      component.ngOnDestroy();
+      expect((component as any).destroy$.isStopped).toBe(true);
     });
   });
 });

--- a/src/app/components/projects/edit-project-dialog/readme-editor/readme-editor.component.ts
+++ b/src/app/components/projects/edit-project-dialog/readme-editor/readme-editor.component.ts
@@ -1,11 +1,16 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, inject, input, signal } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, inject, input, signal, output, Output, OnDestroy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { MatTabsModule } from '@angular/material/tabs';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
 import { MarkdownModule } from 'ngx-markdown';
 import { ProjectService } from '@services/project.service';
 import { Controller } from '@models/controller';
 import { Project } from '@models/project';
+import { debounceTime, distinctUntilChanged, tap, takeUntil } from 'rxjs/operators';
+import { Subject, Subscription } from 'rxjs';
 
 @Component({
   standalone: true,
@@ -13,9 +18,9 @@ import { Project } from '@models/project';
   templateUrl: './readme-editor.component.html',
   styleUrls: ['./readme-editor.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [CommonModule, FormsModule, MatTabsModule, MarkdownModule],
+  imports: [CommonModule, FormsModule, MatButtonModule, MatIconModule, MatFormFieldModule, MatInputModule, MarkdownModule],
 })
-export class ReadmeEditorComponent implements OnInit {
+export class ReadmeEditorComponent implements OnInit, OnDestroy {
   readonly controller = input<Controller>(undefined);
   readonly project = input<Project>(undefined);
 
@@ -23,6 +28,15 @@ export class ReadmeEditorComponent implements OnInit {
   private cd = inject(ChangeDetectorRef);
 
   markdown = signal('');
+  isEditing = signal(false);
+  saveStatus = signal<'idle' | 'saving' | 'saved' | 'error'>('idle');
+  private originalMarkdown = '';
+  private destroy$ = new Subject<void>();
+  private markdownChangeSubscription: Subscription | null = null;
+
+  readonly isEditingChange = output<boolean>();
+
+  private markdownChange$ = new Subject<string>();
 
   ngOnInit() {
     this.projectService.getReadmeFile(this.controller(), this.project().project_id).subscribe({
@@ -40,5 +54,73 @@ export class ReadmeEditorComponent implements OnInit {
         this.cd.markForCheck();
       },
     });
+
+    // Setup auto-save with 2 second debounce
+    this.markdownChangeSubscription = this.markdownChange$
+      .pipe(
+        debounceTime(2000),
+        distinctUntilChanged(),
+        tap((content) => this.autoSave(content)),
+        takeUntil(this.destroy$)
+      )
+      .subscribe();
+  }
+
+  ngOnDestroy() {
+    this.destroy$.next();
+    this.destroy$.complete();
+    if (this.markdownChangeSubscription) {
+      this.markdownChangeSubscription.unsubscribe();
+    }
+  }
+
+  onMarkdownInput(event: Event) {
+    const content = (event.target as HTMLTextAreaElement).value;
+    this.markdown.set(content);
+    this.markdownChange$.next(content);
+  }
+
+  private autoSave(content: string) {
+    this.saveStatus.set('saving');
+
+    this.projectService.postReadmeFile(this.controller(), this.project().project_id, content).subscribe({
+      next: () => {
+        this.saveStatus.set('saved');
+        this.cd.markForCheck();
+
+        // Reset to idle after 2 seconds
+        setTimeout(() => {
+          this.saveStatus.set('idle');
+          this.cd.markForCheck();
+        }, 2000);
+      },
+      error: (err) => {
+        this.saveStatus.set('error');
+        this.cd.markForCheck();
+
+        // Reset to idle after 3 seconds
+        setTimeout(() => {
+          this.saveStatus.set('idle');
+          this.cd.markForCheck();
+        }, 3000);
+      },
+    });
+  }
+
+  enterEditMode() {
+    this.originalMarkdown = this.markdown();
+    this.isEditing.set(true);
+    this.isEditingChange.emit(true);
+  }
+
+  cancelEdit() {
+    // Just exit edit mode, content is already auto-saved
+    this.isEditing.set(false);
+    this.isEditingChange.emit(false);
+  }
+
+  saveEdit() {
+    this.isEditing.set(false);
+    this.isEditingChange.emit(false);
   }
 }


### PR DESCRIPTION
## Summary

This PR improves the Edit Project dialog with better layout and enhanced readme editing experience.

## Changes

### General Tab - Two-Column Grid Layout
- Project name field occupies full width for better visibility
- Scene width/height fields paired in two columns for compact layout
- Node grid size/Drawing grid size fields paired in two columns
- Checkboxes remain in single column layout for clarity

### Readme Tab - Real-Time Auto-Save
- Replace Edit/Preview tabs with single preview mode by default
- Add Edit button in dialog footer to enter editing mode
- Implement auto-save with 2-second debounce to prevent excessive API calls
- Display save status indicators (Saving.../Saved/Error)
- All action buttons (Cancel/Edit/Apply) moved to dialog footer
- Cancel button in edit mode only exits edit mode (no content restore)

## Benefits
- More intuitive and user-friendly interface
- Reduced cognitive load with real-time auto-save
- Better visual organization with two-column layout
- Consistent button placement in dialog footer