### PR TITLE
Remove running nodes restriction in save project dialog

### DIFF
--- a/src/app/components/projects/save-project-dialog/save-project-dialog.component.spec.ts
+++ b/src/app/components/projects/save-project-dialog/save-project-dialog.component.spec.ts
@@ -4,7 +4,6 @@ import { of, throwError } from 'rxjs';
 import { SaveProjectDialogComponent } from './save-project-dialog.component';
 import { ProjectService } from '@services/project.service';
 import { ToasterService } from '@services/toaster.service';
-import { NodesDataSource } from '../../../cartography/datasources/nodes-datasource';
 import { Project } from '@models/project';
 import { Controller } from '@models/controller';
 import { ProjectNameValidator } from '../models/projectNameValidator';
@@ -15,7 +14,6 @@ describe('SaveProjectDialogComponent', () => {
   let component: SaveProjectDialogComponent;
   let mockDialogRef: any;
   let mockProjectService: any;
-  let mockNodesDataSource: any;
   let mockToasterService: any;
   let mockController: Controller;
   let mockProject: Project;
@@ -61,7 +59,6 @@ describe('SaveProjectDialogComponent', () => {
       list: vi.fn().mockReturnValue(of([])),
       duplicate: vi.fn().mockReturnValue(of(createMockProject('New Project', 'proj2'))),
     };
-    mockNodesDataSource = { getItems: vi.fn().mockReturnValue([]) };
     mockToasterService = { success: vi.fn(), error: vi.fn() };
     mockValidator = { get: vi.fn().mockReturnValue(null) };
 
@@ -109,7 +106,6 @@ describe('SaveProjectDialogComponent', () => {
       providers: [
         { provide: MatDialogRef, useValue: mockDialogRef },
         { provide: ProjectService, useValue: mockProjectService },
-        { provide: NodesDataSource, useValue: mockNodesDataSource },
         { provide: ToasterService, useValue: mockToasterService },
         { provide: ProjectNameValidator, useValue: mockValidator },
       ],
@@ -197,20 +193,6 @@ describe('SaveProjectDialogComponent', () => {
       await vi.runAllTimersAsync();
 
       expect(mockToasterService.error).toHaveBeenCalledWith('Project with this name already exists.');
-      expect(mockProjectService.duplicate).not.toHaveBeenCalled();
-    });
-
-    it('should show error when running nodes exist', async () => {
-      mockProjectService.list.mockReturnValue(of([]));
-      mockNodesDataSource.getItems.mockReturnValue([
-        { status: 'started', node_type: 'vpcs' },
-      ]);
-
-      component.projectName.set('NewProject');
-      component.onAddClick();
-      await vi.runAllTimersAsync();
-
-      expect(mockToasterService.error).toHaveBeenCalledWith('Please stop all nodes in order to save project.');
       expect(mockProjectService.duplicate).not.toHaveBeenCalled();
     });
 

--- a/src/app/components/projects/save-project-dialog/save-project-dialog.component.ts
+++ b/src/app/components/projects/save-project-dialog/save-project-dialog.component.ts
@@ -6,7 +6,6 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
-import { NodesDataSource } from '../../../cartography/datasources/nodes-datasource';
 import { Project } from '@models/project';
 import { Controller } from '@models/controller';
 import { ProjectService } from '@services/project.service';
@@ -32,7 +31,6 @@ import { ProjectNameValidator } from '../models/projectNameValidator';
 export class SaveProjectDialogComponent {
   private readonly dialogRef = inject(MatDialogRef<SaveProjectDialogComponent>);
   private readonly projectService = inject(ProjectService);
-  private readonly nodesDataSource = inject(NodesDataSource);
   private readonly toasterService = inject(ToasterService);
   private readonly projectNameValidator = inject(ProjectNameValidator);
 
@@ -95,8 +93,6 @@ export class SaveProjectDialogComponent {
         if (existingProject) {
           this.nameExistsError.set(true);
           this.toasterService.error('Project with this name already exists.');
-        } else if (this.hasRunningNodes()) {
-          this.toasterService.error('Please stop all nodes in order to save project.');
         } else {
           this.addProject();
         }
@@ -127,16 +123,4 @@ export class SaveProjectDialogComponent {
       });
   }
 
-  private hasRunningNodes(): boolean {
-    return (
-      this.nodesDataSource
-        .getItems()
-        .filter(
-          (node) =>
-            (node.status === 'started' && node.node_type === 'vpcs') ||
-            (node.status === 'started' && node.node_type === 'virtualbox') ||
-            (node.status === 'started' && node.node_type === 'vmware')
-        ).length > 0
-    );
-  }
 }


### PR DESCRIPTION
## Summary

Remove a 5-year-old restriction that prevented users from saving projects when nodes were running. This was an artificial frontend limitation that only checked 3 out of many node types.

## Changes

- **Remove hasRunningNodes() method** - Only checked VPCS, VirtualBox, and VMware nodes
- **Remove NodesDataSource dependency** - No longer needed
- **Remove running nodes check** in `checkProjectNameExists()` 
- **Update tests** - Remove running nodes test case

## Why This Matters

1. **Inconsistent check** - Only blocked 3 node types (VPCS, VirtualBox, VMware) but allowed Docker, QEMU, Dynamips, IOU, etc.
2. **Artificial limitation** - Backend API has no such restriction
3. **User experience** - Prevented legitimate use cases without technical reason
4. **Age** - Added in 2019, likely outdated for current infrastructure

## Related

GNS3 server: #2767 - https://github.com/GNS3/gns3-server/pull/2767

## Backend Confirmation

The `POST /projects/{project_id}/duplicate` API has no checks for running nodes, confirming this was purely a frontend restriction.