### PR TITLE
fix(ai-profile): convert custom mode to all manual inputs

### DIFF
--- a/src/app/components/group-details/group-ai-profile-tab/group-ai-profile-tab.component.html
+++ b/src/app/components/group-details/group-ai-profile-tab/group-ai-profile-tab.component.html
@@ -3,7 +3,7 @@
   <div class="toolbar">
     <div class="toolbar-info">
       <h3>Group LLM Model Configurations</h3>
-      <p class="subtitle">Manage group LLM model configurations. These configs will be inherited by group members.</p>
+      <p class="subtitle">Manage group OpenAI-compatible LLM model configurations. These configs will be inherited by group members.</p>
     </div>
     <div class="toolbar-actions">
       <button mat-button (click)="loadConfigs()" [disabled]="loading$ | async">

--- a/src/app/components/group-details/group-ai-profile-tab/group-ai-profile-tab.component.html
+++ b/src/app/components/group-details/group-ai-profile-tab/group-ai-profile-tab.component.html
@@ -2,7 +2,7 @@
   <!-- Toolbar -->
   <div class="toolbar">
     <div class="toolbar-info">
-      <h3>Group LLM Model Configurations</h3>
+      <h3>Group LLM Model Configurations <span class="compatibility-badge">OpenAI-Compatible</span></h3>
       <p class="subtitle">Manage group OpenAI-compatible LLM model configurations. These configs will be inherited by group members.</p>
     </div>
     <div class="toolbar-actions">

--- a/src/app/components/group-details/group-ai-profile-tab/group-ai-profile-tab.component.scss
+++ b/src/app/components/group-details/group-ai-profile-tab/group-ai-profile-tab.component.scss
@@ -12,11 +12,27 @@
         margin: 0 0 4px 0;
         font-size: 18px;
         font-weight: 500;
+        display: flex;
+        align-items: center;
+        gap: 12px;
       }
 
       .subtitle {
         margin: 0;
         font-size: 13px;
+      }
+
+      .compatibility-badge {
+        display: inline-block;
+        padding: 2px 10px;
+        font-size: 11px;
+        font-weight: 600;
+        letter-spacing: 0.3px;
+        background: var(--mat-sys-primary-container);
+        color: var(--mat-sys-primary);
+        border-radius: 12px;
+        line-height: 20px;
+        text-transform: uppercase;
       }
     }
 

--- a/src/app/components/user-management/user-detail/ai-profile-tab/ai-profile-dialog/ai-profile-dialog.component.html
+++ b/src/app/components/user-management/user-detail/ai-profile-tab/ai-profile-dialog/ai-profile-dialog.component.html
@@ -161,55 +161,11 @@
         }
       </mat-form-field>
 
-      <!-- Model Type Selection -->
+      <!-- Model Type (fixed to text) -->
       <mat-form-field appearance="outline" class="full-width">
         <mat-label>Model Type</mat-label>
-        <mat-select formControlName="model_type">
-          @for (type of modelTypes; track type.value) {
-          <mat-option [value]="type.value">
-            {{ type.label }}
-          </mat-option>
-          }
-        </mat-select>
+        <input matInput formControlName="model_type" value="text" readonly />
       </mat-form-field>
-
-      <!-- Provider Preset Selection -->
-      <mat-form-field appearance="outline" class="full-width">
-        <mat-label>Select LLM Provider</mat-label>
-        <mat-select [value]="selectedPresetId" (selectionChange)="onPresetChange($event.value)">
-          @for (preset of providerPresets; track preset.id) {
-          <mat-option [value]="preset.id">
-            {{ preset.label }}
-          </mat-option>
-          }
-        </mat-select>
-      </mat-form-field>
-
-      <!-- Model Selection (when preset is selected and not custom) -->
-      @if (selectedPreset && selectedPresetId !== 'custom' && !useCustomModel) {
-      <mat-form-field appearance="outline" class="full-width">
-        <mat-label>Model Name</mat-label>
-        <mat-select [value]="form.get('model')?.value" (selectionChange)="onModelChange($event.value)">
-          @for (model of selectedPreset.models; track model) {
-          <mat-option [value]="model">
-            {{ model }}
-          </mat-option>
-          }
-          <mat-option value="__custom__">Custom model name...</mat-option>
-        </mat-select>
-      </mat-form-field>
-      }
-
-      <!-- Custom Model Input (when Custom preset is selected or "Custom model name..." is chosen) -->
-      @if (selectedPresetId === 'custom' || useCustomModel) {
-      <mat-form-field appearance="outline" class="full-width">
-        <mat-label>Model Name</mat-label>
-        <input matInput formControlName="model" placeholder="Enter model name" />
-        @if (!form.get('model')?.value) {
-        <mat-error>Model name is required</mat-error>
-        }
-      </mat-form-field>
-      }
 
       <!-- API Configuration Section -->
       <div class="section-header">
@@ -218,19 +174,13 @@
 
       <mat-form-field appearance="outline" class="full-width">
         <mat-label>Model Provider</mat-label>
-        <mat-select formControlName="provider" placeholder="Select provider">
-          @for (provider of supportedProviders; track provider.value) {
-          <mat-option [value]="provider.value">
-            {{ provider.label }}
-          </mat-option>
-          }
-        </mat-select>
+        <input matInput formControlName="provider" placeholder="e.g.: openai, anthropic, ollama" />
         <mat-error>Provider is required</mat-error>
       </mat-form-field>
 
       <mat-form-field appearance="outline" class="full-width">
         <mat-label>Base URL</mat-label>
-        <input matInput formControlName="base_url" placeholder="Auto-filled from preset" />
+        <input matInput formControlName="base_url" placeholder="e.g.: https://api.openai.com/v1" />
       </mat-form-field>
 
       <mat-form-field appearance="outline" class="full-width">
@@ -244,6 +194,15 @@
         />
         @if (hasError('api_key')) {
         <mat-error>{{ getErrorMessage('api_key') }}</mat-error>
+        }
+      </mat-form-field>
+
+      <!-- Model Name -->
+      <mat-form-field appearance="outline" class="full-width">
+        <mat-label>Model Name</mat-label>
+        <input matInput formControlName="model" placeholder="e.g.: gpt-4o, deepseek-v4-flash, claude-sonnet-4" />
+        @if (!form.get('model')?.value) {
+        <mat-error>Model name is required</mat-error>
         }
       </mat-form-field>
 

--- a/src/app/components/user-management/user-detail/ai-profile-tab/ai-profile-dialog/ai-profile-dialog.component.ts
+++ b/src/app/components/user-management/user-detail/ai-profile-tab/ai-profile-dialog/ai-profile-dialog.component.ts
@@ -533,7 +533,7 @@ export class AiProfileDialogComponent implements OnInit {
    */
   openCustomModeHelp(): void {
     this.dialog.open(ModelTypeHelpDialogComponent, {
-      panelClass: ['base-dialog-panel', 'simple-dialog-panel'],
+      panelClass: ['base-dialog-panel', 'ai-profile-dialog-panel'],
     });
   }
 

--- a/src/app/components/user-management/user-detail/ai-profile-tab/ai-profile-dialog/ai-profile-dialog.component.ts
+++ b/src/app/components/user-management/user-detail/ai-profile-tab/ai-profile-dialog/ai-profile-dialog.component.ts
@@ -5,6 +5,7 @@ import {
   FormGroup,
   FormArray,
   Validators,
+  ValidatorFn,
   AbstractControl,
   ValidationErrors,
   ReactiveFormsModule,
@@ -173,26 +174,6 @@ export class AiProfileDialogComponent implements OnInit {
   selectedPreset: ProviderPreset | null = null;
   useCustomModel: boolean = false;
 
-  // Supported providers for Custom Mode
-  supportedProviders = [
-    { value: 'openai', label: 'OpenAI' },
-    { value: 'anthropic', label: 'Anthropic' },
-    { value: 'google', label: 'Google' },
-    { value: 'aws', label: 'AWS Bedrock' },
-    { value: 'ollama', label: 'Ollama' },
-    { value: 'deepseek', label: 'DeepSeek' },
-    { value: 'xai', label: 'xAI' },
-  ];
-
-  // Default base URLs for providers
-  providerDefaultUrls: { [key: string]: string } = {
-    openai: 'https://api.openai.com/v1',
-    anthropic: 'https://api.anthropic.com',
-    google: 'https://generativelanguage.googleapis.com',
-    deepseek: 'https://api.deepseek.com/v1',
-    xai: 'https://api.x.ai',
-  };
-
   // Get non-custom presets for Basic Mode
   get basicModePresets(): ProviderPreset[] {
     return this.providerPresets.filter((preset) => preset.id !== 'custom');
@@ -266,21 +247,6 @@ export class AiProfileDialogComponent implements OnInit {
       this.detectPresetFromConfig();
       this.cd.markForCheck();
     }
-
-    // Watch for provider changes to auto-fill base URL in Custom mode
-    this.form.get('provider')?.valueChanges.subscribe((providerValue) => {
-      // Only auto-fill in Custom mode (not when using presets)
-      if (this.selectedPresetId === 'custom' && providerValue) {
-        const defaultUrl = this.providerDefaultUrls[providerValue];
-        const baseUrlControl = this.form.get('base_url');
-
-        // Add null check for base_url control
-        if (defaultUrl && baseUrlControl && !baseUrlControl.value) {
-          baseUrlControl.setValue(defaultUrl);
-        }
-      }
-      this.cd.markForCheck();
-    });
   }
 
   private createForm(): FormGroup {
@@ -295,6 +261,7 @@ export class AiProfileDialogComponent implements OnInit {
             Validators.minLength(1),
             Validators.maxLength(100),
             Validators.pattern(/^[a-zA-Z0-9_-]+$/),
+            this.duplicateNameValidator(),
           ],
         ],
         model_type: ['text', Validators.required],
@@ -309,8 +276,21 @@ export class AiProfileDialogComponent implements OnInit {
         is_default: [false],
         customFields: this.customFieldsArray,
       },
-      { validators: this.nameUniqueValidator.bind(this) }
     );
+  }
+
+  /**
+   * Custom validator: check if the name already exists
+   */
+  private duplicateNameValidator(): ValidatorFn {
+    return (control: AbstractControl): ValidationErrors | null => {
+      const name = control.value;
+      if (!name) return null;
+      if (this.existingNames.includes(name)) {
+        return { duplicateName: true };
+      }
+      return null;
+    };
   }
 
   /**
@@ -412,20 +392,6 @@ export class AiProfileDialogComponent implements OnInit {
   }
 
   /**
-   * Name uniqueness validator
-   */
-  private nameUniqueValidator(group: AbstractControl): ValidationErrors | null {
-    const name = group.get('name')?.value;
-    if (!name) return null;
-
-    if (this.existingNames.includes(name)) {
-      return { duplicateName: true };
-    }
-
-    return null;
-  }
-
-  /**
    * Get error message
    */
   getErrorMessage(field: string): string {
@@ -433,14 +399,13 @@ export class AiProfileDialogComponent implements OnInit {
     if (!control || !control.errors) return '';
 
     const errors = control.errors;
-    const formErrors = this.form.errors;
 
     if (field === 'name') {
       if (errors.required) return 'Name is required';
       if (errors.minlength) return 'Name must be at least 1 character';
       if (errors.maxlength) return 'Name cannot exceed 100 characters';
       if (errors.pattern) return 'Name can only contain letters, numbers, underscores and hyphens';
-      if (formErrors?.duplicateName) return 'Name already exists';
+      if (errors.duplicateName) return 'Name already exists';
       return 'Invalid name format';
     }
 

--- a/src/app/components/user-management/user-detail/ai-profile-tab/ai-profile-dialog/model-type-help-dialog/model-type-help-dialog.component.html
+++ b/src/app/components/user-management/user-detail/ai-profile-tab/ai-profile-dialog/model-type-help-dialog/model-type-help-dialog.component.html
@@ -4,6 +4,18 @@
 </h2>
 
 <mat-dialog-content class="help-content">
+  <!-- Compatibility Notice -->
+  <mat-card class="compatibility-card">
+    <mat-card-content>
+      <p class="status-text">
+        <mat-icon class="status-icon">info</mat-icon>
+        <strong>OpenAI-Compatible Only:</strong> GNS3 currently supports only OpenAI-compatible LLM APIs.
+        Ensure your provider and model use the OpenAI API format
+        (e.g., OpenAI, DeepSeek, OpenRouter, Ollama with OpenAI compatibility).
+      </p>
+    </mat-card-content>
+  </mat-card>
+
   <!-- Basic Configuration Section -->
   <div class="help-section">
     <h3>Basic Configuration</h3>

--- a/src/app/components/user-management/user-detail/ai-profile-tab/ai-profile-dialog/model-type-help-dialog/model-type-help-dialog.component.html
+++ b/src/app/components/user-management/user-detail/ai-profile-tab/ai-profile-dialog/model-type-help-dialog/model-type-help-dialog.component.html
@@ -20,40 +20,16 @@
 
     <div class="field-item">
       <h4>Model Type</h4>
-      <p>The category of AI model you are configuring. This field is reserved for future use.</p>
+      <p>The category of AI model for this configuration.</p>
       <mat-card class="info-card">
         <mat-card-content>
           <p class="status-text">
             <mat-icon class="status-icon">info</mat-icon>
-            Currently, only <strong>text</strong> model type is supported. Other options (vision, stt, tts, multimodal,
-            embedding, reranking, other) are reserved for future enhancements.
+            Currently fixed to <strong>text</strong>. This field is reserved for future use when additional model
+            types become supported.
           </p>
         </mat-card-content>
       </mat-card>
-    </div>
-
-    <div class="field-item">
-      <h4>Select LLM Provider</h4>
-      <p>Choose a preset provider to auto-configure the connection settings.</p>
-      <ul>
-        <li><strong>OpenRouter:</strong> Access to multiple models through openrouter.ai</li>
-        <li><strong>DeepSeek:</strong> DeepSeek's official API endpoint</li>
-        <li><strong>Custom:</strong> Manually configure all settings</li>
-      </ul>
-      <p class="note">Presets automatically fill in the Base URL and default model list.</p>
-    </div>
-
-    <div class="field-item">
-      <h4>Model Name</h4>
-      <p>The specific model to use from the selected provider.</p>
-      <ul>
-        <li><strong>From preset:</strong> Select from a dropdown list of available models</li>
-        <li><strong>Custom:</strong> Enter any model name manually</li>
-      </ul>
-      <p>
-        <strong>Examples:</strong> <code>gpt-4o</code>, <code>claude-3-5-sonnet-20241022</code>,
-        <code>deepseek-v4-pro</code>
-      </p>
     </div>
   </div>
 
@@ -63,21 +39,31 @@
 
     <div class="field-item">
       <h4>Model Provider</h4>
-      <p>The provider type for API communication.</p>
+      <p>The LLM provider identifier for API communication.</p>
       <p>
-        Select the provider that matches your API endpoint. For OpenAI-compatible APIs, choose "OpenAI" and customize
-        the Base URL.
+        Enter the provider that matches your API endpoint. Common values include
+        <code>openai</code>, <code>anthropic</code>, <code>ollama</code>, <code>deepseek</code>.
       </p>
+      <p>For OpenAI-compatible APIs, use <code>openai</code> as the provider and customize the Base URL.</p>
     </div>
 
     <div class="field-item">
       <h4>Base URL</h4>
       <p>The API endpoint URL for the provider.</p>
       <ul>
-        <li><strong>Default:</strong> Leave empty to use the provider's default endpoint</li>
-        <li><strong>Custom:</strong> Enter a full URL (e.g., <code>https://api.openai.com/v1</code>)</li>
+        <li>Enter the full URL of the API endpoint</li>
+        <li><strong>Examples:</strong> <code>https://api.openai.com/v1</code>, <code>http://localhost:11434/v1</code></li>
       </ul>
-      <p class="note">This field is auto-filled when using presets.</p>
+    </div>
+
+    <div class="field-item">
+      <h4>Model Name</h4>
+      <p>The specific model to use.</p>
+      <p>Enter the model identifier exactly as required by the provider's API.</p>
+      <p>
+        <strong>Examples:</strong> <code>gpt-4o</code>, <code>claude-sonnet-4</code>,
+        <code>deepseek-v4-pro</code>, <code>llama-3-70b</code>
+      </p>
     </div>
 
     <div class="field-item">

--- a/src/app/components/user-management/user-detail/ai-profile-tab/ai-profile-dialog/model-type-help-dialog/model-type-help-dialog.component.scss
+++ b/src/app/components/user-management/user-detail/ai-profile-tab/ai-profile-dialog/model-type-help-dialog/model-type-help-dialog.component.scss
@@ -19,6 +19,33 @@ mat-dialog-title {
   max-height: 60vh;
   overflow-y: auto;
 
+  .compatibility-card {
+    margin: 0 0 24px 0;
+    border-radius: 8px;
+    background: var(--mat-sys-primary-container);
+    border: 1px solid var(--mat-sys-primary);
+
+    mat-card-content {
+      padding: 12px 16px;
+    }
+
+    .status-text {
+      display: flex;
+      align-items: flex-start;
+      gap: 12px;
+      margin: 0;
+      font-size: 14px;
+      line-height: 1.6;
+      color: var(--mat-sys-on-primary-container);
+
+      .status-icon {
+        flex-shrink: 0;
+        margin-top: 2px;
+        color: var(--mat-sys-primary);
+      }
+    }
+  }
+
   .help-section {
     margin-bottom: 32px;
 

--- a/src/app/components/user-management/user-detail/ai-profile-tab/ai-profile-tab.component.html
+++ b/src/app/components/user-management/user-detail/ai-profile-tab/ai-profile-tab.component.html
@@ -2,7 +2,7 @@
   <!-- Toolbar -->
   <div class="toolbar">
     <div class="toolbar-info">
-      <h3>LLM Model Configurations</h3>
+      <h3>LLM Model Configurations <span class="compatibility-badge">OpenAI-Compatible</span></h3>
       <p class="subtitle">
         Manage OpenAI-compatible LLM model configurations. Your configs and configs inherited from your groups are shown below.
       </p>

--- a/src/app/components/user-management/user-detail/ai-profile-tab/ai-profile-tab.component.html
+++ b/src/app/components/user-management/user-detail/ai-profile-tab/ai-profile-tab.component.html
@@ -4,7 +4,7 @@
     <div class="toolbar-info">
       <h3>LLM Model Configurations</h3>
       <p class="subtitle">
-        Manage LLM model configurations. Your configs and configs inherited from your groups are shown below.
+        Manage OpenAI-compatible LLM model configurations. Your configs and configs inherited from your groups are shown below.
       </p>
     </div>
     <div class="toolbar-actions">

--- a/src/app/components/user-management/user-detail/ai-profile-tab/ai-profile-tab.component.scss
+++ b/src/app/components/user-management/user-detail/ai-profile-tab/ai-profile-tab.component.scss
@@ -12,11 +12,27 @@
         margin: 0 0 4px 0;
         font-size: 18px;
         font-weight: 500;
+        display: flex;
+        align-items: center;
+        gap: 12px;
       }
 
       .subtitle {
         margin: 0;
         font-size: 13px;
+      }
+
+      .compatibility-badge {
+        display: inline-block;
+        padding: 2px 10px;
+        font-size: 11px;
+        font-weight: 600;
+        letter-spacing: 0.3px;
+        background: var(--mat-sys-primary-container);
+        color: var(--mat-sys-primary);
+        border-radius: 12px;
+        line-height: 20px;
+        text-transform: uppercase;
       }
     }
 


### PR DESCRIPTION
## Summary

Convert the Custom Mode section of the LLM Model Configuration dialog from preset-based dropdowns to fully manual text inputs, since this is an advanced setting.

## Changes

### Custom Mode Dialog
- **Model Type**: Select → readonly input (fixed to `text`)
- **Model Provider**: Provider dropdown → text input
- **Removed**: Provider Preset Selection dropdown (OpenRouter/DeepSeek/Custom)
- **Model Name**: Simplified conditional logic → always text input, moved to API Configuration section
- **Context Strategy / Copilot Mode**: Retained as selects
- **Base URL**: Updated placeholder, removed auto-fill from preset logic

### Code cleanup
- Removed `supportedProviders` array, `providerDefaultUrls`, auto-fill subscription
- Name duplicate validation: form-group level → control-level (`duplicateNameValidator()`) for inline error display

### UI improvements
- Added `OpenAI-Compatible` badge to LLM config page titles
- Updated Custom Mode Field Documentation help dialog
- Help dialog width matched to main dialog (700px)