### PR TITLE
feat: add Hide Management Link dialog and context menu positioning fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 /scripts/build
 /scripts/dist
 /env
+/.local-node18
 
 # dependencies
 /node_modules

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "ipaddr.js": "^2.1.0",
     "material-design-icons": "^3.0.1",
     "mousetrap": "^1.6.5",
-    "ng-circle-progress": "^1.6.0",
+    "ng-circle-progress": "1.6.0",
     "ng2-file-upload": "^1.4.0",
     "ngx-childprocess": "^0.0.6",
     "ngx-device-detector": "^2.1.1",
@@ -134,5 +134,9 @@
       "typescript"
     ]
   },
-  "snyk": true
+  "snyk": true,
+  "resolutions": {
+    "electron": "13.6.9",
+    "ng-circle-progress": "1.6.0"
+  }
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -144,6 +144,7 @@ import { StyleEditorDialogComponent } from './components/project-map/drawings-ed
 import { TextEditorDialogComponent } from './components/project-map/drawings-editors/text-editor/text-editor.component';
 import { HelpDialogComponent } from './components/project-map/help-dialog/help-dialog.component';
 import { NodeCreatedLabelStylesFixer } from './components/project-map/helpers/node-created-label-styles-fixer';
+import { HideManagementLinksDialogComponent } from './components/project-map/hide-management-links-dialog/hide-management-links-dialog.component';
 import { ImportApplianceComponent } from './components/project-map/import-appliance/import-appliance.component';
 import { InfoDialogComponent } from './components/project-map/info-dialog/info-dialog.component';
 import { LogConsoleComponent } from './components/project-map/log-console/log-console.component';
@@ -447,6 +448,7 @@ import { RotationValidator } from './validators/rotation-validator';
     ConsoleWrapperComponent,
     HttpConsoleNewTabActionComponent,
     WebConsoleFullWindowComponent,
+    HideManagementLinksDialogComponent,
     NewTemplateDialogComponent,
     ChangeHostnameActionComponent,
     ChangeHostnameDialogComponent,
@@ -594,6 +596,7 @@ import { RotationValidator } from './validators/rotation-validator';
     ConfigDialogComponent,
     AdbutlerComponent,
     NewTemplateDialogComponent,
+    HideManagementLinksDialogComponent,
     ChangeHostnameDialogComponent,
     ApplianceInfoDialogComponent,
     ConfigureCustomAdaptersDialogComponent,

--- a/src/app/components/project-map/context-menu/context-menu.component.scss
+++ b/src/app/components/project-map/context-menu/context-menu.component.scss
@@ -1,5 +1,5 @@
 .context-menu {
-  position: absolute;
+  position: fixed;
   min-height: 0px;
 }
 

--- a/src/app/components/project-map/hide-management-links-dialog/hide-management-links-dialog.component.html
+++ b/src/app/components/project-map/hide-management-links-dialog/hide-management-links-dialog.component.html
@@ -1,0 +1,22 @@
+<h1 mat-dialog-title>Hide Management Link</h1>
+
+<div mat-dialog-content class="hide-management-links-dialog">
+  <mat-form-field class="search-field">
+    <input matInput placeholder="Search devices" [(ngModel)]="searchText" (ngModelChange)="filterNodes()" />
+  </mat-form-field>
+
+  <mat-selection-list class="nodes-list">
+    <mat-list-option
+      *ngFor="let node of filteredNodes"
+      [selected]="isSelected(node.node_id)"
+      (selectionChange)="toggleNode(node.node_id, $event.source.selected)"
+    >
+      {{ node.name }}
+    </mat-list-option>
+  </mat-selection-list>
+</div>
+
+<div mat-dialog-actions>
+  <button mat-button (click)="onCancelClick()" color="accent">Cancel</button>
+  <button mat-button (click)="onApplyClick()" mat-raised-button color="primary">Apply</button>
+</div>

--- a/src/app/components/project-map/hide-management-links-dialog/hide-management-links-dialog.component.html
+++ b/src/app/components/project-map/hide-management-links-dialog/hide-management-links-dialog.component.html
@@ -5,15 +5,13 @@
     <input matInput placeholder="Search devices" [(ngModel)]="searchText" (ngModelChange)="filterNodes()" />
   </mat-form-field>
 
-  <mat-selection-list class="nodes-list">
-    <mat-list-option
-      *ngFor="let node of filteredNodes"
-      [selected]="isSelected(node.node_id)"
-      (selectionChange)="toggleNode(node.node_id, $event.source.selected)"
-    >
-      {{ node.name }}
-    </mat-list-option>
-  </mat-selection-list>
+  <mat-form-field class="devices-field">
+    <mat-select placeholder="Devices" multiple [(ngModel)]="selectedNodeIds">
+      <mat-option *ngFor="let node of filteredNodes" [value]="node.node_id">{{ node.name }}</mat-option>
+    </mat-select>
+  </mat-form-field>
+
+  <div class="selection-count">{{ selectedNodeIds.length }} selected</div>
 </div>
 
 <div mat-dialog-actions>

--- a/src/app/components/project-map/hide-management-links-dialog/hide-management-links-dialog.component.scss
+++ b/src/app/components/project-map/hide-management-links-dialog/hide-management-links-dialog.component.scss
@@ -1,0 +1,12 @@
+.hide-management-links-dialog {
+  min-width: 360px;
+}
+
+.search-field {
+  width: 100%;
+}
+
+.nodes-list {
+  max-height: 320px;
+  overflow: auto;
+}

--- a/src/app/components/project-map/hide-management-links-dialog/hide-management-links-dialog.component.scss
+++ b/src/app/components/project-map/hide-management-links-dialog/hide-management-links-dialog.component.scss
@@ -6,7 +6,11 @@
   width: 100%;
 }
 
-.nodes-list {
-  max-height: 320px;
-  overflow: auto;
+.devices-field {
+  width: 100%;
+}
+
+.selection-count {
+  margin-top: 8px;
+  opacity: 0.7;
 }

--- a/src/app/components/project-map/hide-management-links-dialog/hide-management-links-dialog.component.ts
+++ b/src/app/components/project-map/hide-management-links-dialog/hide-management-links-dialog.component.ts
@@ -1,0 +1,58 @@
+import { Component, Inject, OnInit } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { Node } from '../../../cartography/models/node';
+
+export interface HideManagementLinksDialogData {
+  nodes: Node[];
+  selectedNodeIds: string[];
+}
+
+@Component({
+  selector: 'app-hide-management-links-dialog',
+  templateUrl: './hide-management-links-dialog.component.html',
+  styleUrls: ['./hide-management-links-dialog.component.scss'],
+})
+export class HideManagementLinksDialogComponent implements OnInit {
+  nodes: Node[] = [];
+  filteredNodes: Node[] = [];
+  selectedNodeIds: string[] = [];
+  searchText = '';
+
+  constructor(
+    public dialogRef: MatDialogRef<HideManagementLinksDialogComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: HideManagementLinksDialogData
+  ) {}
+
+  ngOnInit() {
+    this.nodes = this.data.nodes.slice().sort((first, second) => first.name.localeCompare(second.name));
+    this.selectedNodeIds = [...this.data.selectedNodeIds];
+    this.filterNodes();
+  }
+
+  filterNodes() {
+    const search = this.searchText.toLowerCase();
+    this.filteredNodes = this.nodes.filter((node) => node.name.toLowerCase().includes(search));
+  }
+
+  toggleNode(nodeId: string, selected: boolean) {
+    if (selected && !this.selectedNodeIds.includes(nodeId)) {
+      this.selectedNodeIds.push(nodeId);
+    }
+
+    if (!selected) {
+      this.selectedNodeIds = this.selectedNodeIds.filter((id) => id !== nodeId);
+    }
+  }
+
+  isSelected(nodeId: string) {
+    return this.selectedNodeIds.includes(nodeId);
+  }
+
+  onCancelClick() {
+    this.dialogRef.close();
+  }
+
+  onApplyClick() {
+    this.dialogRef.close(this.selectedNodeIds);
+  }
+}

--- a/src/app/components/project-map/hide-management-links-dialog/hide-management-links-dialog.component.ts
+++ b/src/app/components/project-map/hide-management-links-dialog/hide-management-links-dialog.component.ts
@@ -34,20 +34,6 @@ export class HideManagementLinksDialogComponent implements OnInit {
     this.filteredNodes = this.nodes.filter((node) => node.name.toLowerCase().includes(search));
   }
 
-  toggleNode(nodeId: string, selected: boolean) {
-    if (selected && !this.selectedNodeIds.includes(nodeId)) {
-      this.selectedNodeIds.push(nodeId);
-    }
-
-    if (!selected) {
-      this.selectedNodeIds = this.selectedNodeIds.filter((id) => id !== nodeId);
-    }
-  }
-
-  isSelected(nodeId: string) {
-    return this.selectedNodeIds.includes(nodeId);
-  }
-
   onCancelClick() {
     this.dialogRef.close();
   }

--- a/src/app/components/project-map/project-map.component.html
+++ b/src/app/components/project-map/project-map.component.html
@@ -5,7 +5,7 @@
     [project]="project"
     [symbols]="symbols"
     [nodes]="nodes"
-    [links]="links"
+    [links]="visibleLinks"
     [drawings]="drawings"
     [width]="project.scene_width"
     [height]="project.scene_height"
@@ -22,7 +22,7 @@
     *ngIf="settings.angular_map"
     [symbols]="symbols"
     [nodes]="nodes"
-    [links]="links"
+    [links]="visibleLinks"
     [drawings]="drawings"
     [width]="project.scene_width"
     [height]="project.scene_height"
@@ -171,6 +171,9 @@
         ><br />
         <mat-checkbox [ngModel]="symbolScaling" (change)="toggleSymbolScaling($event.checked)">
           Scale symbols </mat-checkbox
+        ><br />
+        <mat-checkbox [ngModel]="hideManagementLinks" (change)="toggleHideManagementLinks($event.checked)">
+          Hide Management Link </mat-checkbox
         ><br />
       </div>
     </mat-menu>

--- a/src/app/components/project-map/project-map.component.ts
+++ b/src/app/components/project-map/project-map.component.ts
@@ -271,10 +271,7 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
         });
 
         this.nodes = nodes;
-        this.restoreHideManagementLinks();
-        this.restoreHiddenLinksNodes();
         this.nodesWithHiddenLinks = this.nodesWithHiddenLinks.filter((nodeId) => nodes.some((node) => node.node_id === nodeId));
-        this.persistHideManagementLinks();
         this.persistHiddenLinksNodes();
         this.updateVisibleLinks();
         if (this.mapSettingsService.getSymbolScaling()) this.applyScalingOfNodeSymbols();
@@ -569,8 +566,14 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
           return this.projectService.drawings(this.server, project.project_id);
         })
       )
-      .subscribe((drawings: Drawing[]) => {
+          .subscribe((drawings: Drawing[]) => {
         this.drawingsDataSource.set(drawings);
+
+        this.restoreHideManagementLinks();
+        this.restoreHiddenLinksNodes();
+        this.persistHideManagementLinks();
+        this.persistHiddenLinksNodes();
+        this.updateVisibleLinks();
 
         this.setUpMapCallbacks();
         this.setUpProjectWS(project);

--- a/src/app/components/project-map/project-map.component.ts
+++ b/src/app/components/project-map/project-map.component.ts
@@ -324,18 +324,28 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
     this.nodesWithHiddenLinks = nodeIds;
     this.persistHiddenLinksNodes();
     this.updateVisibleLinks();
+    this.cd.detectChanges();
     this.mapChangeDetectorRef.detectChanges();
   }
 
   updateVisibleLinks() {
     if (!this.hideManagementLinks || this.nodesWithHiddenLinks.length === 0) {
       this.visibleLinks = this.links;
+      this.refreshVisibleLinks();
       return;
     }
 
     this.visibleLinks = this.links.filter((link) => {
       return !link.nodes.some((node) => this.nodesWithHiddenLinks.includes(node.node_id));
     });
+    this.refreshVisibleLinks();
+  }
+
+  refreshVisibleLinks() {
+    if (this.mapChild) {
+      this.mapChild.links = this.visibleLinks;
+      this.mapChild.applyMapSettingsChanges();
+    }
   }
 
   getHideManagementLinksStorageKey() {
@@ -392,6 +402,7 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
     }
 
     this.updateVisibleLinks();
+    this.cd.detectChanges();
     this.mapChangeDetectorRef.detectChanges();
   }
 
@@ -573,6 +584,12 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
         this.persistHideManagementLinks();
         this.persistHiddenLinksNodes();
         this.updateVisibleLinks();
+        this.cd.detectChanges();
+        this.mapChangeDetectorRef.detectChanges();
+
+        if (this.hideManagementLinks && this.nodesWithHiddenLinks.length === 0) {
+          this.openHideManagementLinksDialog();
+        }
 
         this.setUpMapCallbacks();
         this.setUpProjectWS(project);

--- a/src/app/components/project-map/project-map.component.ts
+++ b/src/app/components/project-map/project-map.component.ts
@@ -78,6 +78,7 @@ import { NodeAddedEvent } from '../template/template-list-dialog/template-list-d
 import { TopologySummaryComponent } from '../topology-summary/topology-summary.component';
 import { ContextMenuComponent } from './context-menu/context-menu.component';
 import { NodeCreatedLabelStylesFixer } from './helpers/node-created-label-styles-fixer';
+import { HideManagementLinksDialogComponent } from './hide-management-links-dialog/hide-management-links-dialog.component';
 import { NewTemplateDialogComponent } from './new-template-dialog/new-template-dialog.component';
 import { ProjectMapMenuComponent } from './project-map-menu/project-map-menu.component';
 
@@ -90,6 +91,7 @@ import { ProjectMapMenuComponent } from './project-map-menu/project-map-menu.com
 export class ProjectMapComponent implements OnInit, OnDestroy {
   public nodes: Node[] = [];
   public links: Link[] = [];
+  public visibleLinks: Link[] = [];
   public drawings: Drawing[] = [];
   public symbols: Symbol[] = [];
   public project: Project;
@@ -105,6 +107,10 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
   public gridVisibility: boolean = false;
   public toolbarVisibility: boolean = true;
   public symbolScaling: boolean = true;
+  public hideManagementLinks: boolean = false;
+  public nodesWithHiddenLinks: string[] = [];
+  private readonly hideManagementLinksStorageKeyPrefix = 'hideManagementLinks';
+  private readonly hiddenLinksStorageKeyPrefix = 'hiddenLinksConnectedTo';
   private instance: ComponentRef<TopologySummaryComponent>;
 
   tools = {
@@ -212,8 +218,11 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
 
     this.settings = this.settingsService.getAll();
     this.symbolScaling = this.mapSettingsService.getSymbolScaling();
-    this.isConsoleVisible = this.mapSettingsService.isLogConsoleVisible;
+    this.isConsoleVisible = localStorage.getItem('showConsole') === 'true' ? true : false;
+    this.mapSettingsService.toggleLogConsole(this.isConsoleVisible);
     this.mapSettingsService.logConsoleSubject.subscribe((value) => (this.isConsoleVisible = value));
+    this.isTopologySummaryVisible = localStorage.getItem('showTopologySummary') === 'false' ? false : true;
+    this.mapSettingsService.toggleTopologySummary(this.isTopologySummaryVisible);
     this.notificationsVisibility = localStorage.getItem('notificationsVisibility') === 'true' ? true : false;
     this.layersVisibility = localStorage.getItem('layersVisibility') === 'true' ? true : false;
     this.gridVisibility = localStorage.getItem('gridVisibility') === 'true' ? true : false;
@@ -262,6 +271,12 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
         });
 
         this.nodes = nodes;
+        this.restoreHideManagementLinks();
+        this.restoreHiddenLinksNodes();
+        this.nodesWithHiddenLinks = this.nodesWithHiddenLinks.filter((nodeId) => nodes.some((node) => node.node_id === nodeId));
+        this.persistHideManagementLinks();
+        this.persistHiddenLinksNodes();
+        this.updateVisibleLinks();
         if (this.mapSettingsService.getSymbolScaling()) this.applyScalingOfNodeSymbols();
         this.mapChangeDetectorRef.detectChanges();
       })
@@ -270,6 +285,7 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
     this.projectMapSubscription.add(
       this.linksDataSource.changes.subscribe((links: Link[]) => {
         this.links = links;
+        this.updateVisibleLinks();
         this.mapChangeDetectorRef.detectChanges();
       })
     );
@@ -306,6 +322,106 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
         node.width = newDimensions.width;
         node.height = newDimensions.height;
       }
+    });
+  }
+
+  updateHiddenLinksNodes(nodeIds: string[]) {
+    this.nodesWithHiddenLinks = nodeIds;
+    this.persistHiddenLinksNodes();
+    this.updateVisibleLinks();
+    this.mapChangeDetectorRef.detectChanges();
+  }
+
+  updateVisibleLinks() {
+    if (!this.hideManagementLinks || this.nodesWithHiddenLinks.length === 0) {
+      this.visibleLinks = this.links;
+      return;
+    }
+
+    this.visibleLinks = this.links.filter((link) => {
+      return !link.nodes.some((node) => this.nodesWithHiddenLinks.includes(node.node_id));
+    });
+  }
+
+  getHideManagementLinksStorageKey() {
+    return `${this.hideManagementLinksStorageKeyPrefix}-${this.project.project_id}`;
+  }
+
+  getHiddenLinksStorageKey() {
+    return `${this.hiddenLinksStorageKeyPrefix}-${this.project.project_id}`;
+  }
+
+  restoreHideManagementLinks() {
+    if (!this.project) return;
+
+    this.hideManagementLinks = localStorage.getItem(this.getHideManagementLinksStorageKey()) === 'true';
+  }
+
+  persistHideManagementLinks() {
+    if (!this.project) return;
+
+    localStorage.setItem(this.getHideManagementLinksStorageKey(), this.hideManagementLinks ? 'true' : 'false');
+  }
+
+  restoreHiddenLinksNodes() {
+    if (!this.project) return;
+
+    const hiddenNodes = localStorage.getItem(this.getHiddenLinksStorageKey());
+    if (!hiddenNodes) return;
+
+    try {
+      this.nodesWithHiddenLinks = JSON.parse(hiddenNodes);
+    } catch (error) {
+      this.nodesWithHiddenLinks = [];
+      localStorage.removeItem(this.getHiddenLinksStorageKey());
+    }
+  }
+
+  persistHiddenLinksNodes() {
+    if (!this.project) return;
+
+    if (this.nodesWithHiddenLinks.length === 0) {
+      localStorage.removeItem(this.getHiddenLinksStorageKey());
+      return;
+    }
+
+    localStorage.setItem(this.getHiddenLinksStorageKey(), JSON.stringify(this.nodesWithHiddenLinks));
+  }
+
+  toggleHideManagementLinks(enabled: boolean) {
+    this.hideManagementLinks = enabled;
+    this.persistHideManagementLinks();
+
+    if (enabled) {
+      this.openHideManagementLinksDialog();
+    }
+
+    this.updateVisibleLinks();
+    this.mapChangeDetectorRef.detectChanges();
+  }
+
+  openHideManagementLinksDialog() {
+    const dialogRef = this.dialog.open(HideManagementLinksDialogComponent, {
+      width: '420px',
+      autoFocus: false,
+      data: {
+        nodes: this.nodes,
+        selectedNodeIds: this.nodesWithHiddenLinks,
+      },
+    });
+
+    dialogRef.afterClosed().subscribe((nodeIds: string[]) => {
+      if (!nodeIds) {
+        if (this.nodesWithHiddenLinks.length === 0) {
+          this.hideManagementLinks = false;
+          this.persistHideManagementLinks();
+          this.updateVisibleLinks();
+          this.mapChangeDetectorRef.detectChanges();
+        }
+        return;
+      }
+
+      this.updateHiddenLinksNodes(nodeIds);
     });
   }
 
@@ -487,44 +603,51 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
 
     const onLinkContextMenu = this.linkWidget.onContextMenu.subscribe((eventLink: LinkContextMenu) => {
       const link = this.mapLinkToLink.convert(eventLink.link);
-      this.contextMenu.openMenuForListOfElements([], [], [], [link], eventLink.event.pageY, eventLink.event.pageX);
+      const position = this.getContextMenuPosition(eventLink.event);
+      this.contextMenu.openMenuForListOfElements([], [], [], [link], position.top, position.left);
     });
 
     const onEthernetLinkContextMenu = this.ethernetLinkWidget.onContextMenu.subscribe((eventLink: LinkContextMenu) => {
       const link = this.mapLinkToLink.convert(eventLink.link);
-      this.contextMenu.openMenuForListOfElements([], [], [], [link], eventLink.event.pageY, eventLink.event.pageX);
+      const position = this.getContextMenuPosition(eventLink.event);
+      this.contextMenu.openMenuForListOfElements([], [], [], [link], position.top, position.left);
     });
 
     const onSerialLinkContextMenu = this.serialLinkWidget.onContextMenu.subscribe((eventLink: LinkContextMenu) => {
       const link = this.mapLinkToLink.convert(eventLink.link);
-      this.contextMenu.openMenuForListOfElements([], [], [], [link], eventLink.event.pageY, eventLink.event.pageX);
+      const position = this.getContextMenuPosition(eventLink.event);
+      this.contextMenu.openMenuForListOfElements([], [], [], [link], position.top, position.left);
     });
 
     const onNodeContextMenu = this.nodeWidget.onContextMenu.subscribe((eventNode: NodeContextMenu) => {
       const node = this.mapNodeToNode.convert(eventNode.node);
-      this.contextMenu.openMenuForNode(node, eventNode.event.pageY, eventNode.event.pageX);
+      const position = this.getContextMenuPosition(eventNode.event);
+      this.contextMenu.openMenuForNode(node, position.top, position.left);
     });
 
     const onDrawingContextMenu = this.drawingsWidget.onContextMenu.subscribe((eventDrawing: DrawingContextMenu) => {
       const drawing = this.mapDrawingToDrawing.convert(eventDrawing.drawing);
-      this.contextMenu.openMenuForDrawing(drawing, eventDrawing.event.pageY, eventDrawing.event.pageX);
+      const position = this.getContextMenuPosition(eventDrawing.event);
+      this.contextMenu.openMenuForDrawing(drawing, position.top, position.left);
     });
 
     const onLabelContextMenu = this.labelWidget.onContextMenu.subscribe((eventLabel: LabelContextMenu) => {
       const label = this.mapLabelToLabel.convert(eventLabel.label);
       const node = this.nodes.find((n) => n.node_id === eventLabel.label.nodeId);
-      this.contextMenu.openMenuForLabel(label, node, eventLabel.event.screenY - 60, eventLabel.event.screenX);
+      const position = this.getContextMenuPosition(eventLabel.event);
+      this.contextMenu.openMenuForLabel(label, node, position.top, position.left);
     });
 
     const onInterfaceLabelContextMenu = this.interfaceLabelWidget.onContextMenu.subscribe(
       (eventInterfaceLabel: InterfaceLabelContextMenu) => {
         const linkNode = this.mapLinkNodeToLinkNode.convert(eventInterfaceLabel.interfaceLabel);
         const link = this.links.find((l) => l.link_id === eventInterfaceLabel.interfaceLabel.linkId);
+        const position = this.getContextMenuPosition(eventInterfaceLabel.event);
         this.contextMenu.openMenuForInterfaceLabel(
           linkNode,
           link,
-          eventInterfaceLabel.event.pageY,
-          eventInterfaceLabel.event.pageX
+          position.top,
+          position.left
         );
       }
     );
@@ -550,7 +673,8 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
         }
       });
 
-      this.contextMenu.openMenuForListOfElements(drawings, nodes, labels, links, event.pageY, event.pageX);
+      const position = this.getContextMenuPosition(event);
+      this.contextMenu.openMenuForListOfElements(drawings, nodes, labels, links, position.top, position.left);
     });
 
     this.projectMapSubscription.add(onLinkContextMenu);
@@ -562,6 +686,13 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
     this.projectMapSubscription.add(onLabelContextMenu);
     this.projectMapSubscription.add(onInterfaceLabelContextMenu);
     this.mapChangeDetectorRef.detectChanges();
+  }
+
+  getContextMenuPosition(event: MouseEvent) {
+    return {
+      top: event.clientY,
+      left: event.clientX,
+    };
   }
 
   onNodeCreation(nodeAddedEvent: NodeAddedEvent) {
@@ -827,11 +958,13 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
   public toggleShowConsole(visible: boolean) {
     this.isConsoleVisible = visible;
     this.mapSettingsService.toggleLogConsole(this.isConsoleVisible);
+    localStorage.setItem('showConsole', this.isConsoleVisible ? 'true' : 'false');
   }
 
   public toggleShowTopologySummary(visible: boolean) {
     this.isTopologySummaryVisible = visible;
     this.mapSettingsService.toggleTopologySummary(this.isTopologySummaryVisible);
+    localStorage.setItem('showTopologySummary', this.isTopologySummaryVisible ? 'true' : 'false');
     this.lazyLoadTopologySummary();
   }
 

--- a/src/app/components/project-map/project-map.component.ts
+++ b/src/app/components/project-map/project-map.component.ts
@@ -271,8 +271,6 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
         });
 
         this.nodes = nodes;
-        this.nodesWithHiddenLinks = this.nodesWithHiddenLinks.filter((nodeId) => nodes.some((node) => node.node_id === nodeId));
-        this.persistHiddenLinksNodes();
         this.updateVisibleLinks();
         if (this.mapSettingsService.getSymbolScaling()) this.applyScalingOfNodeSymbols();
         this.mapChangeDetectorRef.detectChanges();
@@ -571,6 +569,7 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
 
         this.restoreHideManagementLinks();
         this.restoreHiddenLinksNodes();
+        this.nodesWithHiddenLinks = this.nodesWithHiddenLinks.filter((nodeId) => this.nodes.some((node) => node.node_id === nodeId));
         this.persistHideManagementLinks();
         this.persistHiddenLinksNodes();
         this.updateVisibleLinks();


### PR DESCRIPTION
Reemplaza el selector inline 'Hide links connected to' por un checkbox 'Hide Management Link' que abre un modal con búsqueda y selección múltiple de dispositivos.

Además corrige la posición del menú contextual para que aparezca sobre el dispositivo clickeado y no desplazado hacia la derecha.