### PR TITLE
fix: preserve canvas origin in redraw to prevent content jumping after node creation (#1696)

### DIFF
--- a/src/app/cartography/components/d3-map/d3-map.component.ts
+++ b/src/app/cartography/components/d3-map/d3-map.component.ts
@@ -372,19 +372,17 @@ export class D3MapComponent implements OnInit, OnChanges, OnDestroy {
     // Save current origin before getSize() potentially changes it — when new
     // content extends beyond the current canvas boundary getSize() grows the
     // canvas and shifts centerX/Y, which would make every visible element jump.
-    const prevOriginX = this.context.centerX ?? this.context.size.width / 2;
-    const prevOriginY = this.context.centerY ?? this.context.size.height / 2;
+    const savedCenterX = this.context.centerX;
+    const savedCenterY = this.context.centerY;
 
     // Recalculate after setNodes/Drawings so graphDataManager has current positions.
     this.context.size = this.getSize();
 
-    // Compensate scroll when canvas origin shifts, keeping visual position
-    // stable (same pattern as node-drag-end compensation in ngOnInit).
-    const newOriginX = this.context.centerX ?? this.context.size.width / 2;
-    const newOriginY = this.context.centerY ?? this.context.size.height / 2;
-    if (newOriginX !== prevOriginX || newOriginY !== prevOriginY) {
-      window.scrollBy(newOriginX - prevOriginX, newOriginY - prevOriginY);
-    }
+    // Restore origin to prevent visual canvas shifting. The size is updated to
+    // accommodate new content, but the <g> transform origin stays stable so
+    // existing elements don't jump (same pattern as node-drag locking).
+    this.context.centerX = savedCenterX;
+    this.context.centerY = savedCenterY;
 
     this.graphLayout.draw(this.svg, this.context);
     this.textEditor().activateTextEditingForDrawings();

--- a/src/app/cartography/components/d3-map/d3-map.component.ts
+++ b/src/app/cartography/components/d3-map/d3-map.component.ts
@@ -368,8 +368,24 @@ export class D3MapComponent implements OnInit, OnChanges, OnDestroy {
     this.graphDataManager.setNodes(this.nodes());
     this.graphDataManager.setLinks(this.links());
     this.graphDataManager.setDrawings(this.drawings());
+
+    // Save current origin before getSize() potentially changes it — when new
+    // content extends beyond the current canvas boundary getSize() grows the
+    // canvas and shifts centerX/Y, which would make every visible element jump.
+    const prevOriginX = this.context.centerX ?? this.context.size.width / 2;
+    const prevOriginY = this.context.centerY ?? this.context.size.height / 2;
+
     // Recalculate after setNodes/Drawings so graphDataManager has current positions.
     this.context.size = this.getSize();
+
+    // Compensate scroll when canvas origin shifts, keeping visual position
+    // stable (same pattern as node-drag-end compensation in ngOnInit).
+    const newOriginX = this.context.centerX ?? this.context.size.width / 2;
+    const newOriginY = this.context.centerY ?? this.context.size.height / 2;
+    if (newOriginX !== prevOriginX || newOriginY !== prevOriginY) {
+      window.scrollBy(newOriginX - prevOriginX, newOriginY - prevOriginY);
+    }
+
     this.graphLayout.draw(this.svg, this.context);
     this.textEditor().activateTextEditingForDrawings();
     this.textEditor().activateTextEditingForNodeLabels();

--- a/src/app/components/template/template.component.ts
+++ b/src/app/components/template/template.component.ts
@@ -341,9 +341,12 @@ export class TemplateComponent implements OnInit, OnDestroy {
     const pageX = this.lastPageX();
     const pageY = this.lastPageY();
 
-    // Use scene dimensions as fallback for context size
-    const centerX = this.context.size.width > 0 ? this.context.size.width / 2 : this.project().scene_width / 2;
-    const centerY = this.context.size.height > 0 ? this.context.size.height / 2 : this.project().scene_height / 2;
+    // Use the same origin as the SVG <g> canvas transform (getZeroZeroTransformationPoint)
+    // to ensure consistent screen-to-world coordinate conversion. This prevents
+    // the canvas from shifting when getSize() recalculates centerX/Y after node creation.
+    const origin = this.context.getZeroZeroTransformationPoint();
+    const centerX = this.context.size.width > 0 ? origin.x : this.project().scene_width / 2;
+    const centerY = this.context.size.height > 0 ? origin.y : this.project().scene_height / 2;
 
     // Convert screen coordinates to world coordinates using D3 transformation
     const worldX = (pageX - (centerX + this.context.transformation.x)) / this.context.transformation.k;


### PR DESCRIPTION
Fixes #1696.

After panning the canvas, adding a node via template drag-and-drop triggered getSize() inside redraw(), which shifted centerX/Y to accommodate the new node's pan-influenced world coordinates. This caused the entire canvas content to jump.

Previously attempted scroll compensation via window.scrollBy() had a timing issue — changeLayout() already called getSize() before redraw(), so prevOrigin was already the updated value and compensation never fired.

Instead, save and restore centerX/Y around getSize() in redraw() so the canvas dimensions expand to fit new content without shifting the <g> transform origin.