### PR TITLE
fix: cleanup unused import and guard token cleanup on retry

### DIFF
--- a/src/app/services/http-controller.service.ts
+++ b/src/app/services/http-controller.service.ts
@@ -1,7 +1,7 @@
 import { HttpClient, HttpErrorResponse, HttpHeaders, HttpParams } from '@angular/common/http';
 import { EventEmitter, Injectable } from '@angular/core';
 import { environment } from 'environments/environment';
-import { Observable, from, throwError } from 'rxjs';
+import { Observable, throwError } from 'rxjs';
 import { catchError, switchMap } from 'rxjs/operators';
 import { Controller, ControllerProtocol } from '@models/controller';
 import { AuthResponse } from '@models/authResponse';
@@ -364,8 +364,12 @@ export class HttpController {
       catchError((refreshError) => {
         this.isRefreshing = false;
         this.processQueue(refreshError);
-        this.clearTokens(controller);
-        this.redirectToLogin(controller);
+        // Only clear tokens and redirect on 401; preserve tokens for other errors
+        // (e.g. network failure, server error) so the user can retry
+        if (refreshError.status === 401) {
+          this.clearTokens(controller);
+          this.redirectToLogin(controller);
+        }
         return throwError(() => refreshError);
       }),
     );


### PR DESCRIPTION
Follow-up to PR #1728 (refresh token support).

### Changes

- Remove unused `from` import in `http-controller.service.ts`
- Only clear tokens and redirect to login when the retried request fails with **401**; for other errors (network failure, server 500) preserve tokens so the user can retry without logging in again