### PR TITLE
Enhancement: Add Show in file manager menu option to web-ui for listing nodes path on the server

### DIFF
--- a/src/app/components/project-map/context-menu/actions/show-in-file-manager-action/show-in-file-manager-action.component.html
+++ b/src/app/components/project-map/context-menu/actions/show-in-file-manager-action/show-in-file-manager-action.component.html
@@ -1,0 +1,4 @@
+<button mat-menu-item (click)="showInFileManager()">
+  <mat-icon>folder_open</mat-icon>
+  <span>Show in file manager</span>
+</button>

--- a/src/app/components/project-map/context-menu/actions/show-in-file-manager-action/show-in-file-manager-action.component.ts
+++ b/src/app/components/project-map/context-menu/actions/show-in-file-manager-action/show-in-file-manager-action.component.ts
@@ -1,0 +1,37 @@
+import { ChangeDetectionStrategy, Component, inject, input } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatMenuModule } from '@angular/material/menu';
+import { MatDialog } from '@angular/material/dialog';
+import { Node } from '../../../../../cartography/models/node';
+import { Controller } from '@models/controller';
+import { NodeFileManagerDialogComponent } from '../../../node-file-manager-dialog/node-file-manager-dialog.component';
+
+@Component({
+  standalone: true,
+  selector: 'app-show-in-file-manager-action',
+  templateUrl: './show-in-file-manager-action.component.html',
+  imports: [MatButtonModule, MatIconModule, MatMenuModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ShowInFileManagerActionComponent {
+  private dialog = inject(MatDialog);
+
+  readonly node = input<Node>(undefined);
+  readonly controller = input<Controller>(undefined);
+
+  showInFileManager() {
+    const node = this.node();
+    const controller = this.controller();
+    this.dialog.open(NodeFileManagerDialogComponent, {
+      panelClass: ['base-dialog-panel', 'node-file-manager-dialog-panel'],
+      autoFocus: false,
+      disableClose: false,
+      data: {
+        nodeName: node.name,
+        nodeDirectory: node.node_directory || 'Directory not available (node may not be running)',
+        controllerName: controller?.name || controller?.host || 'Unknown server',
+      },
+    });
+  }
+}

--- a/src/app/components/project-map/context-menu/context-menu.component.html
+++ b/src/app/components/project-map/context-menu/context-menu.component.html
@@ -4,6 +4,8 @@
     @if (nodes.length === 1) {
     <app-show-node-action [controller]="controller" [node]="nodes[0]"></app-show-node-action>
     } @if (nodes.length === 1) {
+    <app-show-in-file-manager-action [controller]="controller" [node]="nodes[0]"></app-show-in-file-manager-action>
+    } @if (nodes.length === 1) {
     <app-config-node-action [controller]="controller" [node]="nodes[0]"></app-config-node-action>
     } @if (nodes.length) {
     <app-start-node-action [controller]="controller" [nodes]="nodes"></app-start-node-action>

--- a/src/app/components/project-map/context-menu/context-menu.component.ts
+++ b/src/app/components/project-map/context-menu/context-menu.component.ts
@@ -50,6 +50,7 @@ import { LockActionComponent } from './actions/lock-action/lock-action.component
 import { DeleteActionComponent } from './actions/delete-action/delete-action.component';
 import { AlignHorizontallyActionComponent } from './actions/align-horizontally/align-horizontally.component';
 import { AlignVerticallyActionComponent } from './actions/align_vertically/align-vertically.component';
+import { ShowInFileManagerActionComponent } from './actions/show-in-file-manager-action/show-in-file-manager-action.component';
 
 @Component({
   selector: 'app-context-menu',
@@ -97,6 +98,7 @@ import { AlignVerticallyActionComponent } from './actions/align_vertically/align
     DeleteActionComponent,
     AlignHorizontallyActionComponent,
     AlignVerticallyActionComponent,
+    ShowInFileManagerActionComponent,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/src/app/components/project-map/node-file-manager-dialog/node-file-manager-dialog.component.html
+++ b/src/app/components/project-map/node-file-manager-dialog/node-file-manager-dialog.component.html
@@ -1,0 +1,25 @@
+<h1 mat-dialog-title>
+  {{ data.nodeName }}
+  <button mat-icon-button class="close-btn" (click)="onCloseClick()">
+    <mat-icon>close</mat-icon>
+  </button>
+</h1>
+
+<div mat-dialog-content class="node-file-manager-dialog__content">
+  <p class="node-file-manager-dialog__label">Node directory on server <strong>{{ data.controllerName }}</strong>:</p>
+  <div class="node-file-manager-dialog__path-row">
+    <span class="node-file-manager-dialog__path">{{ data.nodeDirectory }}</span>
+    <button
+      mat-icon-button
+      [matTooltip]="copied ? 'Copied!' : 'Copy path to clipboard'"
+      (click)="copyPath()"
+      aria-label="Copy path to clipboard"
+    >
+      <mat-icon>{{ copied ? 'check' : 'content_copy' }}</mat-icon>
+    </button>
+  </div>
+</div>
+
+<div mat-dialog-actions align="end">
+  <button mat-button (click)="onCloseClick()">Close</button>
+</div>

--- a/src/app/components/project-map/node-file-manager-dialog/node-file-manager-dialog.component.scss
+++ b/src/app/components/project-map/node-file-manager-dialog/node-file-manager-dialog.component.scss
@@ -1,18 +1,18 @@
 .node-file-manager-dialog__content {
-  min-width: 420px;
+  min-width: 100%;
 }
 
 .node-file-manager-dialog__label {
   margin: 0 0 8px;
   font-weight: 500;
-  color: rgba(0, 0, 0, 0.6);
+  color: var(--mat-sys-on-surface);
 }
 
 .node-file-manager-dialog__path-row {
   display: flex;
   align-items: center;
   gap: 4px;
-  background: rgba(0, 0, 0, 0.04);
+  background: var(--mat-sys-surface-container-low);
   border-radius: 4px;
   padding: 8px 4px 8px 12px;
 }

--- a/src/app/components/project-map/node-file-manager-dialog/node-file-manager-dialog.component.scss
+++ b/src/app/components/project-map/node-file-manager-dialog/node-file-manager-dialog.component.scss
@@ -1,0 +1,25 @@
+.node-file-manager-dialog__content {
+  min-width: 420px;
+}
+
+.node-file-manager-dialog__label {
+  margin: 0 0 8px;
+  font-weight: 500;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.node-file-manager-dialog__path-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  background: rgba(0, 0, 0, 0.04);
+  border-radius: 4px;
+  padding: 8px 4px 8px 12px;
+}
+
+.node-file-manager-dialog__path {
+  flex: 1;
+  font-family: monospace;
+  font-size: 13px;
+  word-break: break-all;
+}

--- a/src/app/components/project-map/node-file-manager-dialog/node-file-manager-dialog.component.ts
+++ b/src/app/components/project-map/node-file-manager-dialog/node-file-manager-dialog.component.ts
@@ -1,0 +1,40 @@
+import { ChangeDetectionStrategy, Component, Inject } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDialogModule, MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { MatIconModule } from '@angular/material/icon';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { ClipboardModule, Clipboard } from '@angular/cdk/clipboard';
+
+export interface NodeFileManagerDialogData {
+  nodeName: string;
+  nodeDirectory: string;
+  controllerName: string;
+}
+
+@Component({
+  standalone: true,
+  selector: 'app-node-file-manager-dialog',
+  templateUrl: './node-file-manager-dialog.component.html',
+  styleUrls: ['./node-file-manager-dialog.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [MatDialogModule, MatButtonModule, MatIconModule, MatTooltipModule, ClipboardModule],
+})
+export class NodeFileManagerDialogComponent {
+  copied = false;
+
+  constructor(
+    public dialogRef: MatDialogRef<NodeFileManagerDialogComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: NodeFileManagerDialogData,
+    private clipboard: Clipboard
+  ) {}
+
+  copyPath() {
+    this.clipboard.copy(this.data.nodeDirectory);
+    this.copied = true;
+    setTimeout(() => (this.copied = false), 2000);
+  }
+
+  onCloseClick() {
+    this.dialogRef.close();
+  }
+}


### PR DESCRIPTION


## Feature: Show in File Manager — node server path dialog

### Overview

Adds a **Show in file manager** context menu option to nodes on the project map, mirroring the equivalent feature available in the GNS3 desktop GUI. Because the web UI runs in a browser and cannot open the native file manager directly, the feature instead shows a dialog with the node's server-side directory path and a one-click copy-to-clipboard button.

---

### Behaviour

- Right-click any node on the project map.
- Select **Show in file manager** (listed directly below **Show node information**).
- A dialog opens showing:
  - The node name as the dialog title.
  - The label **"Node directory on server `<server name>`:"** — the server name is taken from `controller.name`, falling back to `controller.host`, so it is always meaningful when multiple controllers are in use.
  - The full server-side path of the node directory in a monospaced block.
  - A copy-to-clipboard icon button; clicking it switches to a ✓ icon for 2 seconds to confirm the copy.
  - A **Close** button.
- If the node has not been started and has no directory assigned yet, a descriptive message is shown instead of an empty path: *"Directory not available (node may not be running)"*.

> **Note:** Unlike the desktop GUI, this feature does not attempt to open the native file manager for local servers — that is not possible in a browser context. The dialog approach works consistently for both local and remote servers.

---
### Testing

1. Start a project and place at least one node.
2. Right-click the node — confirm Show in file manager appears directly below Show node information.
3. Click Show in file manager:
4. Dialog title shows the node name.
5. Label shows "Node directory on server <your server name>:".
6. Click the copy icon — it switches to ✓ for ~2 seconds, then reverts.
7. Paste the clipboard contents and confirm the path matches the node directory.
8. Click Close — dialog dismisses cleanly.
---
