### PR TITLE
Upload: show MD5 checksum progress and auto-refresh image status

### DIFF
--- a/src/app/common/uploading-processbar/upload-service.service.ts
+++ b/src/app/common/uploading-processbar/upload-service.service.ts
@@ -9,6 +9,10 @@ export class UploadServiceService {
   currentCount = this.countSource.asObservable();
   private cancelItem = new Subject();
   currentCancelItemDetails = this.cancelItem.asObservable();
+  private messageSource = new BehaviorSubject<string>('');
+  currentMessage = this.messageSource.asObservable();
+  private computingSource = new BehaviorSubject<boolean>(false);
+  currentComputing = this.computingSource.asObservable();
 
   constructor() {}
 
@@ -17,5 +21,11 @@ export class UploadServiceService {
   }
   cancelFileUploading(isCancel) {
     this.cancelItem.next(isCancel);
+  }
+  setMessage(message: string) {
+    this.messageSource.next(message);
+  }
+  setComputing(value: boolean) {
+    this.computingSource.next(value);
   }
 }

--- a/src/app/common/uploading-processbar/uploading-processbar.component.html
+++ b/src/app/common/uploading-processbar/uploading-processbar.component.html
@@ -1,7 +1,7 @@
-<p>{{ upload_file_type }} Uploading please wait .... {{ uploadProgress }}%</p>
+<p>{{ upload_file_type }} Uploading please wait .... {{ uploadProgress() }}%</p>
 <div class="row proccessBar-row">
   <div class="col-md-9 proccessBar-col">
-    <mat-progress-bar mode="determinate" [value]="uploadProgress" aria-valuemin="0" aria-valuemax="100">
+    <mat-progress-bar mode="determinate" [value]="uploadProgress()" aria-valuemin="0" aria-valuemax="100">
     </mat-progress-bar>
   </div>
   <div class="col-md-3 proccessBar-col">

--- a/src/app/common/uploading-processbar/uploading-processbar.component.html
+++ b/src/app/common/uploading-processbar/uploading-processbar.component.html
@@ -1,4 +1,4 @@
-<p>{{ upload_file_type }} Uploading please wait .... {{ uploadProgress() }}%</p>
+<p>{{ label() ? label() : (upload_file_type + ' Uploading please wait') }} .... {{ uploadProgress() }}%</p>
 <div class="row proccessBar-row">
   <div class="col-md-9 proccessBar-col">
     <mat-progress-bar mode="determinate" [value]="uploadProgress()" aria-valuemin="0" aria-valuemax="100">

--- a/src/app/common/uploading-processbar/uploading-processbar.component.spec.ts
+++ b/src/app/common/uploading-processbar/uploading-processbar.component.spec.ts
@@ -1,0 +1,71 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatSnackBarRef, MAT_SNACK_BAR_DATA } from '@angular/material/snack-bar';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { UploadingProcessbarComponent } from './uploading-processbar.component';
+import { UploadServiceService } from './upload-service.service';
+
+describe('UploadingProcessbarComponent', () => {
+  let fixture: ComponentFixture<UploadingProcessbarComponent>;
+  let component: UploadingProcessbarComponent;
+  let uploadService: UploadServiceService;
+  let dismissSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    dismissSpy = vi.fn();
+    await TestBed.configureTestingModule({
+      imports: [UploadingProcessbarComponent],
+      providers: [
+        UploadServiceService,
+        { provide: MAT_SNACK_BAR_DATA, useValue: { upload_file_type: 'Image' } },
+        { provide: MatSnackBarRef, useValue: { dismiss: dismissSpy } },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(UploadingProcessbarComponent);
+    component = fixture.componentInstance;
+    uploadService = TestBed.inject(UploadServiceService);
+    fixture.detectChanges(); // triggers ngOnInit → subscribes to the service streams
+  });
+
+  afterEach(() => {
+    if (fixture) {
+      fixture.destroy();
+    }
+  });
+
+  it('falls back to the legacy label when no message is pushed', () => {
+    const p = fixture.nativeElement.querySelector('p');
+    expect(p.textContent).toContain('Image Uploading please wait');
+  });
+
+  it('renders the pushed message as the label instead of the legacy text', () => {
+    uploadService.setMessage('Computing checksum');
+    fixture.detectChanges();
+    const p = fixture.nativeElement.querySelector('p');
+    expect(p.textContent).toContain('Computing checksum');
+    expect(p.textContent).not.toContain('Uploading please wait');
+  });
+
+  it('does not dismiss at 100 while computing (MD5 phase)', () => {
+    uploadService.setComputing(true);
+    uploadService.processBarCount(100);
+    expect(dismissSpy).not.toHaveBeenCalled();
+  });
+
+  it('dismisses at 100 when not computing (backward compat with the other uploaders)', () => {
+    uploadService.processBarCount(100);
+    expect(dismissSpy).toHaveBeenCalled();
+  });
+
+  it('dismisses on null regardless of computing (cancel path for all consumers)', () => {
+    uploadService.setComputing(true);
+    uploadService.processBarCount(null);
+    expect(dismissSpy).toHaveBeenCalled();
+  });
+
+  it('reflects the computed progress value', () => {
+    uploadService.processBarCount(42);
+    expect(component.uploadProgress()).toBe(42);
+  });
+});

--- a/src/app/common/uploading-processbar/uploading-processbar.component.ts
+++ b/src/app/common/uploading-processbar/uploading-processbar.component.ts
@@ -26,6 +26,8 @@ export class UploadingProcessbarComponent implements OnInit, OnDestroy {
   private _US = inject(UploadServiceService);
 
   uploadProgress = signal<number>(0);
+  label = signal<string>('');
+  isComputing = signal<boolean>(false);
   subscription: Subscription;
   upload_file_type: string;
 
@@ -35,10 +37,15 @@ export class UploadingProcessbarComponent implements OnInit, OnDestroy {
     this.upload_file_type = this.data.upload_file_type;
     this.subscription = this._US.currentCount.subscribe((count: number) => {
       this.uploadProgress.set(count);
-      if (this.uploadProgress() === 100 || this.uploadProgress() == null) {
+      // `null` always dismisses (cancel path for all consumers).
+      // `100` only dismisses when not in the local-compute (e.g. MD5) phase,
+      // otherwise the bar would close before the real upload starts.
+      if (this.uploadProgress() == null || (this.uploadProgress() === 100 && !this.isComputing())) {
         this.dismiss();
       }
     });
+    this.subscription.add(this._US.currentMessage.subscribe((msg: string) => this.label.set(msg)));
+    this.subscription.add(this._US.currentComputing.subscribe((v: boolean) => this.isComputing.set(v)));
   }
 
   dismiss() {

--- a/src/app/components/project-map/new-template-dialog/new-template-dialog.component.spec.ts
+++ b/src/app/components/project-map/new-template-dialog/new-template-dialog.component.spec.ts
@@ -206,6 +206,10 @@ describe('NewTemplateDialogComponent', () => {
       processBarCount: vi.fn(),
       currentCancelItemDetails: of(false),
       cancelFileUploading: vi.fn(),
+      setMessage: vi.fn(),
+      setComputing: vi.fn(),
+      currentMessage: of(''),
+      currentComputing: of(false),
     };
 
     mockChangeDetectorRef = {
@@ -617,6 +621,52 @@ describe('NewTemplateDialogComponent', () => {
           data: { upload_file_type: 'Image' },
         })
       );
+    });
+  });
+
+  describe('cancelUploading computing-phase reset', () => {
+    it('should clear the phase message on cancel', () => {
+      component.cancelUploading();
+      expect(mockUploadServiceService.setMessage).toHaveBeenCalledWith('');
+    });
+
+    it('should clear the computing flag on cancel', () => {
+      component.cancelUploading();
+      expect(mockUploadServiceService.setComputing).toHaveBeenCalledWith(false);
+    });
+  });
+
+  describe('refreshImagesUntilReady', () => {
+    it('should stop polling once the uploaded image checksum is available', () => {
+      mockQemuService.getImages.mockReturnValue(of([{ checksum: 'abc123' }]));
+      component.applianceToInstall = createMockAppliance();
+      mockQemuService.getImages.mockClear(); // ignore the initial load triggered by ngOnInit
+
+      (component as any).refreshImagesUntilReady('test-image.img');
+
+      expect(mockQemuService.getImages).toHaveBeenCalledTimes(1);
+      expect(component.checkImageFromVersion('test-image.img')).toBe(true);
+    });
+
+    it('should retry until the checksum becomes available', async () => {
+      let callCount = 0;
+      mockQemuService.getImages.mockImplementation(() => {
+        callCount++;
+        return of(callCount === 1 ? [] : [{ checksum: 'abc123' }]);
+      });
+      component.applianceToInstall = createMockAppliance();
+      mockQemuService.getImages.mockClear(); // ignore the initial load triggered by ngOnInit
+
+      vi.useFakeTimers();
+      try {
+        (component as any).refreshImagesUntilReady('test-image.img');
+        await vi.runAllTimersAsync();
+
+        expect(mockQemuService.getImages).toHaveBeenCalledTimes(2);
+        expect(component.checkImageFromVersion('test-image.img')).toBe(true);
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 

--- a/src/app/components/project-map/new-template-dialog/new-template-dialog.component.ts
+++ b/src/app/components/project-map/new-template-dialog/new-template-dialog.component.ts
@@ -9,6 +9,7 @@ import { MatTableDataSource } from '@angular/material/table';
 import { UploadingProcessbarComponent } from 'app/common/uploading-processbar/uploading-processbar.component';
 import { FileItem, FileUploader, ParsedResponseHeaders } from 'ng2-file-upload';
 import * as SparkMD5 from 'spark-md5';
+import { timer } from 'rxjs';
 import { v4 as uuid } from 'uuid';
 import { ProgressService } from '../../../common/progress/progress.service';
 import { InformationDialogComponent } from '@components/dialogs/information-dialog/information-dialog.component';
@@ -142,6 +143,7 @@ export class NewTemplateDialogComponent implements OnInit, AfterViewInit {
   uploadingImageName: string = '';
   isUploading: boolean = false;
   isUpdatingAppliances: boolean = false;
+  private checksumCancelled = false;
 
   readonly paginator = viewChild(MatPaginator);
   readonly stepper = viewChild<MatStepper>('stepper');
@@ -331,12 +333,16 @@ export class NewTemplateDialogComponent implements OnInit, AfterViewInit {
       headers: ParsedResponseHeaders
     ) => {
       this.toasterService.success('Image successfully imported');
-      this.refreshImages();
+      const uploadedFilename = this.uploadingImageName;
       this.progressService.deactivate();
       this.isUploading = false;
       this.uploadingImageName = '';
       this.uploaderImage.clearQueue();
       this.changeDetectorRef.markForCheck();
+      // The server computes the image checksum asynchronously after the upload
+      // finishes, so poll until the just-uploaded image shows up as installed
+      // (otherwise the dialog stays "missing" until a manual page refresh).
+      this.refreshImagesUntilReady(uploadedFilename);
     };
 
     this.uploaderImage.onProgressItem = (progress: any) => {
@@ -419,6 +425,28 @@ export class NewTemplateDialogComponent implements OnInit, AfterViewInit {
         this.toasterService.error(message);
         this.changeDetectorRef.markForCheck();
       },
+    });
+  }
+
+  private refreshImagesUntilReady(filename: string, attempt = 0): void {
+    const MAX_ATTEMPTS = 15;
+    const service = this.applianceToInstall?.qemu
+      ? this.qemuService
+      : this.applianceToInstall?.dynamips
+        ? this.iosService
+        : this.iouService;
+    service.getImages(this.controller).subscribe((images: any[]) => {
+      if (this.applianceToInstall?.qemu) this.qemuImages = images;
+      else if (this.applianceToInstall?.dynamips) this.iosImages = images;
+      else this.iouImages = images;
+      // TEMP diagnostic — remove once checksum-timing root cause is confirmed.
+      if (attempt === 0) {
+        const hasChecksum = images.some((i: any) => i.checksum);
+        console.log('[refreshImagesUntilReady] attempt 0 — checksum present:', hasChecksum);
+      }
+      this.changeDetectorRef.markForCheck();
+      if (this.checkImageFromVersion(filename) || attempt >= MAX_ATTEMPTS) return;
+      timer(1000).subscribe(() => this.refreshImagesUntilReady(filename, attempt + 1));
     });
   }
 
@@ -683,10 +711,26 @@ export class NewTemplateDialogComponent implements OnInit, AfterViewInit {
 
   importImage(event, imageName) {
     this.uploadingImageName = imageName;
-    this.computeChecksumMd5(event.target.files[0], false).then((output) => {
+    this.checksumCancelled = false;
+    // Open the progress snackbar up front and drive it from the MD5 computation,
+    // so the user sees feedback during the (potentially long) local checksum phase.
+    this.uploadServiceService.setMessage('Computing checksum');
+    this.uploadServiceService.setComputing(true);
+    this.openSnackBar();
+    this.uploadServiceService.processBarCount(0);
+
+    this.computeChecksumMd5(event.target.files[0], false, (percent) => {
+      this.uploadServiceService.processBarCount(percent);
+    }).then((output) => {
+      if (this.checksumCancelled) return;
+
       let imageToInstall = this.applianceToInstall.images.filter((n) => n.filename === imageName)[0];
 
       if (imageToInstall.md5sum !== output) {
+        // Close the checksum snackbar so it does not linger behind the dialog.
+        this.uploadServiceService.processBarCount(null);
+        this.uploadServiceService.setMessage('');
+        this.uploadServiceService.setComputing(false);
         this.progressService.deactivate();
         const dialogRef = this.dialog.open(InformationDialogComponent, {
           autoFocus: false,
@@ -697,8 +741,10 @@ export class NewTemplateDialogComponent implements OnInit, AfterViewInit {
                     The MD5 sum is ${output} and should be ${imageToInstall.md5sum}. Do you want to accept it at your own risks?`;
         dialogRef.afterClosed().subscribe((answer: boolean) => {
           if (answer) {
-            this.importImageFile(event, imageName);
             this.openSnackBar();
+            this.uploadServiceService.setMessage('Uploading');
+            this.uploadServiceService.setComputing(false);
+            this.importImageFile(event, imageName);
           } else {
             this.isUploading = false;
             this.uploadingImageName = '';
@@ -707,8 +753,10 @@ export class NewTemplateDialogComponent implements OnInit, AfterViewInit {
           }
         });
       } else {
+        this.uploadServiceService.setMessage('Uploading');
+        this.uploadServiceService.setComputing(false);
+        this.uploadServiceService.processBarCount(0);
         this.importImageFile(event, imageName);
-        this.openSnackBar();
       }
     });
   }
@@ -742,8 +790,11 @@ export class NewTemplateDialogComponent implements OnInit, AfterViewInit {
   }
 
   cancelUploading() {
+    this.checksumCancelled = true;
     this.uploaderImage.clearQueue();
     this.uploadServiceService.processBarCount(null);
+    this.uploadServiceService.setMessage('');
+    this.uploadServiceService.setComputing(false);
     this.toasterService.warning('File upload cancelled');
     this.uploadServiceService.cancelFileUploading(false);
   }
@@ -1076,7 +1127,11 @@ export class NewTemplateDialogComponent implements OnInit, AfterViewInit {
     });
   }
 
-  private computeChecksumMd5(file: File, encode = false): Promise<string> {
+  private computeChecksumMd5(
+    file: File,
+    encode = false,
+    onProgress?: (percent: number) => void,
+  ): Promise<string> {
     return new Promise((resolve, reject) => {
       const chunkSize = 2097152;
       const spark = new SparkMD5.ArrayBuffer();
@@ -1095,6 +1150,10 @@ export class NewTemplateDialogComponent implements OnInit, AfterViewInit {
       fileReader.onload = function (e: any): void {
         spark.append(e.target.result);
         cursor += chunkSize;
+        if (onProgress) {
+          const pct = Math.min(100, Math.floor((Math.min(cursor, file.size) / file.size) * 100));
+          onProgress(pct);
+        }
         if (cursor < file.size) {
           processChunk(cursor);
         } else {

--- a/src/app/components/project-map/new-template-dialog/new-template-dialog.component.ts
+++ b/src/app/components/project-map/new-template-dialog/new-template-dialog.component.ts
@@ -439,11 +439,6 @@ export class NewTemplateDialogComponent implements OnInit, AfterViewInit {
       if (this.applianceToInstall?.qemu) this.qemuImages = images;
       else if (this.applianceToInstall?.dynamips) this.iosImages = images;
       else this.iouImages = images;
-      // TEMP diagnostic — remove once checksum-timing root cause is confirmed.
-      if (attempt === 0) {
-        const hasChecksum = images.some((i: any) => i.checksum);
-        console.log('[refreshImagesUntilReady] attempt 0 — checksum present:', hasChecksum);
-      }
       this.changeDetectorRef.markForCheck();
       if (this.checkImageFromVersion(filename) || attempt >= MAX_ATTEMPTS) return;
       timer(1000).subscribe(() => this.refreshImagesUntilReady(filename, attempt + 1));


### PR DESCRIPTION
## Summary

Two related improvements to the image upload experience in the **Add new template / appliance** wizard.

### 1. Progress feedback during the MD5 checksum phase
Before the actual HTTP upload, the UI computes an MD5 checksum of the whole file in the browser (`computeChecksumMd5`, 2 MB chunks). For large images (hundreds of MB to GB) this takes several seconds, but there was **no feedback** and the progress snackbar only appeared *after* the checksum finished — users saw a frozen UI. The existing upload snackbar now opens up front, shows `Computing checksum …. NN%` (driven by bytes-read / file-size), then switches to `Uploading …. NN%` for the real upload.

This also fixes a signal misuse where `{{ uploadProgress }}` (instead of `{{ uploadProgress() }}`) rendered the minified signal function as \`()=>1y(e)%\` in the progress text.

### 2. Auto-refresh image status after upload
After uploading an image (e.g. csr1000v), the version/image list did not update its `installed/ready` state until the page was manually refreshed. Root cause: the server computes the image checksum **asynchronously**, so `getImages` called right after `onCompleteItem` returns the new image with an empty `checksum`, and `checkImageFromVersion` (which compares `checksum === md5sum`) reports it as missing. `onCompleteItem` now polls `getImages` until the checksum is ready (max 15 attempts, ~1 s apart).

## Changes
- **`UploadServiceService`** — add `setMessage` / `setComputing` channels (`currentMessage` is a `BehaviorSubject` so a newly-opened snackbar picks up the current label).
- **`UploadingProcessbarComponent`** — subscribe to the new channels; gate the `100%` auto-dismiss on `!isComputing` so the bar stays open during the checksum phase (the `null` cancel path still dismisses unconditionally); fall back to the legacy `<type> Uploading please wait` label when no message is pushed.
- **`NewTemplateDialogComponent`**:
  - `computeChecksumMd5` gains an optional `onProgress(percent)` callback.
  - `importImage` reordered: open snackbar → drive from MD5 progress → switch label to \"Uploading\" → upload.
  - `checksumCancelled` guard so cancelling during the checksum phase prevents a phantom upload (the in-flight `FileReader` still finishes; a true `abort()` is left as a follow-up).
  - `refreshImagesUntilReady` polls the image list after upload.

## Backward compatibility
The other four upload entry points (add-qemu / -iou / -ios templates, import-project) never call `setMessage`/`setComputing`, so `label` stays empty and `isComputing` stays `false`. They render the legacy label and dismiss at `100`/`null` exactly as before.

## Testing
- \`yarn build\` ✅
- \`yarn lint\` ✅
- \`yarn test\` ✅ — new \`uploading-processbar.component.spec.ts\` (6 tests) plus new \`new-template-dialog\` cases (cancel resets phase ×2, polling stops when ready, polling retries); 86 tests green.
- Manual (\`yarn ng serve\`): verified the checksum→upload progress flow, the MD5-mismatch dialog path, cancel-during-checksum (no phantom upload), and that the installed/missing status auto-refreshes without a manual page reload.