### PR TITLE
Replace crypto.randomUUID() with uuid library for HTTP compatibility

### DIFF
--- a/src/app/components/projects/import-project-dialog/import-project-dialog.component.ts
+++ b/src/app/components/projects/import-project-dialog/import-project-dialog.component.ts
@@ -8,6 +8,7 @@ import { MatInputModule } from '@angular/material/input';
 import { MatIconModule } from '@angular/material/icon';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { v4 as uuid } from 'uuid';
 import { ToasterService } from '@services/toaster.service';
 import { FileItem, FileUploader, ParsedResponseHeaders, FileUploadModule } from 'ng2-file-upload';
 import { Project } from '@models/project';
@@ -215,7 +216,7 @@ export class ImportProjectDialogComponent implements OnInit {
   }
 
   prepareUploadPath(): string {
-    this.uuid.set(crypto.randomUUID());
+    this.uuid.set(uuid());
     const projectName = this.projectName().trim();
     return this.projectService.getUploadPath(this.controller, this.uuid(), projectName);
   }

--- a/src/app/components/projects/save-project-dialog/save-project-dialog.component.ts
+++ b/src/app/components/projects/save-project-dialog/save-project-dialog.component.ts
@@ -40,7 +40,6 @@ export class SaveProjectDialogComponent {
   project: Project;
 
   readonly projectName = model('');
-  readonly uuid = signal('');
   readonly isCheckingName = signal(false);
   readonly nameExistsError = signal(false);
 
@@ -110,8 +109,6 @@ export class SaveProjectDialogComponent {
   }
 
   private addProject(): void {
-    this.uuid.set(crypto.randomUUID());
-
     this.projectService
       .duplicate(this.controller, this.project.project_id, this.projectName().trim())
       .subscribe({


### PR DESCRIPTION
## Summary

This PR addresses a critical compatibility issue where `crypto.randomUUID()` fails in non-secure HTTP contexts (e.g., `http://192.168.1.3:3080`), throwing `TypeError: crypto.randomUUID is not a function`.

## Changes

- **ImportProjectDialog**: Replace `crypto.randomUUID()` with `uuid()` library
- **SaveProjectDialog**: Remove unused UUID generation code (dead code cleanup)

## Why This Matters

The native `crypto.randomUUID()` API only works in secure contexts (HTTPS/localhost). GNS3 Web UI is commonly accessed via HTTP in network environments, causing project import functionality to break. The `uuid` library provides consistent UUID generation across all environments.

## Testing

- Project import works in both HTTP and HTTPS environments
- Save Project As functionality unchanged (backend generates UUID)

## Related

All other components already use `uuid()` library. This completes the migration away from `crypto.randomUUID()`.