### PR TITLE
feat(cloud): show host interface IP addresses, status, speed, MTU and flags

### DIFF
--- a/src/app/cartography/models/node.ts
+++ b/src/app/cartography/models/node.ts
@@ -8,10 +8,17 @@ export class PortsMapping {
   type?: string;
 }
 
+export interface HostInterfaceIPAddress {
+  family: string; // 'ipv4' | 'ipv6'
+  address: string;
+  netmask: string;
+}
+
 export interface NetworkInterface {
   name: string;
   special: boolean;
   type: string;
+  ip_addresses?: HostInterfaceIPAddress[];
 }
 
 export class Properties {

--- a/src/app/cartography/models/node.ts
+++ b/src/app/cartography/models/node.ts
@@ -19,6 +19,10 @@ export interface NetworkInterface {
   special: boolean;
   type: string;
   ip_addresses?: HostInterfaceIPAddress[];
+  status?: string; // 'up' | 'down' — link carrier state (psutil isup)
+  speed?: number; // Mbit/s, 0 = unknown
+  mtu?: number;
+  flags?: string[]; // normalized Linux interface flags
 }
 
 export class Properties {

--- a/src/app/components/project-map/context-menu/context-menu.component.html
+++ b/src/app/components/project-map/context-menu/context-menu.component.html
@@ -3,7 +3,7 @@
   <mat-menu #contextMenu="matMenu" class="context-menu-items">
     @if (nodes.length === 1) {
     <app-show-node-action [controller]="controller" [node]="nodes[0]"></app-show-node-action>
-    } @if (nodes.length === 1) {
+    } @if (nodes.length === 1 && nodes[0].node_type !== 'cloud') {
     <app-show-in-file-manager-action [controller]="controller" [node]="nodes[0]" (openFileManagerInline)="onOpenFileManagerInline($event)"></app-show-in-file-manager-action>
     } @if (nodes.length === 1) {
     <app-config-node-action [controller]="controller" [node]="nodes[0]"></app-config-node-action>
@@ -15,16 +15,16 @@
     <app-stop-node-action [controller]="controller" [nodes]="nodes"></app-stop-node-action>
     } @if (nodes.length) {
     <app-reload-node-action [controller]="controller" [nodes]="nodes"></app-reload-node-action>
-    } @if (!projectService.isReadOnly(project) && nodes.length > 0) {
+    } @if (!projectService.isReadOnly(project) && nodes.length > 0 && nodes[0].node_type !== 'cloud') {
     <app-http-console-action
       [controller]="controller"
       [project]="project"
       [nodes]="nodes"
       (openWebConsoleInline)="onOpenWebConsoleInline($event)"
     ></app-http-console-action>
-    } @if (!projectService.isReadOnly(project) && nodes.length > 0) {
+    } @if (!projectService.isReadOnly(project) && nodes.length > 0 && nodes[0].node_type !== 'cloud') {
     <app-http-console-new-tab-action [controller]="controller" [nodes]="nodes"></app-http-console-new-tab-action>
-    } @if (!projectService.isReadOnly(project) && nodes.length === 1) {
+    } @if (!projectService.isReadOnly(project) && nodes.length === 1 && nodes[0].node_type !== 'cloud') {
     <app-console-device-action-browser [controller]="controller" [node]="nodes[0]"></app-console-device-action-browser>
     } @if (nodes.length === 1) {
     <app-isolate-node-action [controller]="controller" [node]="nodes[0]"></app-isolate-node-action>

--- a/src/app/components/project-map/node-editors/configurator/cloud/configurator-cloud.component.html
+++ b/src/app/components/project-map/node-editors/configurator/cloud/configurator-cloud.component.html
@@ -11,9 +11,18 @@
               <div class="add-interface-row">
                 <mat-form-field>
                   <mat-label>Ethernet interface</mat-label>
-                  <mat-select [value]="ethernetInterface()" (selectionChange)="ethernetInterface.set($event.value)">
-                    @for (iface of availableEthernetInterfaces; track iface) {
-                    <mat-option [value]="iface">{{ iface }}</mat-option>
+                  <mat-select
+                    panelClass="cloud-ethernet-select-panel"
+                    [value]="ethernetInterface()"
+                    (selectionChange)="ethernetInterface.set($event.value)"
+                  >
+                    @for (iface of availableEthernetInterfaces; track iface.name) {
+                    <mat-option [value]="iface.name">
+                      <span class="cloud-iface-option__name">{{ iface.name }}</span>
+                      @if (formatIpAddresses(iface.ip_addresses); as ips) {
+                      <span class="cloud-iface-option__ips">{{ ips }}</span>
+                      }
+                    </mat-option>
                     }
                   </mat-select>
                 </mat-form-field>
@@ -24,6 +33,13 @@
                 <ng-container matColumnDef="name">
                   <th mat-header-cell *matHeaderCellDef>Interface</th>
                   <td mat-cell *matCellDef="let element">{{ element.name }}</td>
+                </ng-container>
+
+                <ng-container matColumnDef="ipAddresses">
+                  <th mat-header-cell *matHeaderCellDef>IP addresses</th>
+                  <td mat-cell *matCellDef="let element">
+                    {{ formatIpAddresses(getHostInterfaceIps(element.interface || element.name)) || '—' }}
+                  </td>
                 </ng-container>
 
                 <ng-container matColumnDef="actions">

--- a/src/app/components/project-map/node-editors/configurator/cloud/configurator-cloud.component.html
+++ b/src/app/components/project-map/node-editors/configurator/cloud/configurator-cloud.component.html
@@ -38,7 +38,11 @@
                 <ng-container matColumnDef="ipAddresses">
                   <th mat-header-cell *matHeaderCellDef>IP addresses</th>
                   <td mat-cell *matCellDef="let element">
-                    {{ formatIpAddresses(getHostInterfaceIps(element.interface || element.name)) || '—' }}
+                    @for (ip of getHostInterfaceIps(element.interface || element.name); track ip.address) {
+                      <div class="cloud-ip-line">{{ formatIpAddress(ip) }}</div>
+                    } @empty {
+                      —
+                    }
                   </td>
                 </ng-container>
 

--- a/src/app/components/project-map/node-editors/configurator/cloud/configurator-cloud.component.html
+++ b/src/app/components/project-map/node-editors/configurator/cloud/configurator-cloud.component.html
@@ -16,12 +16,22 @@
                     [value]="ethernetInterface()"
                     (selectionChange)="ethernetInterface.set($event.value)"
                   >
+                    <span mat-select-trigger>{{ ethernetInterface() }}</span>
                     @for (iface of availableEthernetInterfaces; track iface.name) {
                     <mat-option [value]="iface.name">
-                      <span class="cloud-iface-option__name">{{ iface.name }}</span>
-                      @if (formatIpAddresses(iface.ip_addresses); as ips) {
-                      <span class="cloud-iface-option__ips">{{ ips }}</span>
-                      }
+                      <div class="cloud-iface-option">
+                        <div class="cloud-iface-option__head">
+                          <span
+                            class="cloud-iface-status"
+                            [class.cloud-iface-status--up]="iface.status === 'up'"
+                            [class.cloud-iface-status--down]="iface.status !== 'up'"
+                          ></span>
+                          <span class="cloud-iface-option__name">{{ iface.name }}</span>
+                        </div>
+                        @for (ip of iface.ip_addresses || []; track ip.address) {
+                          <span class="cloud-iface-option__ip">{{ formatIpAddress(ip) }}</span>
+                        }
+                      </div>
                     </mat-option>
                     }
                   </mat-select>
@@ -32,7 +42,25 @@
               <table mat-table [dataSource]="portsMappingEthernet" class="interfaces-table">
                 <ng-container matColumnDef="name">
                   <th mat-header-cell *matHeaderCellDef>Interface</th>
-                  <td mat-cell *matCellDef="let element">{{ element.name }}</td>
+                  <td mat-cell *matCellDef="let element">
+                    @if (getHostInterface(element.interface || element.name); as host) {
+                      <div class="cloud-iface-cell">
+                        <span [matTooltip]="formatFlags(host.flags) || null">
+                          <span
+                            class="cloud-iface-status"
+                            [class.cloud-iface-status--up]="host.status === 'up'"
+                            [class.cloud-iface-status--down]="host.status !== 'up'"
+                          ></span>
+                          {{ element.name }}
+                        </span>
+                        @if (formatInterfaceMeta(host); as meta) {
+                          <span class="cloud-iface-meta">{{ meta }}</span>
+                        }
+                      </div>
+                    } @else {
+                      {{ element.name }}
+                    }
+                  </td>
                 </ng-container>
 
                 <ng-container matColumnDef="ipAddresses">

--- a/src/app/components/project-map/node-editors/configurator/cloud/configurator-cloud.component.html
+++ b/src/app/components/project-map/node-editors/configurator/cloud/configurator-cloud.component.html
@@ -16,7 +16,7 @@
                     [value]="ethernetInterface()"
                     (selectionChange)="ethernetInterface.set($event.value)"
                   >
-                    <span mat-select-trigger>{{ ethernetInterface() }}</span>
+                    <mat-select-trigger>{{ ethernetInterface() }}</mat-select-trigger>
                     @for (iface of availableEthernetInterfaces; track iface.name) {
                     <mat-option [value]="iface.name">
                       <div class="cloud-iface-option">

--- a/src/app/components/project-map/node-editors/configurator/cloud/configurator-cloud.component.spec.ts
+++ b/src/app/components/project-map/node-editors/configurator/cloud/configurator-cloud.component.spec.ts
@@ -234,6 +234,43 @@ describe('ConfiguratorDialogCloudComponent', () => {
     });
   });
 
+  describe('getHostInterfaceIps', () => {
+    it('returns ip_addresses for a matching host interface', () => {
+      component.node = {
+        ...mockNode,
+        properties: {
+          ...mockNode.properties,
+          interfaces: [
+            {
+              name: 'eth0',
+              special: false,
+              type: 'ethernet',
+              ip_addresses: [{ family: 'ipv4', address: '192.168.1.5', netmask: '255.255.255.0' }],
+            },
+          ],
+        } as any,
+      };
+
+      const ips = component.getHostInterfaceIps('eth0');
+
+      expect(ips).toHaveLength(1);
+      expect(ips[0].address).toBe('192.168.1.5');
+    });
+
+    it('returns an empty array when the host interface is not found', () => {
+      component.node = { ...mockNode };
+
+      expect(component.getHostInterfaceIps('unknown')).toEqual([]);
+    });
+
+    it('returns an empty array when interfaces are absent', () => {
+      component.node = { ...mockNode, properties: { ...mockNode.properties } as any };
+      delete (component.node.properties as any).interfaces;
+
+      expect(component.getHostInterfaceIps('eth0')).toEqual([]);
+    });
+  });
+
   describe('onAddEthernetInterface', () => {
     beforeEach(() => {
       mockCloudValidationService.validateInterfaceName.mockReturnValue({ isValid: true });

--- a/src/app/components/project-map/node-editors/configurator/cloud/configurator-cloud.component.ts
+++ b/src/app/components/project-map/node-editors/configurator/cloud/configurator-cloud.component.ts
@@ -16,7 +16,7 @@ import { COMMA, ENTER } from '@angular/cdk/keycodes';
 import { Node } from '../../../../../cartography/models/node';
 import type { HostInterfaceIPAddress, NetworkInterface } from '../../../../../cartography/models/node';
 import { UdpTunnelsComponent } from '@components/preferences/common/udp-tunnels/udp-tunnels.component';
-import { formatIpAddresses } from './ip-address.util';
+import { formatIpAddress, formatIpAddresses } from './ip-address.util';
 import { PortsMappingEntity } from '@models/ethernetHub/ports-mapping-enity';
 import { QemuBinary } from '@models/qemu/qemu-binary';
 import { Controller } from '@models/controller';
@@ -134,8 +134,9 @@ export class ConfiguratorDialogCloudComponent implements OnInit {
     this.consoleTypes = this.builtInTemplatesConfigurationService.getConsoleTypesForCloudNodes();
   }
 
-  /** Expose the IP formatter to the template. */
+  /** Expose the IP formatters to the template. */
   formatIpAddresses = formatIpAddresses;
+  formatIpAddress = formatIpAddress;
 
   /** Look up the host interface IP addresses bridged by a configured ethernet port. */
   getHostInterfaceIps(hostInterfaceName: string): HostInterfaceIPAddress[] {

--- a/src/app/components/project-map/node-editors/configurator/cloud/configurator-cloud.component.ts
+++ b/src/app/components/project-map/node-editors/configurator/cloud/configurator-cloud.component.ts
@@ -14,7 +14,9 @@ import { MatTableModule } from '@angular/material/table';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { COMMA, ENTER } from '@angular/cdk/keycodes';
 import { Node } from '../../../../../cartography/models/node';
+import type { HostInterfaceIPAddress, NetworkInterface } from '../../../../../cartography/models/node';
 import { UdpTunnelsComponent } from '@components/preferences/common/udp-tunnels/udp-tunnels.component';
+import { formatIpAddresses } from './ip-address.util';
 import { PortsMappingEntity } from '@models/ethernetHub/ports-mapping-enity';
 import { QemuBinary } from '@models/qemu/qemu-binary';
 import { Controller } from '@models/controller';
@@ -67,13 +69,13 @@ export class ConfiguratorDialogCloudComponent implements OnInit {
   portsMappingTap: PortsMappingEntity[] = [];
   portsMappingUdp: PortsMappingEntity[] = [];
 
-  ethernetDisplayColumns: string[] = ['name', 'actions'];
+  ethernetDisplayColumns: string[] = ['name', 'ipAddresses', 'actions'];
   tapDisplayColumns: string[] = ['name', 'actions'];
   displayedColumns: string[] = ['adapter_number', 'port_name', 'adapter_type', 'actions'];
   networkTypes = [];
   readonly tapInterface = model('');
   readonly ethernetInterface = model('');
-  availableEthernetInterfaces: string[] = [];
+  availableEthernetInterfaces: NetworkInterface[] = [];
 
   // Model signals for form fields
   readonly nodeName = model('');
@@ -107,9 +109,9 @@ export class ConfiguratorDialogCloudComponent implements OnInit {
 
         // Populate available ethernet interfaces from gns3server
         if (this.node.properties.interfaces) {
-          this.availableEthernetInterfaces = this.node.properties.interfaces
-            .filter((iface) => iface.type === 'ethernet')
-            .map((iface) => iface.name);
+          this.availableEthernetInterfaces = this.node.properties.interfaces.filter(
+            (iface) => iface.type === 'ethernet'
+          );
         }
 
         this.portsMappingEthernet = this.node.properties.ports_mapping.filter((elem) => elem.type === 'ethernet');
@@ -130,6 +132,16 @@ export class ConfiguratorDialogCloudComponent implements OnInit {
 
   getConfiguration() {
     this.consoleTypes = this.builtInTemplatesConfigurationService.getConsoleTypesForCloudNodes();
+  }
+
+  /** Expose the IP formatter to the template. */
+  formatIpAddresses = formatIpAddresses;
+
+  /** Look up the host interface IP addresses bridged by a configured ethernet port. */
+  getHostInterfaceIps(hostInterfaceName: string): HostInterfaceIPAddress[] {
+    return (
+      this.node?.properties?.interfaces?.find((iface) => iface.name === hostInterfaceName)?.ip_addresses ?? []
+    );
   }
 
   onAddEthernetInterface() {

--- a/src/app/components/project-map/node-editors/configurator/cloud/configurator-cloud.component.ts
+++ b/src/app/components/project-map/node-editors/configurator/cloud/configurator-cloud.component.ts
@@ -16,7 +16,7 @@ import { COMMA, ENTER } from '@angular/cdk/keycodes';
 import { Node } from '../../../../../cartography/models/node';
 import type { HostInterfaceIPAddress, NetworkInterface } from '../../../../../cartography/models/node';
 import { UdpTunnelsComponent } from '@components/preferences/common/udp-tunnels/udp-tunnels.component';
-import { formatIpAddress, formatIpAddresses } from './ip-address.util';
+import { formatFlags, formatIpAddress, formatIpAddresses, formatInterfaceMeta } from './ip-address.util';
 import { PortsMappingEntity } from '@models/ethernetHub/ports-mapping-enity';
 import { QemuBinary } from '@models/qemu/qemu-binary';
 import { Controller } from '@models/controller';
@@ -134,15 +134,20 @@ export class ConfiguratorDialogCloudComponent implements OnInit {
     this.consoleTypes = this.builtInTemplatesConfigurationService.getConsoleTypesForCloudNodes();
   }
 
-  /** Expose the IP formatters to the template. */
+  /** Expose the interface formatters to the template. */
   formatIpAddresses = formatIpAddresses;
   formatIpAddress = formatIpAddress;
+  formatInterfaceMeta = formatInterfaceMeta;
+  formatFlags = formatFlags;
+
+  /** Look up the full host interface bridged by a configured ethernet port. */
+  getHostInterface(hostInterfaceName: string): NetworkInterface | undefined {
+    return this.node?.properties?.interfaces?.find((iface) => iface.name === hostInterfaceName);
+  }
 
   /** Look up the host interface IP addresses bridged by a configured ethernet port. */
   getHostInterfaceIps(hostInterfaceName: string): HostInterfaceIPAddress[] {
-    return (
-      this.node?.properties?.interfaces?.find((iface) => iface.name === hostInterfaceName)?.ip_addresses ?? []
-    );
+    return this.getHostInterface(hostInterfaceName)?.ip_addresses ?? [];
   }
 
   onAddEthernetInterface() {

--- a/src/app/components/project-map/node-editors/configurator/cloud/ip-address.util.spec.ts
+++ b/src/app/components/project-map/node-editors/configurator/cloud/ip-address.util.spec.ts
@@ -1,6 +1,14 @@
 import { describe, it, expect } from 'vitest';
 import type { HostInterfaceIPAddress } from '../../../../../cartography/models/node';
-import { formatIpAddress, formatIpAddresses, netmaskToPrefix, stripScope } from './ip-address.util';
+import {
+  formatFlags,
+  formatIpAddress,
+  formatIpAddresses,
+  formatInterfaceMeta,
+  formatSpeed,
+  netmaskToPrefix,
+  stripScope,
+} from './ip-address.util';
 
 describe('stripScope', () => {
   it('removes an IPv6 scope zone', () => {
@@ -76,5 +84,50 @@ describe('formatIpAddress', () => {
   it('formats a single address with prefix and strips the scope zone', () => {
     expect(formatIpAddress({ family: 'ipv4', address: '192.168.1.5', netmask: '255.255.255.0' })).toBe('192.168.1.5/24');
     expect(formatIpAddress({ family: 'ipv6', address: 'fe80::1%eth0', netmask: 'ffff:ffff:ffff:ffff::' })).toBe('fe80::1/64');
+  });
+});
+
+describe('formatSpeed', () => {
+  it('formats megabit speeds', () => {
+    expect(formatSpeed(100)).toBe('100 Mbit/s');
+    expect(formatSpeed(10)).toBe('10 Mbit/s');
+  });
+
+  it('formats gigabit speeds', () => {
+    expect(formatSpeed(1000)).toBe('1 Gbit/s');
+    expect(formatSpeed(10000)).toBe('10 Gbit/s');
+    expect(formatSpeed(2500)).toBe('2.5 Gbit/s');
+  });
+
+  it('returns "—" for unknown / missing / non-positive speeds', () => {
+    expect(formatSpeed(0)).toBe('—');
+    expect(formatSpeed(undefined)).toBe('—');
+    expect(formatSpeed(-1)).toBe('—');
+  });
+});
+
+describe('formatInterfaceMeta', () => {
+  it('combines speed and MTU', () => {
+    expect(formatInterfaceMeta({ speed: 1000, mtu: 1500 } as any)).toBe('1 Gbit/s · MTU 1500');
+  });
+
+  it('omits speed when unknown, keeps MTU', () => {
+    expect(formatInterfaceMeta({ speed: 0, mtu: 1360 } as any)).toBe('MTU 1360');
+  });
+
+  it('returns "" when nothing is known', () => {
+    expect(formatInterfaceMeta({} as any)).toBe('');
+    expect(formatInterfaceMeta(undefined)).toBe('');
+  });
+});
+
+describe('formatFlags', () => {
+  it('joins flags with commas, prefixed with "Flags: "', () => {
+    expect(formatFlags(['up', 'broadcast', 'running', 'multicast'])).toBe('Flags: up, broadcast, running, multicast');
+  });
+
+  it('returns "" for empty / missing flags', () => {
+    expect(formatFlags([])).toBe('');
+    expect(formatFlags(undefined)).toBe('');
   });
 });

--- a/src/app/components/project-map/node-editors/configurator/cloud/ip-address.util.spec.ts
+++ b/src/app/components/project-map/node-editors/configurator/cloud/ip-address.util.spec.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import type { HostInterfaceIPAddress } from '../../../../../cartography/models/node';
+import { formatIpAddresses, netmaskToPrefix, stripScope } from './ip-address.util';
+
+describe('stripScope', () => {
+  it('removes an IPv6 scope zone', () => {
+    expect(stripScope('fe80::1%eth0')).toBe('fe80::1');
+  });
+
+  it('leaves addresses without a scope unchanged', () => {
+    expect(stripScope('192.168.1.5')).toBe('192.168.1.5');
+    expect(stripScope('2001:db8::1')).toBe('2001:db8::1');
+  });
+
+  it('handles empty input', () => {
+    expect(stripScope('')).toBe('');
+  });
+});
+
+describe('netmaskToPrefix', () => {
+  it('converts an IPv4 /24 netmask', () => {
+    expect(netmaskToPrefix('255.255.255.0', 'ipv4')).toBe(24);
+  });
+
+  it('converts other IPv4 netmasks', () => {
+    expect(netmaskToPrefix('255.255.0.0', 'ipv4')).toBe(16);
+    expect(netmaskToPrefix('255.0.0.0', 'ipv4')).toBe(8);
+    expect(netmaskToPrefix('255.255.255.255', 'ipv4')).toBe(32);
+    expect(netmaskToPrefix('0.0.0.0', 'ipv4')).toBe(0);
+    expect(netmaskToPrefix('255.255.255.252', 'ipv4')).toBe(30);
+  });
+
+  it('converts an IPv6 /64 netmask with "::"', () => {
+    expect(netmaskToPrefix('ffff:ffff:ffff:ffff::', 'ipv6')).toBe(64);
+  });
+
+  it('converts a full IPv6 /128 netmask', () => {
+    expect(netmaskToPrefix('ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff', 'ipv6')).toBe(128);
+  });
+
+  it('detects IPv6 from ":" even without family', () => {
+    expect(netmaskToPrefix('ffff:ffff:ffff:ffff::', '')).toBe(64);
+  });
+
+  it('returns 0 for empty netmask', () => {
+    expect(netmaskToPrefix('', 'ipv4')).toBe(0);
+    expect(netmaskToPrefix('', 'ipv6')).toBe(0);
+  });
+});
+
+describe('formatIpAddresses', () => {
+  it('returns empty string for undefined/empty input', () => {
+    expect(formatIpAddresses(undefined)).toBe('');
+    expect(formatIpAddresses([])).toBe('');
+  });
+
+  it('formats a single IPv4 address with prefix', () => {
+    const ips: HostInterfaceIPAddress[] = [
+      { family: 'ipv4', address: '192.168.1.5', netmask: '255.255.255.0' },
+    ];
+    expect(formatIpAddresses(ips)).toBe('192.168.1.5/24');
+  });
+
+  it('formats mixed IPv4 and IPv6 addresses, stripping scope zones', () => {
+    const ips: HostInterfaceIPAddress[] = [
+      { family: 'ipv4', address: '192.168.1.5', netmask: '255.255.255.0' },
+      { family: 'ipv4', address: '10.0.0.5', netmask: '255.255.255.0' },
+      { family: 'ipv6', address: 'fe80::1%eth0', netmask: 'ffff:ffff:ffff:ffff::' },
+      { family: 'ipv6', address: '2001:db8::1', netmask: 'ffff:ffff:ffff:ffff::' },
+    ];
+    expect(formatIpAddresses(ips)).toBe('192.168.1.5/24, 10.0.0.5/24, fe80::1/64, 2001:db8::1/64');
+  });
+});

--- a/src/app/components/project-map/node-editors/configurator/cloud/ip-address.util.spec.ts
+++ b/src/app/components/project-map/node-editors/configurator/cloud/ip-address.util.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import type { HostInterfaceIPAddress } from '../../../../../cartography/models/node';
-import { formatIpAddresses, netmaskToPrefix, stripScope } from './ip-address.util';
+import { formatIpAddress, formatIpAddresses, netmaskToPrefix, stripScope } from './ip-address.util';
 
 describe('stripScope', () => {
   it('removes an IPv6 scope zone', () => {
@@ -69,5 +69,12 @@ describe('formatIpAddresses', () => {
       { family: 'ipv6', address: '2001:db8::1', netmask: 'ffff:ffff:ffff:ffff::' },
     ];
     expect(formatIpAddresses(ips)).toBe('192.168.1.5/24, 10.0.0.5/24, fe80::1/64, 2001:db8::1/64');
+  });
+});
+
+describe('formatIpAddress', () => {
+  it('formats a single address with prefix and strips the scope zone', () => {
+    expect(formatIpAddress({ family: 'ipv4', address: '192.168.1.5', netmask: '255.255.255.0' })).toBe('192.168.1.5/24');
+    expect(formatIpAddress({ family: 'ipv6', address: 'fe80::1%eth0', netmask: 'ffff:ffff:ffff:ffff::' })).toBe('fe80::1/64');
   });
 });

--- a/src/app/components/project-map/node-editors/configurator/cloud/ip-address.util.ts
+++ b/src/app/components/project-map/node-editors/configurator/cloud/ip-address.util.ts
@@ -1,4 +1,4 @@
-import type { HostInterfaceIPAddress } from '../../../../../cartography/models/node';
+import type { HostInterfaceIPAddress, NetworkInterface } from '../../../../../cartography/models/node';
 
 /**
  * Drop an IPv6 scope zone (e.g. "fe80::1%eth0" -> "fe80::1").
@@ -81,4 +81,37 @@ export function formatIpAddress(ip: HostInterfaceIPAddress): string {
 export function formatIpAddresses(ips?: HostInterfaceIPAddress[]): string {
   if (!ips || ips.length === 0) return '';
   return ips.map(formatIpAddress).join(', ');
+}
+
+/**
+ * Format a link speed (Mbit/s) as human-readable text. 0 or missing -> '—'.
+ * 1000 -> "1 Gbit/s", 2500 -> "2.5 Gbit/s", 100 -> "100 Mbit/s".
+ */
+export function formatSpeed(mbit?: number): string {
+  if (!mbit || mbit <= 0) return '—';
+  if (mbit >= 1000) {
+    const gbit = mbit / 1000;
+    return `${gbit.toFixed(gbit % 1 === 0 ? 0 : 1)} Gbit/s`;
+  }
+  return `${mbit} Mbit/s`;
+}
+
+/**
+ * Compact secondary detail for a host interface, e.g. "1 Gbit/s · MTU 1500".
+ * Only known values are included; returns '' when neither speed nor MTU is set.
+ */
+export function formatInterfaceMeta(iface?: NetworkInterface): string {
+  if (!iface) return '';
+  const parts: string[] = [];
+  if (iface.speed && iface.speed > 0) parts.push(formatSpeed(iface.speed));
+  if (iface.mtu) parts.push(`MTU ${iface.mtu}`);
+  return parts.join(' · ');
+}
+
+/**
+ * Render Linux interface flags as a labeled, comma-separated string, e.g.
+ * "Flags: up, broadcast, running, multicast". Returns '' when there are none.
+ */
+export function formatFlags(flags?: string[]): string {
+  return flags && flags.length > 0 ? `Flags: ${flags.join(', ')}` : '';
 }

--- a/src/app/components/project-map/node-editors/configurator/cloud/ip-address.util.ts
+++ b/src/app/components/project-map/node-editors/configurator/cloud/ip-address.util.ts
@@ -66,12 +66,19 @@ export function netmaskToPrefix(netmask: string, family: string): number {
 }
 
 /**
- * Render an interface's IP addresses as compact "address/prefix" text,
- * e.g. "192.168.1.5/24, 2001:db8::1/64". Returns '' when there are none.
+ * Render a single address as compact "address/prefix" text,
+ * e.g. "192.168.1.5/24" or "2001:db8::1/64".
+ */
+export function formatIpAddress(ip: HostInterfaceIPAddress): string {
+  return `${stripScope(ip.address)}/${netmaskToPrefix(ip.netmask, ip.family)}`;
+}
+
+/**
+ * Render an interface's IP addresses as compact "address/prefix" text joined
+ * by commas, e.g. "192.168.1.5/24, 2001:db8::1/64". Returns '' when there are
+ * none.
  */
 export function formatIpAddresses(ips?: HostInterfaceIPAddress[]): string {
   if (!ips || ips.length === 0) return '';
-  return ips
-    .map((ip) => `${stripScope(ip.address)}/${netmaskToPrefix(ip.netmask, ip.family)}`)
-    .join(', ');
+  return ips.map(formatIpAddress).join(', ');
 }

--- a/src/app/components/project-map/node-editors/configurator/cloud/ip-address.util.ts
+++ b/src/app/components/project-map/node-editors/configurator/cloud/ip-address.util.ts
@@ -1,0 +1,77 @@
+import type { HostInterfaceIPAddress } from '../../../../../cartography/models/node';
+
+/**
+ * Drop an IPv6 scope zone (e.g. "fe80::1%eth0" -> "fe80::1").
+ * Harmless for IPv4 addresses, which never contain '%'.
+ */
+export function stripScope(address: string): string {
+  return (address ?? '').split('%')[0];
+}
+
+/** Count the set bits of a 0-255 IPv4 octet string. */
+function ipv4OctetBits(octet: string): number {
+  const n = parseInt(octet, 10);
+  if (Number.isNaN(n)) return 0;
+  return (n >>> 0)
+    .toString(2)
+    .split('')
+    .filter((c) => c === '1').length;
+}
+
+/** Convert a dotted-decimal IPv4 netmask to a prefix length. */
+function ipv4NetmaskToPrefix(netmask: string): number {
+  const octets = netmask.split('.');
+  if (octets.length !== 4) return 0;
+  return octets.reduce((prefix, octet) => prefix + ipv4OctetBits(octet), 0);
+}
+
+/** Expand an IPv6 netmask (possibly with "::") into eight hex groups. */
+function ipv6Groups(netmask: string): string[] {
+  if (!netmask.includes('::')) {
+    return netmask.split(':');
+  }
+  const [left = '', right = ''] = netmask.split('::');
+  const leftGroups = left ? left.split(':') : [];
+  const rightGroups = right ? right.split(':') : [];
+  const missing = 8 - leftGroups.length - rightGroups.length;
+  const fill = missing > 0 ? Array<string>(missing).fill('0') : [];
+  return [...leftGroups, ...fill, ...rightGroups];
+}
+
+/** Convert a hex IPv6 netmask to a prefix length. */
+function ipv6NetmaskToPrefix(netmask: string): number {
+  return ipv6Groups(netmask).reduce((prefix, group) => {
+    const n = parseInt(group || '0', 16);
+    if (Number.isNaN(n)) return prefix;
+    return (
+      prefix +
+      n
+        .toString(2)
+        .split('')
+        .filter((c) => c === '1').length
+    );
+  }, 0);
+}
+
+/**
+ * Convert a netmask string (IPv4 dotted-decimal or IPv6 hex) into a CIDR
+ * prefix length. Returns 0 for empty/invalid input.
+ */
+export function netmaskToPrefix(netmask: string, family: string): number {
+  if (!netmask) return 0;
+  if (family === 'ipv6' || netmask.includes(':')) {
+    return ipv6NetmaskToPrefix(netmask);
+  }
+  return ipv4NetmaskToPrefix(netmask);
+}
+
+/**
+ * Render an interface's IP addresses as compact "address/prefix" text,
+ * e.g. "192.168.1.5/24, 2001:db8::1/64". Returns '' when there are none.
+ */
+export function formatIpAddresses(ips?: HostInterfaceIPAddress[]): string {
+  if (!ips || ips.length === 0) return '';
+  return ips
+    .map((ip) => `${stripScope(ip.address)}/${netmaskToPrefix(ip.netmask, ip.family)}`)
+    .join(', ');
+}

--- a/src/styles/_dialogs.scss
+++ b/src/styles/_dialogs.scss
@@ -1213,6 +1213,13 @@ h2[mat-dialog-title] {
       font-size: 14px;
       padding: 12px 16px;
     }
+
+    /* IP addresses column: allow long address lists to wrap */
+    .mat-column-ipAddresses {
+      white-space: normal;
+      word-break: break-word;
+      max-width: 360px;
+    }
   }
 
   /* Add interface row styling */
@@ -1227,6 +1234,21 @@ h2[mat-dialog-title] {
     mat-form-field {
       flex: 1;
     }
+  }
+}
+
+/* Cloud Ethernet interface select — options render in a global overlay,
+   outside the dialog panel, so they cannot be scoped to the panel. */
+.cloud-ethernet-select-panel {
+  .cloud-iface-option__name {
+    flex-shrink: 0;
+  }
+
+  .cloud-iface-option__ips {
+    margin-left: auto;
+    color: var(--mat-sys-on-surface-variant);
+    font-size: 0.85em;
+    white-space: nowrap;
   }
 }
 

--- a/src/styles/_dialogs.scss
+++ b/src/styles/_dialogs.scss
@@ -1214,11 +1214,16 @@ h2[mat-dialog-title] {
       padding: 12px 16px;
     }
 
-    /* IP addresses column: allow long address lists to wrap */
+    /* IP addresses column: one address per line, allow long IPv6 to wrap */
     .mat-column-ipAddresses {
       white-space: normal;
       word-break: break-word;
       max-width: 360px;
+    }
+
+    /* One IP address per line */
+    .cloud-ip-line {
+      line-height: 1.5;
     }
   }
 

--- a/src/styles/_dialogs.scss
+++ b/src/styles/_dialogs.scss
@@ -1225,6 +1225,23 @@ h2[mat-dialog-title] {
     .cloud-ip-line {
       line-height: 1.5;
     }
+
+    /* Interface cell: name (with inline status dot) + secondary meta line */
+    .cloud-iface-cell {
+      display: flex;
+      flex-direction: column;
+    }
+
+    .cloud-iface-cell .cloud-iface-status {
+      vertical-align: middle;
+      margin-right: 8px;
+    }
+
+    .cloud-iface-meta {
+      color: var(--mat-sys-on-surface-variant);
+      font-size: 0.85em;
+      line-height: 1.4;
+    }
   }
 
   /* Add interface row styling */
@@ -1242,18 +1259,48 @@ h2[mat-dialog-title] {
   }
 }
 
+/* Cloud interface status indicator — used both in the in-dialog table cells
+   and in the select overlay options, so it cannot be scoped to either. */
+.cloud-iface-status {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+
+  &--up {
+    background-color: var(--mat-sys-primary);
+  }
+
+  &--down {
+    background-color: var(--mat-sys-error);
+  }
+}
+
 /* Cloud Ethernet interface select — options render in a global overlay,
    outside the dialog panel, so they cannot be scoped to the panel. */
 .cloud-ethernet-select-panel {
-  .cloud-iface-option__name {
-    flex-shrink: 0;
-  }
+  .cloud-iface-option {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    width: 100%;
 
-  .cloud-iface-option__ips {
-    margin-left: auto;
-    color: var(--mat-sys-on-surface-variant);
-    font-size: 0.85em;
-    white-space: nowrap;
+    &__head {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    &__name {
+      flex-shrink: 0;
+    }
+
+    &__ip {
+      color: var(--mat-sys-on-surface-variant);
+      font-size: 0.85em;
+      padding-left: 16px;
+    }
   }
 }
 


### PR DESCRIPTION
Complement the server changes in GNS3/gns3-server#2810 by consuming the new fields on each host interface (`node.properties.interfaces`) returned by `GET /projects/{projectId}/nodes/{nodeId}`.

## Changes

### NetworkInterface model (`cartography/models/node.ts`)
- Add `HostInterfaceIPAddress` interface (family, address, netmask)
- Add optional `ip_addresses`, `status`, `speed`, `mtu`, `flags` to `NetworkInterface`

### Interface formatting utilities (`ip-address.util.ts`)
- `netmaskToPrefix`: convert IPv4/IPv6 netmask to CIDR prefix length
- `formatIpAddress`: render a single address as `192.168.1.5/24`, strips IPv6 scope zones
- `formatInterfaceMeta`: compact secondary line, e.g. `1 Gbit/s · MTU 1500`
- `formatFlags`: join Linux flags, prefixed as `Flags: up, broadcast, …`

### Cloud configurator dialog
- **Dropdown**: custom `<mat-select-trigger>` shows only the interface name when collapsed; open option shows a status dot (`primary` = up, `error` = down) + name + each IP on its own line
- **Table Interface column**: status dot, name with flags tooltip, muted speed/MTU subtitle
- **Table IP addresses column**: one IP per line
- **Zebra striping** on the table for readability

### Context menu
- Hide `Show in file manager`, `Web console (inline)`, `Web console in new tab`, and `Console` for cloud nodes — none of these features apply to cloud nodes

## Remarks
- All new model fields are `optional`, so configurator degrades gracefully against older servers that don't send them.
- The status dot uses `status` (link carrier, from psutil `isup`), not the `flags` array (which may contain \"up\" independently).
- `ip_addresses` is backward-compatible: servers without this field render the table IP column as `—`.