### PR TITLE
fix: remove SVG support from Insert a picture upload

### DIFF
--- a/src/app/components/project-map/project-map-menu/project-map-menu.component.html
+++ b/src/app/components/project-map/project-map-menu/project-map-menu.component.html
@@ -10,7 +10,7 @@
 </button>
 <input
   type="file"
-  accept=".svg, .bmp, .jpeg, .jpg, .gif, .png"
+  accept=".bmp, .jpeg, .jpg, .gif, .png"
   class="non-visible"
   #file
   (change)="uploadImageFile($event)"

--- a/src/app/components/project-map/project-map-menu/project-map-menu.component.ts
+++ b/src/app/components/project-map/project-map-menu/project-map-menu.component.ts
@@ -616,6 +616,15 @@ export class ProjectMapMenuComponent implements OnInit, OnDestroy {
 
   private readImageFile(fileInput) {
     let file: File = fileInput.files[0];
+    if (!file) return;
+
+    const fileExtension = file.name.split('.').pop()?.toLowerCase();
+    if (fileExtension === 'svg') {
+      this.toaster.error('SVG images are not supported. Please use PNG, JPG, GIF or BMP format.');
+      this.cdr.markForCheck();
+      return;
+    }
+
     let fileReader: FileReader = new FileReader();
     let imageToUpload = new Image();
 


### PR DESCRIPTION
SVG files uploaded via the "Insert a picture" feature never appeared on the canvas because browser security policies prevent SVG `<image>` elements from rendering SVG content.

- Removed `.svg` from the file input `accept` filter
- Added a validation check in `readImageFile` to reject SVG files with an error message