### PR TITLE
fix: navigator.clipboard undefined in API key display dialog

### DIFF
--- a/src/app/components/api-key-management/api-key-display-dialog/api-key-display-dialog.component.ts
+++ b/src/app/components/api-key-management/api-key-display-dialog/api-key-display-dialog.component.ts
@@ -4,6 +4,7 @@ import { MatDialogModule, MAT_DIALOG_DATA, MatDialogRef } from '@angular/materia
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { Clipboard } from '@angular/cdk/clipboard';
 import { ApiKeyCreatedResponse } from '@models/api/api-key';
 
 export interface ApiKeyDisplayDialogData {
@@ -21,13 +22,18 @@ export interface ApiKeyDisplayDialogData {
 export class ApiKeyDisplayDialogComponent {
   private dialogRef = inject(MatDialogRef<ApiKeyDisplayDialogComponent>);
   private snackBar = inject(MatSnackBar);
+  private clipboard = inject(Clipboard);
 
   constructor(@Inject(MAT_DIALOG_DATA) public data: ApiKeyDisplayDialogData) {}
 
   copyKey() {
-    navigator.clipboard.writeText(this.data.response.api_key).then(() => {
+    const key = this.data.response.api_key;
+    const copied = this.clipboard.copy(key);
+    if (copied) {
       this.snackBar.open('API key copied to clipboard', 'Close', { duration: 3000 });
-    });
+    } else {
+      this.snackBar.open('Failed to copy. Please copy the key manually.', 'Close', { duration: 5000 });
+    }
   }
 
   onClose() {


### PR DESCRIPTION
## Description

When opening the API key display dialog on an HTTP connection (non-HTTPS) or in restricted browser environments, calling `navigator.clipboard.writeText()` throws `Cannot access property "writeText", navigator.clipboard is undefined`.

## Fix

Use Angular CDK's `Clipboard` service instead of directly calling `navigator.clipboard.writeText()`. The CDK Clipboard service:
- Tries `navigator.clipboard.writeText()` first when available
- Falls back to `document.execCommand('copy')` via a temporary textarea element when the Clipboard API is unavailable
- Returns a boolean indicating success, allowing proper user feedback

This service is already used elsewhere in the project (`node-file-manager-page`), so no new dependencies are introduced.

## Changes

- `src/app/components/api-key-management/api-key-display-dialog/api-key-display-dialog.component.ts` — replaced direct `navigator.clipboard.writeText()` with Angular CDK `Clipboard.copy()` and added failure handling