### PR TITLE
fix: redirect to login via Router to avoid 404 in server-hosted web UI

### DIFF
--- a/src/app/services/http-controller.service.spec.ts
+++ b/src/app/services/http-controller.service.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { TestBed } from '@angular/core/testing';
 import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { Router } from '@angular/router';
 import { HttpController, ControllerError, ControllerErrorHandler, JsonOptions } from './http-controller.service';
 import { Controller, ControllerProtocol } from '@models/controller';
 import { environment } from '../../environments/environment';
@@ -11,6 +12,7 @@ describe('HttpController', () => {
   let service: HttpController;
   let mockHttp: HttpClient;
   let mockErrorHandler: ControllerErrorHandler;
+  let mockRouter: Router;
   let mockController: Controller;
 
   beforeEach(() => {
@@ -32,7 +34,9 @@ describe('HttpController', () => {
       handleError: vi.fn((err: any) => throwError(() => err)),
     } as any as ControllerErrorHandler;
 
-    service = new HttpController(mockHttp, mockErrorHandler);
+    mockRouter = { navigate: vi.fn() } as any as Router;
+
+    service = new HttpController(mockHttp, mockErrorHandler, mockRouter);
 
     mockController = {
       id: 1,
@@ -449,6 +453,17 @@ describe('HttpController', () => {
       });
 
       expect(mockErrorHandler.handleError).toHaveBeenCalled();
+    });
+  });
+
+  describe('Token Expiry Redirect', () => {
+    it('should navigate to login via Router (not a full-page reload) on 401 without refresh token', () => {
+      const error401 = new HttpErrorResponse({ status: 401, statusText: 'Unauthorized' });
+      (mockHttp.get as any).mockReturnValue(throwError(() => error401));
+
+      service.get(mockController, '/test').subscribe({ error: () => {} });
+
+      expect(mockRouter.navigate).toHaveBeenCalledWith(['/controller', mockController.id, 'login']);
     });
   });
 

--- a/src/app/services/http-controller.service.ts
+++ b/src/app/services/http-controller.service.ts
@@ -1,5 +1,6 @@
 import { HttpClient, HttpErrorResponse, HttpHeaders, HttpParams } from '@angular/common/http';
 import { EventEmitter, Injectable } from '@angular/core';
+import { Router } from '@angular/router';
 import { environment } from 'environments/environment';
 import { Observable, throwError } from 'rxjs';
 import { catchError, switchMap } from 'rxjs/operators';
@@ -108,7 +109,11 @@ export class HttpController {
   private isRefreshing = false;
   private failedQueue: { resolve: () => void; reject: (error: unknown) => void }[] = [];
 
-  constructor(private http: HttpClient, private errorHandler: ControllerErrorHandler) {}
+  constructor(
+    private http: HttpClient,
+    private errorHandler: ControllerErrorHandler,
+    private router: Router,
+  ) {}
 
   get<T>(controller: Controller, url: string, options?: JsonOptions): Observable<T> {
     options = this.getJsonOptions(options);
@@ -367,7 +372,6 @@ export class HttpController {
         // Only clear tokens and redirect on 401; preserve tokens for other errors
         // (e.g. network failure, server error) so the user can retry
         if (refreshError.status === 401) {
-          this.clearTokens(controller);
           this.redirectToLogin(controller);
         }
         return throwError(() => refreshError);
@@ -421,6 +425,15 @@ export class HttpController {
   }
 
   private redirectToLogin(controller: Controller): void {
-    window.location.href = `/controller/${controller.id}/login`;
+    // An in-app Router navigation does not reset singletons the way a full-page
+    // reload would, so explicitly tear down the refresh-token flow state and
+    // persisted auth first. Otherwise LoginComponent sees the stale authToken
+    // and navigates back to projects, causing a login loop.
+    this.clearTokens(controller);
+    controller.tokenExpired = true;
+    localStorage.setItem(`controller-${controller.id}`, JSON.stringify(controller));
+    this.isRefreshing = false;
+    this.processQueue(new Error('Session expired, redirecting to login'));
+    this.router.navigate(['/controller', controller.id, 'login']);
   }
 }


### PR DESCRIPTION
## Problem

When the web UI is hosted by gns3-server (served under `/static/web-ui/`), users hit a 404 once their access token expires:

```
GET http://<server>:3080/controller/1/login  404 (Not Found)
```

The standalone / dev-server scenario is unaffected.

## Root cause

`HttpController.redirectToLogin()` used `window.location.href` with a **root-absolute** path (`/controller/:id/login`), which forces a full-page HTTP GET. In the server-hosted deployment the UI lives under `/static/web-ui/`, so `/controller/:id/login` falls outside the mount point and the server returns 404.

This is a regression introduced in 7840f2a5 ("feat: add refresh token support for silent auth renewal"). The dev scenario worked because it is root-deployed with SPA fallback.

## Fix

Replace the full-page redirect with in-app Angular `Router` navigation, which respects the base href and issues no HTTP request. A full-page reload used to discard the refresh-token flow state for free, so that teardown is now done explicitly before navigating:

- `clearTokens()` — drop the stale access/refresh tokens. Without this, `LoginComponent` still sees the cached `authToken` and navigates back to projects, causing a login loop.
- `controller.tokenExpired = true`
- `isRefreshing = false`
- reject the pending request queue

`redirectToLogin` now owns all teardown, so the redundant `clearTokens` call in `retryAfterRefresh` was removed.

## Testing

- **Unit**: 48/48 passing. Added a case asserting that a 401 with no refresh token navigates via `Router` instead of triggering a full-page reload.
- **Manual (server-hosted at 192.168.1.3:3080)**: set `jwt_access_token_expire_minutes = 5` and `jwt_refresh_token_expire_minutes = 10`, logged in, waited past token expiry, then interacted. The UI landed smoothly on the login page — **no `GET /controller/1/login` 404** — and re-login succeeded.