### PR TITLE
fix(console): Auto-start terminal and VNC console for all device types

### DIFF
--- a/src/app/components/project-map/context-menu/actions/console-device-action-browser/console-device-action-browser.component.spec.ts
+++ b/src/app/components/project-map/context-menu/actions/console-device-action-browser/console-device-action-browser.component.spec.ts
@@ -7,7 +7,6 @@ import { ConsoleDeviceActionBrowserComponent } from './console-device-action-bro
 import { NodeService } from '@services/node.service';
 import { ToasterService } from '@services/toaster.service';
 import { ProtocolHandlerService } from '@services/protocol-handler.service';
-import { VncConsoleService } from '@services/vnc-console.service';
 import { Controller } from '@models/controller';
 import { Node } from '../../../../../cartography/models/node';
 import { of, throwError } from 'rxjs';
@@ -18,7 +17,6 @@ describe('ConsoleDeviceActionBrowserComponent', () => {
   let mockNodeService: NodeService;
   let mockToasterService: ToasterService;
   let mockProtocolHandlerService: ProtocolHandlerService;
-  let mockVncConsoleService: VncConsoleService;
 
   const mockController: Controller = {
     id: 1,
@@ -144,17 +142,12 @@ describe('ConsoleDeviceActionBrowserComponent', () => {
       open: vi.fn(),
     } as any;
 
-    mockVncConsoleService = {
-      openVncConsole: vi.fn(),
-    } as any;
-
     await TestBed.configureTestingModule({
       imports: [ConsoleDeviceActionBrowserComponent, MatButtonModule, MatIconModule, MatMenuModule],
     })
       .overrideProvider(NodeService, { useValue: mockNodeService })
       .overrideProvider(ToasterService, { useValue: mockToasterService })
       .overrideProvider(ProtocolHandlerService, { useValue: mockProtocolHandlerService })
-      .overrideProvider(VncConsoleService, { useValue: mockVncConsoleService })
       .compileComponents();
 
     fixture = TestBed.createComponent(ConsoleDeviceActionBrowserComponent);
@@ -462,11 +455,14 @@ describe('ConsoleDeviceActionBrowserComponent', () => {
   });
 
   describe('startConsole() with vnc', () => {
-    it('should call VncConsoleService for vnc console type', () => {
+    it('should build correct gns3+vnc:// URI and call protocol handler', () => {
       const mockNode = createMockNode({
         console_type: 'vnc',
         console_host: '192.168.1.1',
         console: 5900,
+        name: 'VM1',
+        project_id: 'proj-1',
+        node_id: 'node-1',
       });
 
       fixture.componentRef.setInput('controller', mockController);
@@ -475,8 +471,9 @@ describe('ConsoleDeviceActionBrowserComponent', () => {
 
       component.startConsole(false);
 
-      expect(mockVncConsoleService.openVncConsole).toHaveBeenCalledWith(mockController, mockNode);
-      expect(mockProtocolHandlerService.open).not.toHaveBeenCalled();
+      expect(mockProtocolHandlerService.open).toHaveBeenCalledWith(
+        'gns3+vnc://192.168.1.1:5900?name=VM1&project_id=proj-1&node_id=node-1'
+      );
     });
   });
 

--- a/src/app/components/project-map/context-menu/actions/console-device-action-browser/console-device-action-browser.component.ts
+++ b/src/app/components/project-map/context-menu/actions/console-device-action-browser/console-device-action-browser.component.ts
@@ -8,7 +8,6 @@ import { Controller } from '@models/controller';
 import { NodeService } from '@services/node.service';
 import { ToasterService } from '@services/toaster.service';
 import { ProtocolHandlerService } from '@services/protocol-handler.service';
-import { VncConsoleService } from '@services/vnc-console.service';
 
 import * as ipaddr from 'ipaddr.js';
 
@@ -23,7 +22,6 @@ export class ConsoleDeviceActionBrowserComponent {
   private nodeService = inject(NodeService);
   private deviceService = inject(DeviceDetectorService);
   private protocolHandlerService = inject(ProtocolHandlerService);
-  private vncConsoleService = inject(VncConsoleService);
   private cd = inject(ChangeDetectorRef);
 
   readonly controller = input<Controller>(undefined);
@@ -80,9 +78,7 @@ export class ConsoleDeviceActionBrowserComponent {
           }
           uri = `gns3+${node.console_type}://${host}:${console_port}?name=${node.name}&project_id=${node.project_id}&node_id=${node.node_id}`;
         } else if (node.console_type === 'vnc') {
-          // Open VNC console in standalone page via WebSocket API
-          this.vncConsoleService.openVncConsole(this.controller(), node);
-          return; // Return early, don't use protocol handler
+          uri = `gns3+vnc://${host}:${node.console}?name=${node.name}&project_id=${node.project_id}&node_id=${node.node_id}`;
         } else if (node.console_type && node.console_type.startsWith('spice')) {
           uri = `gns3+spice://${host}:${node.console}?name=${node.name}&project_id=${node.project_id}&node_id=${node.node_id}`;
         } else if (node.console_type && node.console_type.startsWith('http')) {

--- a/src/app/components/project-map/project-map.component.ts
+++ b/src/app/components/project-map/project-map.component.ts
@@ -465,6 +465,20 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
         if (value) this.applyScalingOfNodeSymbols();
       })
     );
+
+    this.projectMapSubscription.add(
+      this.projectWebServiceHandler.nodeNotificationEmitter.subscribe((message) => {
+        if (message.action !== 'node.updated') return;
+        const node = message.event as Node;
+        if (node.status !== 'started' || !node.console_auto_start || node.console_type === 'none') return;
+        if (node.console_type === 'vnc') {
+          setTimeout(() => this.onOpenWebConsoleInline({ node, controller: this.controller, project: this.project }), 500);
+        } else {
+          this.mapSettingsService.logConsoleSubject.next(true);
+          setTimeout(() => this.nodeConsoleService.openConsoleForNode(node), 500);
+        }
+      })
+    );
   }
 
   applyScalingOfNodeSymbols() {

--- a/src/app/components/project-map/project-map.component.ts
+++ b/src/app/components/project-map/project-map.component.ts
@@ -245,6 +245,7 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
   readonly templateComponent = viewChild(TemplateComponent);
 
   private projectMapSubscription: Subscription = new Subscription();
+  private startedNodeIds = new Set<string>();
 
   private route = inject(ActivatedRoute);
   private controllerService = inject(ControllerService);
@@ -470,7 +471,14 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
       this.projectWebServiceHandler.nodeNotificationEmitter.subscribe((message) => {
         if (message.action !== 'node.updated') return;
         const node = message.event as Node;
-        if (node.status !== 'started' || !node.console_auto_start || node.console_type === 'none') return;
+        const wasStarted = this.startedNodeIds.has(node.node_id);
+        if (node.status === 'started') {
+          this.startedNodeIds.add(node.node_id);
+        } else {
+          this.startedNodeIds.delete(node.node_id);
+        }
+        // Only open console on the transition from non-started to started
+        if (wasStarted || node.status !== 'started' || !node.console_auto_start || node.console_type === 'none') return;
         if (node.console_type === 'vnc') {
           setTimeout(() => this.onOpenWebConsoleInline({ node, controller: this.controller, project: this.project }), 500);
         } else {
@@ -700,6 +708,7 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
       .pipe(
         mergeMap((nodes: Node[]) => {
           this.nodesDataSource.set(nodes);
+          nodes.filter((n) => n.status === 'started').forEach((n) => this.startedNodeIds.add(n.node_id));
           return this.projectService.links(this.controller, project.project_id);
         }),
         mergeMap((links: Link[]) => {
@@ -1655,5 +1664,6 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
       if (this.ws.OPEN) this.ws.close();
     }
     this.projectMapSubscription.unsubscribe();
+    this.startedNodeIds.clear();
   }
 }


### PR DESCRIPTION
### Problem

####  Auto-start console does not work for Docker containers (VNC nodes) and nodes using telnet/ssh console type

The `console_auto_start` field was already supported in the server API, the node model, and the node configurator UI, but nothing in the Angular client acted on it at runtime. 

All nodes types using telnet/ssh console protocol or VNC console are affected.
