### PR TITLE
feat: add download pcap button to inline Web Wireshark window

### DIFF
--- a/src/app/components/project-map/web-wireshark-inline/web-wireshark-inline.component.html
+++ b/src/app/components/project-map/web-wireshark-inline/web-wireshark-inline.component.html
@@ -40,6 +40,15 @@
       <div class="web-wireshark-inline-header__actions">
         <button
           mat-icon-button
+          class="download-button"
+          (click)="downloadPcapFile()"
+          title="Download pcap file"
+          [disabled]="isDownloading()"
+        >
+          <mat-icon [class.is-downloading]="isDownloading()">download</mat-icon>
+        </button>
+        <button
+          mat-icon-button
           class="restart-button"
           (click)="restartWireshark()"
           title="Restart Web Wireshark"

--- a/src/app/components/project-map/web-wireshark-inline/web-wireshark-inline.component.scss
+++ b/src/app/components/project-map/web-wireshark-inline/web-wireshark-inline.component.scss
@@ -101,7 +101,8 @@
       }
     }
 
-    .restart-button {
+    .restart-button,
+    .download-button {
       width: 24px;
       height: 24px;
       padding: 0;
@@ -132,7 +133,8 @@
         cursor: not-allowed;
       }
 
-      .restart-icon.is-spinning {
+      .restart-icon.is-spinning,
+      mat-icon.is-downloading {
         animation: spin 1s linear infinite;
       }
     }

--- a/src/app/components/project-map/web-wireshark-inline/web-wireshark-inline.component.ts
+++ b/src/app/components/project-map/web-wireshark-inline/web-wireshark-inline.component.ts
@@ -83,12 +83,14 @@ export class WebWiresharkInlineComponent implements OnInit, OnDestroy {
   private isLoadingSignal = signal(true);
   private isMinimizedSignal = signal(false);
   private isRestartingSignal = signal(false);
+  private isDownloadingSignal = signal(false);
 
   public readonly isDragging = this.isDraggingSignal.asReadonly();
   public readonly isResizing = this.isResizingSignal.asReadonly();
   public readonly isLoading = this.isLoadingSignal.asReadonly();
   public readonly isMinimized = this.isMinimizedSignal.asReadonly();
   public readonly isRestarting = this.isRestartingSignal.asReadonly();
+  public readonly isDownloading = this.isDownloadingSignal.asReadonly();
 
   // Wireshark URL
   public wiresharkUrl: SafeResourceUrl = '';
@@ -215,6 +217,43 @@ export class WebWiresharkInlineComponent implements OnInit, OnDestroy {
       error: (error) => {
         this.isRestartingSignal.set(false);
         this.toasterService.error(`Failed to restart Web Wireshark: ${error.message || error.detail || 'Unknown error'}`);
+        this.cdr.markForCheck();
+      },
+    });
+  }
+
+  /**
+   * Download pcap file
+   */
+  downloadPcapFile(): void {
+    if (this.isDownloadingSignal()) {
+      return;
+    }
+
+    this.isDownloadingSignal.set(true);
+    this.cdr.markForCheck();
+
+    this.linkService.downloadPcap(this.controller(), this.link()).subscribe({
+      next: (blob: Blob) => {
+        // Create download link and trigger download
+        const url = window.URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        const fileName = this.link().capture_file_name || 'capture';
+        a.download = fileName.endsWith('.pcap') ? fileName : `${fileName}.pcap`;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        window.URL.revokeObjectURL(url);
+
+        this.isDownloadingSignal.set(false);
+        this.toasterService.success('Pcap file downloaded successfully');
+        this.cdr.markForCheck();
+      },
+      error: (error) => {
+        this.isDownloadingSignal.set(false);
+        const message = error.error?.message || error.message || 'Failed to download pcap file';
+        this.toasterService.error(`Failed to download pcap file: ${message}`);
         this.cdr.markForCheck();
       },
     });

--- a/src/app/services/link.service.ts
+++ b/src/app/services/link.service.ts
@@ -141,4 +141,8 @@ export class LinkService {
   streamPcap(controller: Controller, link: Link) {
     return this.httpController.get(controller, `/projects/${link.project_id}/links/${link.link_id}/capture/stream`);
   }
+
+  downloadPcap(controller: Controller, link: Link) {
+    return this.httpController.getBlob(controller, `/projects/${link.project_id}/links/${link.link_id}/capture/file`);
+  }
 }


### PR DESCRIPTION
## Summary

Add download functionality to inline Web Wireshark window, allowing users to download captured packet files directly from the UI.

## Changes

- Add `downloadPcap()` method to `LinkService` using `/capture/file` endpoint
- Add download button to `WebWiresharkInlineComponent` header (placed before restart button)
- Implement `downloadPcapFile()` method with Blob handling and download triggering
- Add `isDownloading` state signal with loading animation
- Update button styles using Material Design 3 CSS variables

## Technical Details

- Uses `getBlob()` to receive binary pcap data from backend
- Properly handles file naming from `link.capture_file_name`
- Shows success/error toasts for download operations
- Zoneless-compatible with `markForCheck()` pattern
- Follows project CSS conventions (no hardcoded colors, BEM naming)