### PR TITLE
fix(templates): Unable to change QEMU VM disk image on duplicated templates

### DIFF
--- a/src/app/components/preferences/qemu/qemu-vm-template-details/qemu-vm-template-details.component.html
+++ b/src/app/components/preferences/qemu/qemu-vm-template-details/qemu-vm-template-details.component.html
@@ -151,7 +151,7 @@
               (focus)="refreshQemuImages()"
               placeholder="Disk image"
             />
-            <mat-autocomplete #hdaAuto="matAutocomplete">
+            <mat-autocomplete #hdaAuto="matAutocomplete" (optionSelected)="hdaDiskImage.set($event.option.value)">
               @if (filteredImages.length) {
               <mat-optgroup label="Global images">
                 @for (image of filteredImages; track image.filename) {
@@ -185,7 +185,7 @@
               (focus)="refreshQemuImages()"
               placeholder="Disk image"
             />
-            <mat-autocomplete #hdbAuto="matAutocomplete">
+            <mat-autocomplete #hdbAuto="matAutocomplete" (optionSelected)="hdbDiskImage.set($event.option.value)">
               @if (filteredImages.length) {
               <mat-optgroup label="Global images">
                 @for (image of filteredImages; track image.filename) {
@@ -219,7 +219,7 @@
               (focus)="refreshQemuImages()"
               placeholder="Disk image"
             />
-            <mat-autocomplete #hdcAuto="matAutocomplete">
+            <mat-autocomplete #hdcAuto="matAutocomplete" (optionSelected)="hdcDiskImage.set($event.option.value)">
               @if (filteredImages.length) {
               <mat-optgroup label="Global images">
                 @for (image of filteredImages; track image.filename) {
@@ -253,7 +253,7 @@
               (focus)="refreshQemuImages()"
               placeholder="Disk image"
             />
-            <mat-autocomplete #hddAuto="matAutocomplete">
+            <mat-autocomplete #hddAuto="matAutocomplete" (optionSelected)="hddDiskImage.set($event.option.value)">
               @if (filteredImages.length) {
               <mat-optgroup label="Global images">
                 @for (image of filteredImages; track image.filename) {

--- a/src/app/components/preferences/qemu/qemu-vm-template-details/qemu-vm-template-details.component.ts
+++ b/src/app/components/preferences/qemu/qemu-vm-template-details/qemu-vm-template-details.component.ts
@@ -158,9 +158,10 @@ export class QemuVmTemplateDetailsComponent implements OnInit {
         this.getConfiguration();
         this.qemuService.getImages(this.controller).subscribe({
           next: (images: QemuImage[]) => {
-            this.qemuImages = images;
-            this.filteredImages = images;
-            this.filteredAdvancedImages = images;
+            const unique = images.filter((img, idx, arr) => arr.findIndex(i => i.filename === img.filename) === idx);
+            this.qemuImages = unique;
+            this.filteredImages = unique;
+            this.filteredAdvancedImages = unique;
             this.cd.markForCheck();
           },
           error: (err) => {
@@ -298,9 +299,10 @@ export class QemuVmTemplateDetailsComponent implements OnInit {
   refreshQemuImages() {
     this.qemuService.getImages(this.controller).subscribe({
       next: (images: QemuImage[]) => {
-        this.qemuImages = images;
-        this.filteredImages = images;
-        this.filteredAdvancedImages = images;
+        const unique = images.filter((img, idx, arr) => arr.findIndex(i => i.filename === img.filename) === idx);
+        this.qemuImages = unique;
+        this.filteredImages = unique;
+        this.filteredAdvancedImages = unique;
         this.cd.markForCheck();
       },
     });


### PR DESCRIPTION
## Fix: QEMU VM template disk image changes not saved + database error on save

### Problem

When editing a QEMU VM template in **Templates → Qemu VMs → (edit)**, changing the **HDA (Primary Master)** disk image by selecting a new value from the dropdown and clicking **Save** would silently revert to the old image on the next open. Attempting to save after the fix exposed a secondary error in the server:

> **Database error detected, please check logs to find details**

A third issue produced an Angular console error:

> **NG0955: The provided track expression resulted in duplicated keys** — e.g. `viptela-vmanage-20.18.3-generic-x86-64.qcow2` at index 19 and 25.

---

### Root Cause Analysis

#### 1. `(optionSelected)` missing on `mat-autocomplete` — disk image not updated in model

All four disk image fields (HDA, HDB, HDC, HDD) used Angular Material `mat-autocomplete` with only an `(input)` DOM event handler to update the model signal:

`(input)="onHdaImageInput($event); hdaDiskImage.set($event.target.value)"`

When a user clicks a dropdown option, Angular Material sets the <input> element's .value property directly — this is a programmatic assignment and does not fire the DOM input event. The model signal (hdaDiskImage) was never updated. On Save, this.hdaDiskImage() still returned the old value, which was written to qemuTemplate.hda_disk_image and sent to the server.

HDB, HDC and HDD had the same bug but were less noticeable (typically empty).