### PR TITLE
feat: add refresh token support for silent auth renewal

### DIFF
--- a/src/app/components/login/login.component.ts
+++ b/src/app/components/login/login.component.ts
@@ -174,6 +174,12 @@ export class LoginComponent implements OnInit {
       next: async (response: AuthResponse) => {
         let controller = this.controller;
         controller.authToken = response.access_token;
+
+        // Save refresh_token for silent token refresh
+        if (response.refresh_token) {
+          localStorage.setItem(`refresh_token_${controller.id}`, response.refresh_token);
+        }
+
         controller.username = username;
         controller.password = password;
         controller.tokenExpired = false;

--- a/src/app/layouts/default-layout/default-layout.component.ts
+++ b/src/app/layouts/default-layout/default-layout.component.ts
@@ -182,6 +182,9 @@ export class DefaultLayoutComponent implements OnInit, OnDestroy {
 
   logout() {
     this.controllerService.get(+this.controllerId).then((controller: Controller) => {
+      // Clear refresh token
+      localStorage.removeItem(`refresh_token_${controller.id}`);
+
       controller.authToken = null;
       this.controllerService
         .update(controller)

--- a/src/app/models/authResponse.ts
+++ b/src/app/models/authResponse.ts
@@ -1,4 +1,5 @@
 export interface AuthResponse {
   access_token: string;
   token_type: string;
+  refresh_token?: string;
 }

--- a/src/app/services/http-controller.service.ts
+++ b/src/app/services/http-controller.service.ts
@@ -1,9 +1,10 @@
 import { HttpClient, HttpErrorResponse, HttpHeaders, HttpParams } from '@angular/common/http';
 import { EventEmitter, Injectable } from '@angular/core';
 import { environment } from 'environments/environment';
-import { Observable, throwError } from 'rxjs';
-import { catchError } from 'rxjs/operators';
+import { Observable, from, throwError } from 'rxjs';
+import { catchError, switchMap } from 'rxjs/operators';
 import { Controller, ControllerProtocol } from '@models/controller';
+import { AuthResponse } from '@models/authResponse';
 
 /* tslint:disable:interface-over-type-literal */
 export type JsonOptions = {
@@ -103,6 +104,10 @@ export class ControllerErrorHandler {
 export class HttpController {
   public requestsNotificationEmitter = new EventEmitter<string>();
 
+  // Refresh token state
+  private isRefreshing = false;
+  private failedQueue: { resolve: () => void; reject: (error: unknown) => void }[] = [];
+
   constructor(private http: HttpClient, private errorHandler: ControllerErrorHandler) {}
 
   get<T>(controller: Controller, url: string, options?: JsonOptions): Observable<T> {
@@ -110,9 +115,11 @@ export class HttpController {
     const intercepted = this.getOptionsForController<JsonOptions>(controller, url, options);
     this.requestsNotificationEmitter.emit(`GET ${intercepted.url}`);
 
-    return this.http
-      .get<T>(intercepted.url, intercepted.options as JsonOptions)
-      .pipe(catchError<T, any>(this.errorHandler.handleError)) as Observable<T>;
+    return this.handleResponse<T>(
+      controller,
+      this.http.get<T>(intercepted.url, intercepted.options as JsonOptions),
+      'GET', url, null, options
+    );
   }
 
   getText(controller: Controller, url: string, options?: TextOptions): Observable<string> {
@@ -120,9 +127,11 @@ export class HttpController {
     const intercepted = this.getOptionsForController<TextOptions>(controller, url, options);
     this.requestsNotificationEmitter.emit(`GET ${intercepted.url}`);
 
-    return this.http
-      .get(intercepted.url, intercepted.options as TextOptions)
-      .pipe(catchError(this.errorHandler.handleError));
+    return this.handleResponse<string>(
+      controller,
+      this.http.get(intercepted.url, intercepted.options as TextOptions),
+      'GET', url, null, options
+    );
   }
 
   getBlob(controller: Controller, url: string, options?: BlobOptions): Observable<Blob> {
@@ -130,9 +139,11 @@ export class HttpController {
     const intercepted = this.getOptionsForController<BlobOptions>(controller, url, options);
     this.requestsNotificationEmitter.emit(`GET ${intercepted.url}`);
 
-    return this.http
-      .get(intercepted.url, intercepted.options as BlobOptions)
-      .pipe(catchError(this.errorHandler.handleError));
+    return this.handleResponse<Blob>(
+      controller,
+      this.http.get(intercepted.url, intercepted.options as BlobOptions),
+      'GET', url, null, options
+    );
   }
 
   post<T>(controller: Controller, url: string, body: any | null, options?: JsonOptions): Observable<T> {
@@ -140,9 +151,11 @@ export class HttpController {
     const intercepted = this.getOptionsForController(controller, url, options);
     this.requestsNotificationEmitter.emit(`POST ${intercepted.url}`);
 
-    return this.http
-      .post<T>(intercepted.url, body, intercepted.options)
-      .pipe(catchError<T, any>(this.errorHandler.handleError)) as Observable<T>;
+    return this.handleResponse<T>(
+      controller,
+      this.http.post<T>(intercepted.url, body, intercepted.options),
+      'POST', url, body, options
+    );
   }
 
   postBlob(controller: Controller, url: string, body: Blob): Observable<Blob> {
@@ -153,7 +166,11 @@ export class HttpController {
     const intercepted = this.getOptionsForController<BlobOptions>(controller, url, options);
     this.requestsNotificationEmitter.emit(`POST ${intercepted.url}`);
 
-    return this.http.post(intercepted.url, body, intercepted.options).pipe(catchError(this.errorHandler.handleError));
+    return this.handleResponse<Blob>(
+      controller,
+      this.http.post(intercepted.url, body, intercepted.options),
+      'POST', url, body, options
+    );
   }
 
   put<T>(controller: Controller, url: string, body: any, options?: JsonOptions): Observable<T> {
@@ -161,9 +178,11 @@ export class HttpController {
     const intercepted = this.getOptionsForController(controller, url, options);
     this.requestsNotificationEmitter.emit(`PUT ${intercepted.url}`);
 
-    return this.http
-      .put<T>(intercepted.url, body, intercepted.options)
-      .pipe(catchError<T, any>(this.errorHandler.handleError)) as Observable<T>;
+    return this.handleResponse<T>(
+      controller,
+      this.http.put<T>(intercepted.url, body, intercepted.options),
+      'PUT', url, body, options
+    );
   }
 
   delete<T>(controller: Controller, url: string, options?: JsonOptions): Observable<T> {
@@ -171,33 +190,41 @@ export class HttpController {
     const intercepted = this.getOptionsForController(controller, url, options);
     this.requestsNotificationEmitter.emit(`DELETE ${intercepted.url}`);
 
-    return this.http
-      .delete<T>(intercepted.url, intercepted.options)
-      .pipe(catchError<T, any>(this.errorHandler.handleError)) as Observable<T>;
+    return this.handleResponse<T>(
+      controller,
+      this.http.delete<T>(intercepted.url, intercepted.options),
+      'DELETE', url, null, options
+    );
   }
 
   patch<T>(controller: Controller, url: string, body: any, options?: JsonOptions): Observable<T> {
     options = this.getJsonOptions(options);
     const intercepted = this.getOptionsForController(controller, url, options);
-    return this.http
-      .patch<T>(intercepted.url, body, intercepted.options)
-      .pipe(catchError<T, any>(this.errorHandler.handleError)) as Observable<T>;
+    return this.handleResponse<T>(
+      controller,
+      this.http.patch<T>(intercepted.url, body, intercepted.options),
+      'PATCH', url, body, options
+    );
   }
 
   head<T>(controller: Controller, url: string, options?: JsonOptions): Observable<T> {
     options = this.getJsonOptions(options);
     const intercepted = this.getOptionsForController(controller, url, options);
-    return this.http
-      .head<T>(intercepted.url, intercepted.options)
-      .pipe(catchError<T, any>(this.errorHandler.handleError)) as Observable<T>;
+    return this.handleResponse<T>(
+      controller,
+      this.http.head<T>(intercepted.url, intercepted.options),
+      'HEAD', url, null, options
+    );
   }
 
   options<T>(controller: Controller, url: string, options?: JsonOptions): Observable<T> {
     options = this.getJsonOptions(options);
     const intercepted = this.getOptionsForController(controller, url, options);
-    return this.http
-      .options<T>(intercepted.url, intercepted.options)
-      .pipe(catchError<T, any>(this.errorHandler.handleError)) as Observable<T>;
+    return this.handleResponse<T>(
+      controller,
+      this.http.options<T>(intercepted.url, intercepted.options),
+      'OPTIONS', url, null, options
+    );
   }
 
   private getJsonOptions(options: JsonOptions): JsonOptions {
@@ -249,5 +276,147 @@ export class HttpController {
       url: url,
       options: options,
     };
+  }
+
+  /**
+   * Wrap an HTTP observable with 401 intercept logic for silent token refresh.
+   */
+  private handleResponse<T>(
+    controller: Controller,
+    source$: Observable<T>,
+    method: string,
+    url: string,
+    body: any | null,
+    options: any,
+  ): Observable<T> {
+    return source$.pipe(
+      catchError((error: HttpErrorResponse) => {
+        // Only intercept 401; skip auth endpoints to avoid loops
+        if (error.status !== 401) {
+          return this.errorHandler.handleError(error);
+        }
+        if (
+          url.endsWith('/access/users/login') ||
+          url.endsWith('/access/users/authenticate') ||
+          url.endsWith('/access/users/refresh')
+        ) {
+          return this.errorHandler.handleError(error);
+        }
+
+        const refreshToken = localStorage.getItem(`refresh_token_${controller.id}`);
+        if (!refreshToken) {
+          this.redirectToLogin(controller);
+          return throwError(() => error);
+        }
+
+        return this.retryAfterRefresh<T>(controller, method, url, body, options, refreshToken);
+      }),
+    );
+  }
+
+  /**
+   * Attempt to refresh the access token and retry the original request.
+   */
+  private retryAfterRefresh<T>(
+    controller: Controller,
+    method: string,
+    url: string,
+    body: any | null,
+    options: any,
+    refreshToken: string,
+  ): Observable<T> {
+    // Another refresh is already in-flight — queue this request
+    if (this.isRefreshing) {
+      return new Observable<T>((subscriber) => {
+        this.failedQueue.push({
+          resolve: () => {
+            this.executeRequest<T>(controller, method, url, body, options).subscribe({
+              next: (v) => {
+                subscriber.next(v);
+                subscriber.complete();
+              },
+              error: (e) => subscriber.error(e),
+            });
+          },
+          reject: (err) => subscriber.error(err),
+        });
+      });
+    }
+
+    // Start the refresh
+    this.isRefreshing = true;
+    return this.doRefreshToken(controller, refreshToken).pipe(
+      switchMap((response) => {
+        // Update tokens
+        controller.authToken = response.access_token;
+        localStorage.setItem(`controller-${controller.id}`, JSON.stringify(controller));
+        if (response.refresh_token) {
+          localStorage.setItem(`refresh_token_${controller.id}`, response.refresh_token);
+        }
+
+        // Drain the queue of requests that arrived while we were refreshing
+        this.isRefreshing = false;
+        this.processQueue(null);
+
+        // Retry the original request
+        return this.executeRequest<T>(controller, method, url, body, options);
+      }),
+      catchError((refreshError) => {
+        this.isRefreshing = false;
+        this.processQueue(refreshError);
+        this.clearTokens(controller);
+        this.redirectToLogin(controller);
+        return throwError(() => refreshError);
+      }),
+    );
+  }
+
+  /**
+   * Call the refresh endpoint to obtain a new access token.
+   */
+  private doRefreshToken(controller: Controller, refreshToken: string): Observable<AuthResponse> {
+    const url = `${controller.protocol}//${controller.host}:${controller.port}/${environment.current_version}/access/users/refresh`;
+    return this.http.post<AuthResponse>(url, { refresh_token: refreshToken }, {
+      headers: new HttpHeaders({ 'Content-Type': 'application/json' }),
+    });
+  }
+
+  /**
+   * Re-execute a request with the current controller state (rebuilds URL + auth headers).
+   */
+  private executeRequest<T>(
+    controller: Controller,
+    method: string,
+    url: string,
+    body: any | null,
+    options: any,
+  ): Observable<T> {
+    const intercepted = this.getOptionsForController(controller, url, options);
+    this.requestsNotificationEmitter.emit(`${method} ${intercepted.url}`);
+    return this.http.request<T>(method, intercepted.url, {
+      body: body,
+      headers: intercepted.options.headers,
+      params: intercepted.options.params,
+      responseType: intercepted.options.responseType || ('json' as const),
+    }) as Observable<T>;
+  }
+
+  private processQueue(error: unknown): void {
+    if (error) {
+      this.failedQueue.forEach((p) => p.reject(error));
+    } else {
+      this.failedQueue.forEach((p) => p.resolve());
+    }
+    this.failedQueue = [];
+  }
+
+  private clearTokens(controller: Controller): void {
+    localStorage.removeItem(`refresh_token_${controller.id}`);
+    controller.authToken = null;
+    localStorage.setItem(`controller-${controller.id}`, JSON.stringify(controller));
+  }
+
+  private redirectToLogin(controller: Controller): void {
+    window.location.href = `/controller/${controller.id}/login`;
   }
 }


### PR DESCRIPTION
This PR adds refresh token support for the GNS3 Web UI, enabling silent authentication renewal when the access token expires.

### Changes

1. **AuthResponse model** — Added optional `refresh_token` field to the interface
2. **Login flow** — Save `refresh_token` to localStorage on successful login/authenticate
3. **HTTP 401 interceptor** — When any API call returns 401:
   - Silently calls `POST /v3/access/users/refresh` with the stored refresh token
   - Updates both tokens on success and retries the original request
   - Queues concurrent 401s during refresh so only one refresh request is made
   - Redirects to login if refresh fails (token expired or missing)
4. **Logout** — Cleans up refresh token from localStorage

### Related

- Closes #2786
- Depends on gns3/gns3-server#2792 (backend refresh token endpoint)

### Testing

1. Login to a controller
2. Verify `refresh_token_<id>` appears in localStorage
3. Manually expire the access token in localStorage, then trigger any API call — observe the silent 401 → refresh → retry flow in the Network tab
4. Click Logout — verify the refresh token is removed