### PR TITLE
feat: add interactive rotation handle for rectangles and ellipses

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -1,0 +1,7 @@
+# Memory Index
+
+Project-specific memory and context for GNS3 Web UI.
+
+## Cartography & Coordinate System
+
+- [Canvas Coordinate System](canvas-coordinate-system.md) — Left-handed Cartesian coordinate system (centered origin) used by D3.js map canvas

--- a/.claude/memory/canvas-coordinate-system.md
+++ b/.claude/memory/canvas-coordinate-system.md
@@ -1,0 +1,63 @@
+---
+name: canvas-coordinate-system
+description: GNS3 uses left-handed Cartesian coordinate system with origin at canvas center
+metadata:
+  type: project
+---
+
+# GNS3 Canvas Coordinate System
+
+GNS3 map canvas uses a **left-handed Cartesian coordinate system** with the origin positioned at the **center of the canvas** (not top-left corner).
+
+## Coordinate Axes
+
+| Axis | Direction | Description |
+|------|-----------|-------------|
+| **Origin (0,0)** | Canvas center | Set by `centerZeroZeroPoint=true` in Context model |
+| **X axis** | → Right | Positive direction: right |
+| **Y axis** | ↓ Down | Positive direction: down (⚠️ opposite of mathematical coordinate systems) |
+| **Z axis** | 👆 Out of screen | Points toward viewer (perpendicular to screen) |
+
+## Left-Handed vs Right-Handed Systems
+
+| Coordinate System | X Axis | Y Axis | Z Axis | Used In |
+|--------------------|--------|--------|--------|---------|
+| **Right-Handed** (Mathematics) | → Right | ↑ Up | 👆 Into screen | Math, physics, engineering |
+| **Left-Handed** (Screen) | → Right | ↓ Down | 👆 Out of screen | Computer graphics, D3.js, SVG |
+| **GNS3 Canvas** | → Right | ↓ Down | 👆 Out of screen | Network topology maps |
+
+## Left-Hand Rule
+
+Using the left hand to determine coordinate directions:
+- **Thumb** points to X axis positive direction (right →)
+- **Index finger** points to Y axis positive direction (down ⬇️)
+- **Middle finger** points to Z axis positive direction (outward 👆)
+
+## Critical Implications for Angle Calculations
+
+In this left-handed coordinate system, `Math.atan2(dy, dx)` returns **clockwise-positive** angles:
+- 0° = East (right)
+- 90° = South (down)
+- 180° = West (left)
+- -90° = North (up)
+
+**This is opposite** of right-handed (mathematical) coordinate systems where counter-clockwise is positive.
+
+## Impact on Rotation Feature Implementation
+
+When implementing rotation drag behavior:
+- Mouse moving down (dy > 0) increases angle → **clockwise rotation**
+- Angle calculations must be normalized to server validation range [-359, 360]
+- Crossing atan2 boundary (-180°/180°) requires special delta handling
+
+**Why:** The screen-based coordinate system affects how `Math.atan2()` interprets mouse positions, causing rotation direction to be clockwise-positive rather than counter-clockwise-positive as in mathematics.
+
+**How to apply:** Always remember that GNS3 canvas coordinates are Y-down, so:
+1. Test rotation behavior to verify direction matches user expectations
+2. Use angle normalization when persisting to server (while loops to keep within [-359, 360])
+3. Handle atan2 boundary crossing correctly when calculating delta angles (if delta > 180°, subtract 360°; if delta < -180°, add 360°)
+
+## Reference Code
+
+- **Context definition**: `src/app/cartography/models/context.ts` — `centerZeroZeroPoint`, `getZeroZeroTransformationPoint()`, `transformation` properties
+- **Rotation drag implementation**: `src/app/cartography/widgets/drawings.ts` — d3-drag rotation behavior

--- a/src/app/cartography/components/drawing-resizing/drawing-resizing.component.ts
+++ b/src/app/cartography/components/drawing-resizing/drawing-resizing.component.ts
@@ -23,7 +23,7 @@ export class DrawingResizingComponent implements OnInit, OnDestroy {
   ngOnInit() {
     this.resizingFinished = this.drawingsWidget.resizingFinished.subscribe((evt: ResizingEnd<MapDrawing>) => {
       this.drawingsEventSource.resized.emit(
-        new ResizedDataEvent<MapDrawing>(evt.datum, evt.x, evt.y, evt.width, evt.height)
+        new ResizedDataEvent<MapDrawing>(evt.datum, evt.x, evt.y, evt.width, evt.height, evt.rotation)
       );
     });
   }

--- a/src/app/cartography/events/event-source.ts
+++ b/src/app/cartography/events/event-source.ts
@@ -11,7 +11,7 @@ export class DataEventSource<T> {
 export class DraggedDataEvent<T> extends DataEventSource<T> {}
 
 export class ResizedDataEvent<T> {
-  constructor(public datum: T, public x: number, public y: number, public width: number, public height: number) {}
+  constructor(public datum: T, public x: number, public y: number, public width: number, public height: number, public rotation?: number) {}
 }
 
 export class AddedDataEvent {

--- a/src/app/cartography/events/resizing.ts
+++ b/src/app/cartography/events/resizing.ts
@@ -4,4 +4,5 @@ export class ResizingEnd<T> {
   public y: number;
   public width: number;
   public height: number;
+  public rotation?: number;
 }

--- a/src/app/cartography/widgets/drawing.ts
+++ b/src/app/cartography/widgets/drawing.ts
@@ -147,11 +147,11 @@ export class DrawingWidget implements Widget {
         .attr('fill', BADGE_OUTLINE_COLOR);
     }
 
-    // Rotation handle — only for rectangle and ellipse shapes
+    // Rotation handle — only for rectangle and ellipse shapes, and only when selected
     drawing_body_merge.select('.rotation-handle-stem').remove();
     drawing_body_merge.select('.rotation-handle-knob').remove();
     drawing_body_merge
-      .filter((d: MapDrawing) => d.element instanceof RectElement || d.element instanceof EllipseElement)
+      .filter((d: MapDrawing) => (d.element instanceof RectElement || d.element instanceof EllipseElement) && this.selectionManager.isSelected(d))
       .each(function (d: MapDrawing) {
         const group = select(this);
         const handleX = d.element.width + 30;

--- a/src/app/cartography/widgets/drawing.ts
+++ b/src/app/cartography/widgets/drawing.ts
@@ -165,12 +165,12 @@ export class DrawingWidget implements Widget {
           .attr('cx', 0)
           .attr('cy', 0)
           .attr('r', 5)
-          .attr('fill', 'blue');
+          .attr('fill', UNLOCKED_ICON_COLOR);
 
         group.append<SVGLineElement>('line')
           .attr('class', 'rotation-handle-stem')
           .attr('pointer-events', 'none')
-          .attr('stroke', 'red')
+          .attr('stroke', LOCKED_ICON_COLOR)
           .attr('stroke-width', '2')
           .attr('stroke-dasharray', '4 2')
           .attr('x1', 0)
@@ -184,7 +184,7 @@ export class DrawingWidget implements Widget {
           .attr('cx', handleX)
           .attr('cy', handleY)
           .attr('r', 8)
-          .attr('fill', 'red')
+          .attr('fill', LOCKED_ICON_COLOR)
           .attr('cursor', 'grab');
       });
 

--- a/src/app/cartography/widgets/drawing.ts
+++ b/src/app/cartography/widgets/drawing.ts
@@ -157,11 +157,17 @@ export class DrawingWidget implements Widget {
         const handleX = d.element.width + 30;
         const handleY = -30;
 
+        const centerX = d.element instanceof EllipseElement ? d.element.cx : d.element.width / 2;
+        const centerY = d.element instanceof EllipseElement ? d.element.cy : d.element.height / 2;
+
         group.append<SVGLineElement>('line')
           .attr('class', 'rotation-handle-stem')
           .attr('pointer-events', 'none')
-          .attr('x1', d.element.width)
-          .attr('y1', 0)
+          .attr('stroke', 'red')
+          .attr('stroke-width', '2')
+          .attr('stroke-dasharray', '4 2')
+          .attr('x1', centerX)
+          .attr('y1', centerY)
           .attr('x2', handleX)
           .attr('y2', handleY);
 
@@ -171,6 +177,7 @@ export class DrawingWidget implements Widget {
           .attr('cx', handleX)
           .attr('cy', handleY)
           .attr('r', 8)
+          .attr('fill', 'red')
           .attr('cursor', 'grab');
       });
 

--- a/src/app/cartography/widgets/drawing.ts
+++ b/src/app/cartography/widgets/drawing.ts
@@ -154,22 +154,21 @@ export class DrawingWidget implements Widget {
       .filter((d: MapDrawing) => d.element instanceof RectElement || d.element instanceof EllipseElement)
       .each(function (d: MapDrawing) {
         const group = select(this);
-        const cx = d.element instanceof EllipseElement ? d.element.cx : d.element.width / 2;
-        const topY = d.element instanceof EllipseElement ? d.element.cy - d.element.ry : 0;
-        const handleY = topY - 30;
+        const handleX = d.element.width + 30;
+        const handleY = -30;
 
         group.append<SVGLineElement>('line')
           .attr('class', 'rotation-handle-stem')
           .attr('pointer-events', 'none')
-          .attr('x1', cx)
-          .attr('y1', topY)
-          .attr('x2', cx)
+          .attr('x1', d.element.width)
+          .attr('y1', 0)
+          .attr('x2', handleX)
           .attr('y2', handleY);
 
         group.append<SVGCircleElement>('circle')
           .attr('class', 'rotation-handle-knob')
           .attr('pointer-events', 'all')
-          .attr('cx', cx)
+          .attr('cx', handleX)
           .attr('cy', handleY)
           .attr('r', 8)
           .attr('cursor', 'grab');

--- a/src/app/cartography/widgets/drawing.ts
+++ b/src/app/cartography/widgets/drawing.ts
@@ -150,6 +150,7 @@ export class DrawingWidget implements Widget {
     // Rotation handle — only for rectangle and ellipse shapes, and only when selected
     drawing_body_merge.select('.rotation-handle-stem').remove();
     drawing_body_merge.select('.rotation-handle-knob').remove();
+    drawing_body_merge.select('.rotation-center-point').remove();
     drawing_body_merge
       .filter((d: MapDrawing) => (d.element instanceof RectElement || d.element instanceof EllipseElement) && this.selectionManager.isSelected(d))
       .each(function (d: MapDrawing) {
@@ -157,8 +158,14 @@ export class DrawingWidget implements Widget {
         const handleX = d.element.width + 30;
         const handleY = -30;
 
-        const centerX = d.element instanceof EllipseElement ? d.element.cx : d.element.width / 2;
-        const centerY = d.element instanceof EllipseElement ? d.element.cy : d.element.height / 2;
+        // Rotation center point (top-left corner)
+        group.append<SVGCircleElement>('circle')
+          .attr('class', 'rotation-center-point')
+          .attr('pointer-events', 'none')
+          .attr('cx', 0)
+          .attr('cy', 0)
+          .attr('r', 5)
+          .attr('fill', 'blue');
 
         group.append<SVGLineElement>('line')
           .attr('class', 'rotation-handle-stem')
@@ -166,8 +173,8 @@ export class DrawingWidget implements Widget {
           .attr('stroke', 'red')
           .attr('stroke-width', '2')
           .attr('stroke-dasharray', '4 2')
-          .attr('x1', centerX)
-          .attr('y1', centerY)
+          .attr('x1', 0)
+          .attr('y1', 0)
           .attr('x2', handleX)
           .attr('y2', handleY);
 

--- a/src/app/cartography/widgets/drawing.ts
+++ b/src/app/cartography/widgets/drawing.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import { select } from 'd3-selection';
 import { MapSettingsService } from '@services/mapsettings.service';
 import { SelectionManager } from '../managers/selection-manager';
 import { EllipseElement } from '../models/drawings/ellipse-element';
@@ -145,6 +146,34 @@ export class DrawingWidget implements Widget {
         .attr('r', 2)
         .attr('fill', BADGE_OUTLINE_COLOR);
     }
+
+    // Rotation handle — only for rectangle and ellipse shapes
+    drawing_body_merge.select('.rotation-handle-stem').remove();
+    drawing_body_merge.select('.rotation-handle-knob').remove();
+    drawing_body_merge
+      .filter((d: MapDrawing) => d.element instanceof RectElement || d.element instanceof EllipseElement)
+      .each(function (d: MapDrawing) {
+        const group = select(this);
+        const cx = d.element instanceof EllipseElement ? d.element.cx : d.element.width / 2;
+        const topY = d.element instanceof EllipseElement ? d.element.cy - d.element.ry : 0;
+        const handleY = topY - 30;
+
+        group.append<SVGLineElement>('line')
+          .attr('class', 'rotation-handle-stem')
+          .attr('pointer-events', 'none')
+          .attr('x1', cx)
+          .attr('y1', topY)
+          .attr('x2', cx)
+          .attr('y2', handleY);
+
+        group.append<SVGCircleElement>('circle')
+          .attr('class', 'rotation-handle-knob')
+          .attr('pointer-events', 'all')
+          .attr('cx', cx)
+          .attr('cy', handleY)
+          .attr('r', 8)
+          .attr('cursor', 'grab');
+      });
 
     drawing_body_merge
       .select<SVGAElement>('line.top')

--- a/src/app/cartography/widgets/drawings.ts
+++ b/src/app/cartography/widgets/drawings.ts
@@ -437,6 +437,33 @@ export class DrawingsWidget implements Widget {
         }
       }
     });
+
+    // Rotation drag behavior
+    let rotateDrag = drag()
+      .on('start', () => {
+        document.body.style.cursor = 'grabbing';
+      })
+      .on('drag', (event: any, datum: MapDrawing) => {
+        const cx = datum.element instanceof EllipseElement ? datum.element.cx : datum.element.width / 2;
+        const cy = datum.element instanceof EllipseElement ? datum.element.cy : datum.element.height / 2;
+        const centerX = datum.x + cx;
+        const centerY = datum.y + cy;
+
+        const mouseX = event.sourceEvent.pageX - (this.context.getZeroZeroTransformationPoint().x + this.context.transformation.x);
+        const mouseY = event.sourceEvent.pageY - (this.context.getZeroZeroTransformationPoint().y + this.context.transformation.y);
+
+        const angle = Math.atan2(mouseY - centerY, mouseX - centerX) * (180 / Math.PI) + 90;
+        datum.rotation = Math.round(angle);
+        this.redrawDrawing(view, datum);
+      })
+      .on('end', (event: any, datum: MapDrawing) => {
+        document.body.style.cursor = 'initial';
+        const evt = this.createResizingEvent(datum);
+        evt.rotation = datum.rotation;
+        this.resizingFinished.emit(evt);
+      });
+
+    merge.select<SVGCircleElement>('circle.rotation-handle-knob').call(rotateDrag);
   }
 
   private createResizingEvent(datum: MapDrawing) {

--- a/src/app/cartography/widgets/drawings.ts
+++ b/src/app/cartography/widgets/drawings.ts
@@ -439,21 +439,37 @@ export class DrawingsWidget implements Widget {
     });
 
     // Rotation drag behavior
+    let startAngle = 0;
+    let startRotation = 0;
+
     let rotateDrag = drag()
-      .on('start', () => {
+      .on('start', (event: any, datum: MapDrawing) => {
         document.body.style.cursor = 'grabbing';
-      })
-      .on('drag', (event: any, datum: MapDrawing) => {
-        const cx = datum.element instanceof EllipseElement ? datum.element.cx : datum.element.width / 2;
-        const cy = datum.element instanceof EllipseElement ? datum.element.cy : datum.element.height / 2;
-        const centerX = datum.x + cx;
-        const centerY = datum.y + cy;
 
         const mouseX = event.sourceEvent.pageX - (this.context.getZeroZeroTransformationPoint().x + this.context.transformation.x);
         const mouseY = event.sourceEvent.pageY - (this.context.getZeroZeroTransformationPoint().y + this.context.transformation.y);
 
-        const angle = Math.atan2(mouseY - centerY, mouseX - centerX) * (180 / Math.PI) + 90;
-        datum.rotation = Math.round(angle);
+        startAngle = Math.atan2(mouseY - datum.y, mouseX - datum.x) * (180 / Math.PI);
+        startRotation = datum.rotation || 0;
+      })
+      .on('drag', (event: any, datum: MapDrawing) => {
+        const mouseX = event.sourceEvent.pageX - (this.context.getZeroZeroTransformationPoint().x + this.context.transformation.x);
+        const mouseY = event.sourceEvent.pageY - (this.context.getZeroZeroTransformationPoint().y + this.context.transformation.y);
+
+        const currentAngle = Math.atan2(mouseY - datum.y, mouseX - datum.x) * (180 / Math.PI);
+
+        // 计算角度差，正确处理边界跨越
+        let deltaAngle = currentAngle - startAngle;
+        if (deltaAngle > 180) deltaAngle -= 360;
+        if (deltaAngle < -180) deltaAngle += 360;
+
+        let newRotation = startRotation + deltaAngle;
+
+        // 规范化到 [-359, 360] 范围
+        while (newRotation > 360) newRotation -= 360;
+        while (newRotation < -359) newRotation += 360;
+
+        datum.rotation = Math.round(newRotation);
         this.redrawDrawing(view, datum);
       })
       .on('end', (event: any, datum: MapDrawing) => {

--- a/src/app/components/drawings-listeners/drawing-resized/drawing-resized.component.ts
+++ b/src/app/components/drawings-listeners/drawing-resized/drawing-resized.component.ts
@@ -34,20 +34,45 @@ export class DrawingResizedComponent implements OnInit, OnDestroy {
 
   onDrawingResized(resizedEvent: ResizedDataEvent<MapDrawing>) {
     const drawing = this.drawingsDataSource.get(resizedEvent.datum.id);
-    let svgString = this.mapDrawingToSvgConverter.convert(resizedEvent.datum);
 
-    this.drawingService
-      .updateSizeAndPosition(this.controller(), drawing, resizedEvent.x, resizedEvent.y, svgString)
-      .subscribe({
-        next: (controllerDrawing: Drawing) => {
-          this.drawingsDataSource.update(controllerDrawing);
-        },
-        error: (err) => {
-          const message = err.error?.message || err.message || 'Failed to update drawing size';
-          this.toasterService.error(message);
-          this.cdr.markForCheck();
-        },
-      });
+    // Check if this is a rotation event (has rotation field)
+    const isRotation = resizedEvent.rotation !== undefined;
+
+    if (isRotation) {
+      // Rotation: use update() method which includes rotation
+      drawing.rotation = resizedEvent.rotation;
+      let svgString = this.mapDrawingToSvgConverter.convert(resizedEvent.datum);
+      drawing.svg = svgString;
+
+      this.drawingService
+        .update(this.controller(), drawing)
+        .subscribe({
+          next: (controllerDrawing: Drawing) => {
+            this.drawingsDataSource.update(controllerDrawing);
+          },
+          error: (err) => {
+            const message = err.error?.message || err.message || 'Failed to update drawing rotation';
+            this.toasterService.error(message);
+            this.cdr.markForCheck();
+          },
+        });
+    } else {
+      // Resize: use updateSizeAndPosition() method
+      let svgString = this.mapDrawingToSvgConverter.convert(resizedEvent.datum);
+
+      this.drawingService
+        .updateSizeAndPosition(this.controller(), drawing, resizedEvent.x, resizedEvent.y, svgString)
+        .subscribe({
+          next: (controllerDrawing: Drawing) => {
+            this.drawingsDataSource.update(controllerDrawing);
+          },
+          error: (err) => {
+            const message = err.error?.message || err.message || 'Failed to update drawing size';
+            this.toasterService.error(message);
+            this.cdr.markForCheck();
+          },
+        });
+    }
   }
 
   ngOnDestroy() {

--- a/src/app/components/project-map/project-map.component.scss
+++ b/src/app/components/project-map/project-map.component.scss
@@ -433,7 +433,7 @@ g.drawing_body.drawing_selected .rotation-handle-stem {
 
 g.drawing_body.drawing_selected .rotation-handle-knob {
   fill: var(--mat-sys-primary);
-  stroke: var(--gns3-bright-text, #ffffff);
+  stroke: var(--gns3-bright-text);
   stroke-width: 2;
 }
 

--- a/src/app/components/project-map/project-map.component.scss
+++ b/src/app/components/project-map/project-map.component.scss
@@ -414,6 +414,29 @@ path.curve_element.selected {
   fill: none;
 }
 
+/* Rotation handle — hidden by default, shown on selection */
+g.drawing_body .rotation-handle-stem,
+g.drawing_body .rotation-handle-knob {
+  visibility: hidden;
+}
+
+g.drawing_body.drawing_selected .rotation-handle-stem,
+g.drawing_body.drawing_selected .rotation-handle-knob {
+  visibility: visible;
+}
+
+g.drawing_body.drawing_selected .rotation-handle-stem {
+  stroke: var(--mat-sys-primary);
+  stroke-width: 2;
+  stroke-dasharray: 4 2;
+}
+
+g.drawing_body.drawing_selected .rotation-handle-knob {
+  fill: var(--mat-sys-primary);
+  stroke: var(--gns3-bright-text, #ffffff);
+  stroke-width: 2;
+}
+
 g.node text,
 .noselect {
   -webkit-touch-callout: none;


### PR DESCRIPTION
## Summary

This PR adds an interactive rotation handle for rectangles and ellipses on the canvas, allowing users to rotate these shapes by dragging a handle instead of manually entering angles in the Edit Style dialog.

## Changes

- **Rotation Handle UI**: Added a visual rotation handle consisting of:
  - Blue center point indicator (at top-left corner, the rotation pivot)
  - Dashed stem line extending from center point to handle knob
  - Red draggable handle knob (positioned at top-right area)
  - Uses same color scheme as lock badge for consistency

- **Rotation Behavior**: 
  - Drag handle to rotate shapes interactively
  - Rotation around top-left corner (datum.x, datum.y)
  - Proper angle delta calculation with boundary crossing support
  - Angle normalization to server validation range [-359, 360]

- **Visibility**: Rotation handle only shows when rectangle or ellipse is selected

- **Persistence**: Rotation changes are persisted to server using existing `drawingService.update()` method

## Files Changed

- `src/app/cartography/widgets/drawing.ts`: Rotation handle rendering
- `src/app/cartography/widgets/drawings.ts`: Rotation drag behavior implementation
- `src/app/cartography/events/resizing.ts`: Added optional `rotation` field to `ResizingEnd`
- `src/app/cartography/events/event-source.ts`: Extended `ResizedDataEvent` to support rotation
- `src/app/cartography/components/drawing-resizing/drawing-resizing.component.ts`: Pass rotation in events
- `src/app/components/drawings-listeners/drawing-resized/drawing-resized.component.ts`: Handle rotation events
- `src/app/components/project-map/project-map.component.scss`: Rotation handle styles