### PR TITLE
refine: exclude allowed-hardcoded-colors.json from hook protection scope

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -121,12 +121,13 @@ jobs:
       - name: Check for hooks modifications
         if: github.event_name == 'pull_request'
         run: |
-          echo "Checking if .husky/ files were modified..."
-          HUSKY_FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD | grep "^\.\husky/" || true)
+          echo "Checking if .husky/ hook scripts were modified..."
+          echo "(Config files like allowed-hardcoded-colors.json are excluded)"
+          HUSKY_SCRIPTS=$(git diff --name-only origin/${{ github.base_ref }}...HEAD | grep "^\.\husky/" | grep -v "allowed-hardcoded-colors.json" || true)
 
-          if [ -n "$HUSKY_FILES" ]; then
-            echo "⚠️  The following hook files were modified:"
-            echo "$HUSKY_FILES" | sed 's/^/  /'
+          if [ -n "$HUSKY_SCRIPTS" ]; then
+            echo "⚠️  The following hook scripts were modified:"
+            echo "$HUSKY_SCRIPTS" | sed 's/^/  /'
 
             # Check if PR has the 'hooks-update' label
             HAS_LABEL=$(echo '${{ github.event.pull_request.labels.*.name }}' | grep -o 'hooks-update' || true)
@@ -145,7 +146,7 @@ jobs:
               echo "✅ PR has 'hooks-update' label - hooks modification allowed"
             fi
           else
-            echo "✅ No hook files modified"
+            echo "✅ No hook scripts modified"
           fi
 
       - name: Install JS dependencies

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -123,7 +123,7 @@ jobs:
         run: |
           echo "Checking if .husky/ hook scripts were modified..."
           echo "(Config files like allowed-hardcoded-colors.json are excluded)"
-          HUSKY_SCRIPTS=$(git diff --name-only origin/${{ github.base_ref }}...HEAD | grep "^\.\husky/" | grep -v "allowed-hardcoded-colors.json" || true)
+          HUSKY_SCRIPTS=$(git diff --name-only origin/${{ github.base_ref }}...HEAD | grep "^\.husky/" | grep -v "allowed-hardcoded-colors.json" || true)
 
           if [ -n "$HUSKY_SCRIPTS" ]; then
             echo "⚠️  The following hook scripts were modified:"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,8 +3,9 @@
 
 echo "🔍 Running Standards check..."
 
-# Check if .husky/ files are being modified (PROTECTED)
-STAGED_HUSKY=$(git diff --cached --name-only --diff-filter=ACM 2>/dev/null | grep "^\.\husky/" || true)
+# Check if .husky/ hook scripts are being modified (PROTECTED)
+# NOTE: allowed-hardcoded-colors.json is a regular config file, not a hook script
+STAGED_HUSKY=$(git diff --cached --name-only --diff-filter=ACM 2>/dev/null | grep "^\.\husky/" | grep -v "allowed-hardcoded-colors.json" || true)
 if [ -n "$STAGED_HUSKY" ]; then
   echo ""
   echo "⚠️  ⚠️  ⚠️  WARNING ⚠️  ⚠️  ⚠️"
@@ -15,8 +16,7 @@ if [ -n "$STAGED_HUSKY" ]; then
   echo ""
   echo "These changes require:"
   echo "  1. Team lead approval"
-  echo "  2. Update allowed-hardcoded-colors.json if adding/removing allowed colors"
-  echo "  3. Add 'hooks-update' label to your PR"
+  echo "  2. Add 'hooks-update' label to your PR"
   echo ""
   echo "If this is intentional, press Enter to continue."
   echo "Press Ctrl+C to cancel."

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -5,7 +5,7 @@ echo "🔍 Running Standards check..."
 
 # Check if .husky/ hook scripts are being modified (PROTECTED)
 # NOTE: allowed-hardcoded-colors.json is a regular config file, not a hook script
-STAGED_HUSKY=$(git diff --cached --name-only --diff-filter=ACM 2>/dev/null | grep "^\.\husky/" | grep -v "allowed-hardcoded-colors.json" || true)
+STAGED_HUSKY=$(git diff --cached --name-only --diff-filter=ACM 2>/dev/null | grep "^\.husky/" | grep -v "allowed-hardcoded-colors.json" || true)
 if [ -n "$STAGED_HUSKY" ]; then
   echo ""
   echo "⚠️  ⚠️  ⚠️  WARNING ⚠️  ⚠️  ⚠️"

--- a/docs/guides/css/hardcoded-color-protection.md
+++ b/docs/guides/css/hardcoded-color-protection.md
@@ -48,9 +48,11 @@ The hardcoded color protection system prevents code quality degradation by enfor
 
 ### Layer 1: Pre-commit Interactive Warning
 
-**Purpose**: Prevents accidental hook modifications
-**Mechanism**: Detects `.husky/` changes in staged files
+**Purpose**: Prevents accidental hook script modifications
+**Mechanism**: Detects changes to `.husky/` hook scripts (scripts and hooks only, not config files)
 **Behavior**: Requires explicit confirmation before proceeding
+
+> **Note**: `allowed-hardcoded-colors.json` is a regular config file — modifying it does **not** trigger this warning.
 
 **User Experience**:
 ```
@@ -62,7 +64,6 @@ Pre-commit: ⚠️  WARNING: Modifying git hooks!
              - .husky/check-hardcoded-colors.sh
            These changes require:
              1. Team lead approval
-             2. Update allowed-hardcoded-colors.json if needed
            If this is intentional, press Enter to continue.
            Press Ctrl+C to cancel.
            ↓
@@ -75,29 +76,41 @@ Commit proceeds
 
 ### Layer 2: CI Label Requirement
 
-**Purpose**: Prevents unauthorized hook changes via PR
-**Mechanism**: Checks for `hooks-update` label on PRs
-**Behavior**: CI fails if label missing when `.husky/` files changed
+**Purpose**: Prevents unauthorized hook script changes via PR
+**Mechanism**: Checks for `hooks-update` label on PRs that modify hook scripts
+**Behavior**: CI fails if label missing when `.husky/` hook scripts (not config files) are changed
+
+> **Note**: Modifying only `allowed-hardcoded-colors.json` does **not** require the `hooks-update` label.
 
 **Pull Request Flow**:
 ```
-┌──────────────────┐
-│  Create PR with  │
-│  .husky/ changes │
-└────────┬─────────┘
-         │
-         ▼
-    ┌─────────┐
-    │   CI    │
-    │  Check  │
-    └────┬────┘
-         │
-    ┌────┴────┐
-    │         │
- Has Label  No Label
-    │         │
-    ▼         ▼
-  Pass      Fail ✗
+                ┌──────────────────┐
+                │  Create PR with  │
+                │  .husky/ changes │
+                └────────┬─────────┘
+                         │
+                         ▼
+               ┌─────────────────────┐
+               │  What was changed?  │
+               ├─────────┬───────────┤
+               │  Config │   Hook    │
+               │  file   │  scripts  │
+               │(no label│           │
+               │ needed) │           │
+               └────┬────┴─────┬─────┘
+                    │          │
+                    ▼          ▼
+                 Pass      ┌─────────┐
+                           │   CI    │
+                           │  Check  │
+                           └────┬────┘
+                                │
+                           ┌────┴────┐
+                           │         │
+                        Has Label  No Label
+                           │         │
+                           ▼         ▼
+                         Pass      Fail ✗
 ```
 
 **Implementation**: `.github/workflows/main.yml` (lines 121-149)
@@ -161,6 +174,8 @@ The allowed hardcoded colors are stored in a structured JSON file:
 
 ### Scenario 1: Adding New Allowed Color
 
+> `allowed-hardcoded-colors.json` is a config file, not a hook script — modifying it does **not** require the `hooks-update` label.
+
 ```
 1. Edit .husky/allowed-hardcoded-colors.json
    ↓
@@ -168,13 +183,11 @@ The allowed hardcoded colors are stored in a structured JSON file:
    ↓
 3. Test: .husky/check-hardcoded-colors.sh --ci
    ↓
-4. Commit (triggers warning, confirm)
+4. Commit (no hook warning triggered)
    ↓
 5. Push and create PR
    ↓
-6. Add 'hooks-update' label
-   ↓
-7. Get approval and merge
+6. Get approval and merge
 ```
 
 ### Scenario 2: Modifying Check Script or Hooks
@@ -215,11 +228,12 @@ These files protect code quality standards:
 
 These changes require:
   1. Team lead approval
-  2. Update allowed-hardcoded-colors.json if needed
 
 If this is intentional, press Enter to continue.
 Press Ctrl+C to cancel.
 ```
+
+> **Note**: Modifying only `allowed-hardcoded-colors.json` does **not** trigger this warning.
 
 ### CI Label Missing
 ```


### PR DESCRIPTION
## Summary

This PR refines the hardcoded color protection mechanism to distinguish between **hook scripts** (security-sensitive) and **config files** (regular development).

## Problem

PR #1709 (and similar future PRs) only modifies `.husky/allowed-hardcoded-colors.json` — a regular config file — but was blocked by the pre-commit hook and would fail CI without the `hooks-update` label (which doesn't exist in the repo yet).

The original code treated `allowed-hardcoded-colors.json` the same as actual hook scripts like `pre-commit` and `check-hardcoded-colors.sh`, creating unnecessary friction.

## Changes

| File | Change |
|------|--------|
| `.husky/pre-commit` | Exclude `allowed-hardcoded-colors.json` from hook modification detection; remove outdated warning about the config file |
| `.github/workflows/main.yml` | CI now only checks for hook script changes; config file changes pass without `hooks-update` label |
| `docs/guides/css/hardcoded-color-protection.md` | Update documentation to reflect the refined scope; Scenario 1 no longer mentions the label |

## Testing

- ✅ grep logic verified for all 5 scenarios (config only, script only, both, check script, non-husky files)
- ✅ End-to-end test: actual commit of config-only change passed pre-commit hook cleanly
- ✅ CI change logic matches pre-commit change