### PR TITLE
refactor: redesign packet filters dialog to vertical form layout

### DIFF
--- a/src/app/components/project-map/packet-capturing/packet-filters/packet-filters.component.html
+++ b/src/app/components/project-map/packet-capturing/packet-filters/packet-filters.component.html
@@ -2,35 +2,41 @@
 
 @if (this.filters) {
 <div mat-dialog-content>
-  <mat-form-field appearance="fill" class="full-width-field">
-    <mat-label>Frequency drop</mat-label>
-    <input matInput type="number" [value]="filters.frequency_drop[0]" (input)="onFrequencyDropChange(+$event.target.value)" />
-    <span matSuffix>packets</span>
-  </mat-form-field>
+  <div class="form-grid">
+    <div class="form-grid-column">
+      <mat-form-field appearance="fill" class="full-width-field">
+        <mat-label>Frequency drop</mat-label>
+        <input matInput type="number" [value]="filters.frequency_drop[0]" (input)="onFrequencyDropChange(+$event.target.value)" />
+        <span matSuffix>packets</span>
+      </mat-form-field>
 
-  <mat-form-field appearance="fill" class="full-width-field">
-    <mat-label>Packet loss</mat-label>
-    <input matInput type="number" [value]="filters.packet_loss[0]" (input)="onPacketLossChange(+$event.target.value)" />
-    <span matSuffix>%</span>
-  </mat-form-field>
+      <mat-form-field appearance="fill" class="full-width-field">
+        <mat-label>Packet loss</mat-label>
+        <input matInput type="number" [value]="filters.packet_loss[0]" (input)="onPacketLossChange(+$event.target.value)" />
+        <span matSuffix>%</span>
+      </mat-form-field>
 
-  <mat-form-field appearance="fill" class="full-width-field">
-    <mat-label>Delay latency</mat-label>
-    <input matInput type="number" [value]="filters.delay[0]" (input)="onDelayLatencyChange(+$event.target.value)" />
-    <span matSuffix>ms</span>
-  </mat-form-field>
+      <mat-form-field appearance="fill" class="full-width-field">
+        <mat-label>Corrupt</mat-label>
+        <input matInput type="number" [value]="filters.corrupt[0]" (input)="onCorruptChange(+$event.target.value)" />
+        <span matSuffix>%</span>
+      </mat-form-field>
+    </div>
 
-  <mat-form-field appearance="fill" class="full-width-field">
-    <mat-label>Delay jitter</mat-label>
-    <input matInput type="number" [value]="filters.delay[1]" (input)="onDelayJitterChange(+$event.target.value)" />
-    <span matSuffix>ms</span>
-  </mat-form-field>
+    <div class="form-grid-column">
+      <mat-form-field appearance="fill" class="full-width-field">
+        <mat-label>Delay latency</mat-label>
+        <input matInput type="number" [value]="filters.delay[0]" (input)="onDelayLatencyChange(+$event.target.value)" />
+        <span matSuffix>ms</span>
+      </mat-form-field>
 
-  <mat-form-field appearance="fill" class="full-width-field">
-    <mat-label>Corrupt</mat-label>
-    <input matInput type="number" [value]="filters.corrupt[0]" (input)="onCorruptChange(+$event.target.value)" />
-    <span matSuffix>%</span>
-  </mat-form-field>
+      <mat-form-field appearance="fill" class="full-width-field">
+        <mat-label>Delay jitter</mat-label>
+        <input matInput type="number" [value]="filters.delay[1]" (input)="onDelayJitterChange(+$event.target.value)" />
+        <span matSuffix>ms</span>
+      </mat-form-field>
+    </div>
+  </div>
 
   <mat-form-field appearance="fill" class="full-width-field">
     <mat-label>Berkeley Packet Filter (BPF)</mat-label>

--- a/src/app/components/project-map/packet-capturing/packet-filters/packet-filters.component.html
+++ b/src/app/components/project-map/packet-capturing/packet-filters/packet-filters.component.html
@@ -40,7 +40,10 @@
 
   <mat-form-field appearance="fill" class="full-width-field">
     <mat-label>Berkeley Packet Filter (BPF)</mat-label>
-    <textarea matInput [value]="filters.bpf[0]" (input)="onBpfChange($event.target.value)"></textarea>
+    <textarea matInput rows="4" placeholder="Examples:
+tcp port 80
+host 192.168.1.1
+tcp dst port 443 and src portrange 1024-65535" [value]="filters.bpf[0]" (input)="onBpfChange($event.target.value)"></textarea>
   </mat-form-field>
 </div>
 }

--- a/src/app/components/project-map/packet-capturing/packet-filters/packet-filters.component.html
+++ b/src/app/components/project-map/packet-capturing/packet-filters/packet-filters.component.html
@@ -1,46 +1,46 @@
 <h1 mat-dialog-title>Packet filters</h1>
 
 @if (this.filters) {
-<div class="modal-form-container content">
-  <mat-tab-group>
-    <mat-tab label="Frequency drop">
-      <mat-form-field class="input-field">
-        <input matInput placeholder="Frequency" type="number" [value]="filters.frequency_drop[0]" (input)="onFrequencyDropChange(+$event.target.value)" />
-      </mat-form-field>
-    </mat-tab>
-    <mat-tab label="Packet loss">
-      <mat-form-field class="input-field">
-        <input matInput placeholder="Chance" type="number" [value]="filters.packet_loss[0]" (input)="onPacketLossChange(+$event.target.value)" />
-      </mat-form-field>
-    </mat-tab>
-    <mat-tab label="Delay">
-      <mat-form-field class="input-field">
-        <input matInput placeholder="Latency" type="number" [value]="filters.delay[0]" (input)="onDelayLatencyChange(+$event.target.value)" />
-      </mat-form-field>
-      <mat-form-field class="input-field">
-        <input matInput placeholder="Jitter" type="number" [value]="filters.delay[1]" (input)="onDelayJitterChange(+$event.target.value)" />
-      </mat-form-field>
-    </mat-tab>
-    <mat-tab label="Corrupt">
-      <mat-form-field class="input-field">
-        <input matInput placeholder="Latency" type="number" [value]="filters.corrupt[0]" (input)="onCorruptChange(+$event.target.value)" />
-      </mat-form-field>
-    </mat-tab>
-    <mat-tab label="Berkeley Packet Filter (BPF)">
-      <mat-form-field class="input-field">
-        <textarea matInput type="text" [value]="filters.bpf[0]" (input)="onBpfChange($event.target.value)"></textarea>
-      </mat-form-field>
-    </mat-tab>
-  </mat-tab-group>
+<div mat-dialog-content>
+  <mat-form-field appearance="fill" class="full-width-field">
+    <mat-label>Frequency drop</mat-label>
+    <input matInput type="number" [value]="filters.frequency_drop[0]" (input)="onFrequencyDropChange(+$event.target.value)" />
+    <span matSuffix>packets</span>
+  </mat-form-field>
+
+  <mat-form-field appearance="fill" class="full-width-field">
+    <mat-label>Packet loss</mat-label>
+    <input matInput type="number" [value]="filters.packet_loss[0]" (input)="onPacketLossChange(+$event.target.value)" />
+    <span matSuffix>%</span>
+  </mat-form-field>
+
+  <mat-form-field appearance="fill" class="full-width-field">
+    <mat-label>Delay latency</mat-label>
+    <input matInput type="number" [value]="filters.delay[0]" (input)="onDelayLatencyChange(+$event.target.value)" />
+    <span matSuffix>ms</span>
+  </mat-form-field>
+
+  <mat-form-field appearance="fill" class="full-width-field">
+    <mat-label>Delay jitter</mat-label>
+    <input matInput type="number" [value]="filters.delay[1]" (input)="onDelayJitterChange(+$event.target.value)" />
+    <span matSuffix>ms</span>
+  </mat-form-field>
+
+  <mat-form-field appearance="fill" class="full-width-field">
+    <mat-label>Corrupt</mat-label>
+    <input matInput type="number" [value]="filters.corrupt[0]" (input)="onCorruptChange(+$event.target.value)" />
+    <span matSuffix>%</span>
+  </mat-form-field>
+
+  <mat-form-field appearance="fill" class="full-width-field">
+    <mat-label>Berkeley Packet Filter (BPF)</mat-label>
+    <textarea matInput [value]="filters.bpf[0]" (input)="onBpfChange($event.target.value)"></textarea>
+  </mat-form-field>
 </div>
 }
-<div class="bottom-bar">
-  <div class="spacer"></div>
-  <div mat-dialog-actions layout="row" class="dialog-actions">
-    <button mat-button (click)="onNoClick()" color="accent">Cancel</button>
-    <button mat-button (click)="onResetClick()" color="accent">Reset</button>
-    <button mat-button (click)="onYesClick()" tabindex="2" mat-raised-button color="primary">Apply</button>
-    <div class="divider"></div>
-    <button mat-button (click)="onHelpClick()" color="accent">Help</button>
-  </div>
+<div mat-dialog-actions align="end">
+  <button mat-button (click)="onNoClick()" color="accent">Cancel</button>
+  <button mat-button (click)="onResetClick()" color="accent">Reset</button>
+  <button mat-button (click)="onYesClick()" tabindex="2" mat-raised-button color="primary">Apply</button>
+  <button mat-button (click)="onHelpClick()" color="accent">Help</button>
 </div>

--- a/src/app/components/project-map/packet-capturing/packet-filters/packet-filters.component.scss
+++ b/src/app/components/project-map/packet-capturing/packet-filters/packet-filters.component.scss
@@ -5,9 +5,22 @@
  * Uses Material Design 3 appearance="fill" for form fields
  */
 
-// Form field spacing
-mat-form-field {
+// Two-column grid layout for filters - compact sizing for 500px dialog
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 12px 16px;
   margin-bottom: 16px;
+}
+
+// Limit form field width to prevent overly wide inputs
+.form-grid-column mat-form-field {
+  max-width: 220px;
+}
+
+// Form field spacing - more compact
+mat-form-field {
+  margin-bottom: 12px;
 
   &:last-child {
     margin-bottom: 0;

--- a/src/app/components/project-map/packet-capturing/packet-filters/packet-filters.component.scss
+++ b/src/app/components/project-map/packet-capturing/packet-filters/packet-filters.component.scss
@@ -1,72 +1,21 @@
 /**
  * GNS3 Packet Filters Component Styles
- * Using MD3 CSS variables
+ *
+ * Follows project dialog design language defined in src/styles/_dialogs.scss
+ * Uses Material Design 3 appearance="fill" for form fields
  */
 
-.spacer {
-  flex-grow: 1;
+// Form field spacing
+mat-form-field {
+  margin-bottom: 16px;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
 }
 
-.content {
-  height: 260px;
-}
-
-.item {
-  height: 25px;
-  font-size: 14px;
-  margin-bottom: 8px;
-}
-
-.item-name {
-  margin-bottom: 8px;
-}
-
-.item-value {
-  width: 100%;
-  margin-bottom: 8px;
-}
-
-.input-field {
-  width: 100%;
-  margin-top: 8px;
-}
-
-.divider {
-  width: fit-content;
-  flex: 1 1 auto;
-}
-
-.input-color {
-  padding: 0px;
-  border-width: 0px;
-  width: 100%;
-  background-color: transparent;
-  outline: none;
-}
-
-input:focus {
-  outline: none;
-}
-
-input[type='color'] {
-  -webkit-appearance: none;
-  border: none;
-  height: 25px;
-}
-
-input[type='color']::-webkit-color-swatch-wrapper {
-  padding: 0;
-}
-
-input[type='color']::-webkit-color-swatch {
-  border: none;
-}
-
-.modal-form-container {
-  display: flex;
-  flex-direction: column;
-}
-
-.modal-form-container > * {
+// Full width fields for consistent layout
+.full-width-field {
   width: 100%;
 }
+

--- a/src/app/components/project-map/packet-capturing/packet-filters/packet-filters.component.spec.ts
+++ b/src/app/components/project-map/packet-capturing/packet-filters/packet-filters.component.spec.ts
@@ -168,7 +168,7 @@ describe('PacketFiltersDialogComponent', () => {
       component.ngOnInit();
 
       expect(component.filters).toEqual({
-        bpf: [],
+        bpf: [''],
         corrupt: [0],
         delay: [0, 0],
         frequency_drop: [0],
@@ -220,7 +220,7 @@ describe('PacketFiltersDialogComponent', () => {
       component.onResetClick();
 
       expect(component.link.filters).toEqual({
-        bpf: [],
+        bpf: [''],
         corrupt: [0],
         delay: [0, 0],
         frequency_drop: [0],
@@ -336,7 +336,7 @@ describe('PacketFiltersDialogComponent', () => {
       mockLinkService.updateLink.mockReturnValue(throwError(() => new Error('Failed to reset filters')));
       const cdrSpy = vi.spyOn(component['cdr'], 'markForCheck');
       component.link = createMockLink();
-      component.filters = { bpf: [], corrupt: [0], delay: [0, 0], frequency_drop: [0], packet_loss: [0] };
+      component.filters = { bpf: [''], corrupt: [0], delay: [0, 0], frequency_drop: [0], packet_loss: [0] };
 
       component.onResetClick();
 

--- a/src/app/components/project-map/packet-capturing/packet-filters/packet-filters.component.ts
+++ b/src/app/components/project-map/packet-capturing/packet-filters/packet-filters.component.ts
@@ -3,7 +3,6 @@ import { CommonModule } from '@angular/common';
 import { MatDialogModule, MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
-import { MatTabsModule } from '@angular/material/tabs';
 import { MatButtonModule } from '@angular/material/button';
 import { Filter } from '@models/filter';
 import { FilterDescription } from '@models/filter-description';
@@ -25,7 +24,6 @@ import { ToasterService } from '@services/toaster.service';
     MatDialogModule,
     MatFormFieldModule,
     MatInputModule,
-    MatTabsModule,
     MatButtonModule,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/src/app/components/project-map/packet-capturing/packet-filters/packet-filters.component.ts
+++ b/src/app/components/project-map/packet-capturing/packet-filters/packet-filters.component.ts
@@ -121,7 +121,7 @@ export class PacketFiltersDialogComponent implements OnInit {
 
   onResetClick() {
     this.link.filters = {
-      bpf: [],
+      bpf: [''],
       corrupt: [0],
       delay: [0, 0],
       frequency_drop: [0],

--- a/src/app/components/project-map/packet-capturing/packet-filters/packet-filters.component.ts
+++ b/src/app/components/project-map/packet-capturing/packet-filters/packet-filters.component.ts
@@ -49,7 +49,7 @@ export class PacketFiltersDialogComponent implements OnInit {
       next: (link: Link) => {
         this.link = link;
         this.filters = {
-          bpf: [],
+          bpf: [''],
           corrupt: [0],
           delay: [0, 0],
           frequency_drop: [0],
@@ -57,7 +57,7 @@ export class PacketFiltersDialogComponent implements OnInit {
         };
 
         if (this.link.filters) {
-          this.filters.bpf = this.link.filters.bpf ? this.link.filters.bpf : [];
+          this.filters.bpf = this.link.filters.bpf ? this.link.filters.bpf : [''];
           this.filters.corrupt = this.link.filters.corrupt ? this.link.filters.corrupt : [0];
           this.filters.delay = this.link.filters.delay ? this.link.filters.delay : [0, 0];
           this.filters.frequency_drop = this.link.filters.frequency_drop ? this.link.filters.frequency_drop : [0];


### PR DESCRIPTION
## Summary
- Redesigned packet filters dialog from tabbed interface to vertical form layout
- All filter options now visible at once without tab switching
- Implemented two-column grid layout for better space utilization
- Updated to Material Design 3 with `appearance="fill"` form fields

## Changes
- Replaced `mat-tab-group` with two-column grid layout using CSS Grid
- Applied `mat-form-field appearance="fill"` to match project design language
- Used `<mat-label>` elements instead of placeholders for better accessibility
- Added unit suffixes (packets, %, ms) using `matSuffix` for better UX
- Separated Delay latency and jitter into individual fields
- BPF textarea spans full width with 4-line height
- Form fields limited to 220px max-width for compact display in 500px dialog
- Fixed BPF syntax examples: use `portrange` instead of invalid port range syntax
- Fixed undefined value issue in BPF field initialization
- Simplified component styles to rely on global dialog styles
- Removed unused `MatTabsModule` dependency

## Form Layout
**Left column**: Frequency drop, Packet loss, Corrupt  
**Right column**: Delay latency, Delay jitter  
**Bottom**: Berkeley Packet Filter (BPF) with examples

## BPF Examples
Three progressive examples provided in placeholder:
1. `tcp port 80` - Simple: TCP port 80
2. `host 192.168.1.1` - Medium: Specific host
3. `tcp dst port 443 and src portrange 1024-65535` - Complex: Combined conditions

## Design Consistency
This change aligns the packet filters dialog with the established design patterns used throughout the project, ensuring a consistent user experience across all configuration dialogs as defined in `src/styles/_dialogs.scss`.