### PR TITLE
refine: hide inapplicable context menu items, show NAT ethernet info, display Node ID

### DIFF
--- a/src/app/components/project-map/context-menu/context-menu.component.html
+++ b/src/app/components/project-map/context-menu/context-menu.component.html
@@ -3,7 +3,7 @@
   <mat-menu #contextMenu="matMenu" class="context-menu-items">
     @if (nodes.length === 1) {
     <app-show-node-action [controller]="controller" [node]="nodes[0]"></app-show-node-action>
-    } @if (nodes.length === 1 && nodes[0].node_type !== 'cloud') {
+    } @if (nodes.length === 1 && nodes[0].node_type !== 'cloud' && nodes[0].node_type !== 'ethernet_switch' && nodes[0].node_type !== 'ethernet_hub' && nodes[0].node_type !== 'nat') {
     <app-show-in-file-manager-action [controller]="controller" [node]="nodes[0]" (openFileManagerInline)="onOpenFileManagerInline($event)"></app-show-in-file-manager-action>
     } @if (nodes.length === 1) {
     <app-config-node-action [controller]="controller" [node]="nodes[0]"></app-config-node-action>

--- a/src/app/components/project-map/context-menu/context-menu.component.html
+++ b/src/app/components/project-map/context-menu/context-menu.component.html
@@ -3,7 +3,7 @@
   <mat-menu #contextMenu="matMenu" class="context-menu-items">
     @if (nodes.length === 1) {
     <app-show-node-action [controller]="controller" [node]="nodes[0]"></app-show-node-action>
-    } @if (nodes.length === 1 && nodes[0].node_type !== 'cloud' && nodes[0].node_type !== 'ethernet_switch' && nodes[0].node_type !== 'ethernet_hub' && nodes[0].node_type !== 'nat') {
+    } @if (nodes.length === 1 && !isCloudLikeNode(nodes[0].node_type)) {
     <app-show-in-file-manager-action [controller]="controller" [node]="nodes[0]" (openFileManagerInline)="onOpenFileManagerInline($event)"></app-show-in-file-manager-action>
     } @if (nodes.length === 1) {
     <app-config-node-action [controller]="controller" [node]="nodes[0]"></app-config-node-action>
@@ -15,16 +15,16 @@
     <app-stop-node-action [controller]="controller" [nodes]="nodes"></app-stop-node-action>
     } @if (nodes.length) {
     <app-reload-node-action [controller]="controller" [nodes]="nodes"></app-reload-node-action>
-    } @if (!projectService.isReadOnly(project) && nodes.length > 0 && nodes[0].node_type !== 'cloud') {
+    } @if (!projectService.isReadOnly(project) && nodes.length > 0 && !isCloudLikeNode(nodes[0].node_type)) {
     <app-http-console-action
       [controller]="controller"
       [project]="project"
       [nodes]="nodes"
       (openWebConsoleInline)="onOpenWebConsoleInline($event)"
     ></app-http-console-action>
-    } @if (!projectService.isReadOnly(project) && nodes.length > 0 && nodes[0].node_type !== 'cloud') {
+    } @if (!projectService.isReadOnly(project) && nodes.length > 0 && !isCloudLikeNode(nodes[0].node_type)) {
     <app-http-console-new-tab-action [controller]="controller" [nodes]="nodes"></app-http-console-new-tab-action>
-    } @if (!projectService.isReadOnly(project) && nodes.length === 1 && nodes[0].node_type !== 'cloud') {
+    } @if (!projectService.isReadOnly(project) && nodes.length === 1 && !isCloudLikeNode(nodes[0].node_type)) {
     <app-console-device-action-browser [controller]="controller" [node]="nodes[0]"></app-console-device-action-browser>
     } @if (nodes.length === 1) {
     <app-isolate-node-action [controller]="controller" [node]="nodes[0]"></app-isolate-node-action>

--- a/src/app/components/project-map/context-menu/context-menu.component.ts
+++ b/src/app/components/project-map/context-menu/context-menu.component.ts
@@ -199,6 +199,14 @@ export class ContextMenuComponent implements OnInit {
     this.contextMenu.openMenu();
   }
 
+  /**
+   * Node types that don't support file manager, web console, or console browser —
+   * same behavior as cloud nodes in the context menu.
+   */
+  isCloudLikeNode(nodeType: string): boolean {
+    return nodeType === 'cloud' || nodeType === 'ethernet_switch' || nodeType === 'ethernet_hub' || nodeType === 'nat';
+  }
+
   private resetCapabilities() {
     this.drawings = [];
     this.nodes = [];

--- a/src/app/components/project-map/node-editors/configurator/cloud/configurator-cloud.component.html
+++ b/src/app/components/project-map/node-editors/configurator/cloud/configurator-cloud.component.html
@@ -17,7 +17,7 @@
                     (selectionChange)="ethernetInterface.set($event.value)"
                   >
                     <mat-select-trigger>{{ ethernetInterface() }}</mat-select-trigger>
-                    @for (iface of availableEthernetInterfaces; track iface.name) {
+                    @for (iface of availableEthernetInterfaces(); track iface.name) {
                     <mat-option [value]="iface.name">
                       <div class="cloud-iface-option">
                         <div class="cloud-iface-option__head">
@@ -39,7 +39,7 @@
                 <button mat-button (click)="onAddEthernetInterface()">Add</button>
               </div>
 
-              <table mat-table [dataSource]="portsMappingEthernet" class="interfaces-table">
+              <table mat-table [dataSource]="portsMappingEthernet()" class="interfaces-table">
                 <ng-container matColumnDef="name">
                   <th mat-header-cell *matHeaderCellDef>Interface</th>
                   <td mat-cell *matCellDef="let element">
@@ -98,7 +98,7 @@
                 <button mat-button (click)="onAddTapInterface()">Add</button>
               </div>
 
-              <table mat-table [dataSource]="portsMappingTap" class="interfaces-table">
+              <table mat-table [dataSource]="portsMappingTap()" class="interfaces-table">
                 <ng-container matColumnDef="name">
                   <th mat-header-cell *matHeaderCellDef>Interface</th>
                   <td mat-cell *matCellDef="let element">{{ element.name }}</td>
@@ -120,7 +120,7 @@
           </mat-tab>
 
           <mat-tab label="UDP tunnels">
-            <app-udp-tunnels #udpTunnels [dataSourceUdp]="portsMappingUdp"></app-udp-tunnels>
+            <app-udp-tunnels #udpTunnels [dataSourceUdp]="portsMappingUdp()"></app-udp-tunnels>
           </mat-tab>
 
           <mat-tab label="Miscellaneous">

--- a/src/app/components/project-map/node-editors/configurator/cloud/configurator-cloud.component.spec.ts
+++ b/src/app/components/project-map/node-editors/configurator/cloud/configurator-cloud.component.spec.ts
@@ -159,7 +159,7 @@ describe('ConfiguratorDialogCloudComponent', () => {
     component = fixture.componentInstance;
     component.controller = mockController;
     component.node = mockNode;
-    component.portsMappingUdp = mockUdpTunnelsData;
+    component.portsMappingUdp.set(mockUdpTunnelsData);
     component.name = 'Cloud-1';
   });
 
@@ -200,16 +200,16 @@ describe('ConfiguratorDialogCloudComponent', () => {
       component.ngOnInit();
       fixture.detectChanges();
 
-      expect(component.portsMappingEthernet.length).toBeGreaterThan(0);
-      expect(component.portsMappingEthernet[0].type).toBe('ethernet');
+      expect(component.portsMappingEthernet().length).toBeGreaterThan(0);
+      expect(component.portsMappingEthernet()[0].type).toBe('ethernet');
     });
 
     it('should populate portsMappingTap from node properties', () => {
       component.ngOnInit();
       fixture.detectChanges();
 
-      expect(component.portsMappingTap.length).toBeGreaterThan(0);
-      expect(component.portsMappingTap[0].type).toBe('tap');
+      expect(component.portsMappingTap().length).toBeGreaterThan(0);
+      expect(component.portsMappingTap()[0].type).toBe('tap');
     });
 
     it('should populate all model signals with node data', () => {
@@ -279,22 +279,22 @@ describe('ConfiguratorDialogCloudComponent', () => {
 
     it('should add ethernet interface to portsMappingEthernet when interface is selected', () => {
       component.ethernetInterface.set('Ethernet 2');
-      const initialLength = component.portsMappingEthernet.length;
+      const initialLength = component.portsMappingEthernet().length;
 
       component.onAddEthernetInterface();
 
-      expect(component.portsMappingEthernet.length).toBe(initialLength + 1);
-      expect(component.portsMappingEthernet[component.portsMappingEthernet.length - 1].interface).toBe('Ethernet 2');
-      expect(component.portsMappingEthernet[component.portsMappingEthernet.length - 1].type).toBe('ethernet');
+      expect(component.portsMappingEthernet().length).toBe(initialLength + 1);
+      expect(component.portsMappingEthernet()[component.portsMappingEthernet().length - 1].interface).toBe('Ethernet 2');
+      expect(component.portsMappingEthernet()[component.portsMappingEthernet().length - 1].type).toBe('ethernet');
     });
 
     it('should not add ethernet interface when ethernetInterface is empty', () => {
       component.ethernetInterface.set('');
-      const initialLength = component.portsMappingEthernet.length;
+      const initialLength = component.portsMappingEthernet().length;
 
       component.onAddEthernetInterface();
 
-      expect(component.portsMappingEthernet.length).toBe(initialLength);
+      expect(component.portsMappingEthernet().length).toBe(initialLength);
     });
 
     it('should validate interface name before adding', () => {
@@ -311,19 +311,19 @@ describe('ConfiguratorDialogCloudComponent', () => {
         errorMessage: 'Interface name is required',
       });
       component.ethernetInterface.set('   '); // Whitespace only, not empty
-      const initialLength = component.portsMappingEthernet.length;
+      const initialLength = component.portsMappingEthernet().length;
 
       component.onAddEthernetInterface();
 
-      expect(component.portsMappingEthernet.length).toBe(initialLength);
+      expect(component.portsMappingEthernet().length).toBe(initialLength);
       expect(mockToasterService.error).toHaveBeenCalledWith('Interface name is required');
     });
 
     it('should check for duplicate interface names', () => {
       component.ethernetInterface.set('eth0');
-      component.portsMappingEthernet = [
+      component.portsMappingEthernet.set([
         { interface: 'eth0', name: 'eth0', port_number: 0, type: 'ethernet' },
-      ];
+      ]);
 
       component.onAddEthernetInterface();
 
@@ -336,9 +336,9 @@ describe('ConfiguratorDialogCloudComponent', () => {
         errorMessage: 'Interface eth0 already configured.',
       });
       component.ethernetInterface.set('eth0');
-      component.portsMappingEthernet = [
+      component.portsMappingEthernet.set([
         { interface: 'eth0', name: 'eth0', port_number: 0, type: 'ethernet' },
-      ];
+      ]);
 
       component.onAddEthernetInterface();
 
@@ -354,22 +354,22 @@ describe('ConfiguratorDialogCloudComponent', () => {
 
     it('should add tap interface to portsMappingTap when interface is specified', () => {
       component.tapInterface.set('tap0');
-      const initialLength = component.portsMappingTap.length;
+      const initialLength = component.portsMappingTap().length;
 
       component.onAddTapInterface();
 
-      expect(component.portsMappingTap.length).toBe(initialLength + 1);
-      expect(component.portsMappingTap[component.portsMappingTap.length - 1].interface).toBe('tap0');
-      expect(component.portsMappingTap[component.portsMappingTap.length - 1].type).toBe('tap');
+      expect(component.portsMappingTap().length).toBe(initialLength + 1);
+      expect(component.portsMappingTap()[component.portsMappingTap().length - 1].interface).toBe('tap0');
+      expect(component.portsMappingTap()[component.portsMappingTap().length - 1].type).toBe('tap');
     });
 
     it('should not add tap interface when tapInterface is empty', () => {
       component.tapInterface.set('');
-      const initialLength = component.portsMappingTap.length;
+      const initialLength = component.portsMappingTap().length;
 
       component.onAddTapInterface();
 
-      expect(component.portsMappingTap.length).toBe(initialLength);
+      expect(component.portsMappingTap().length).toBe(initialLength);
     });
 
     it('should validate interface name before adding', () => {
@@ -386,19 +386,19 @@ describe('ConfiguratorDialogCloudComponent', () => {
         errorMessage: 'Interface name is required',
       });
       component.tapInterface.set('   '); // Whitespace only, not empty
-      const initialLength = component.portsMappingTap.length;
+      const initialLength = component.portsMappingTap().length;
 
       component.onAddTapInterface();
 
-      expect(component.portsMappingTap.length).toBe(initialLength);
+      expect(component.portsMappingTap().length).toBe(initialLength);
       expect(mockToasterService.error).toHaveBeenCalledWith('Interface name is required');
     });
 
     it('should check for duplicate interface names', () => {
       component.tapInterface.set('tap0');
-      component.portsMappingTap = [
+      component.portsMappingTap.set([
         { interface: 'tap0', name: 'tap0', port_number: 0, type: 'tap' },
-      ];
+      ]);
 
       component.onAddTapInterface();
 
@@ -411,9 +411,9 @@ describe('ConfiguratorDialogCloudComponent', () => {
         errorMessage: 'Interface tap0 already configured.',
       });
       component.tapInterface.set('tap0');
-      component.portsMappingTap = [
+      component.portsMappingTap.set([
         { interface: 'tap0', name: 'tap0', port_number: 0, type: 'tap' },
-      ];
+      ]);
 
       component.onAddTapInterface();
 
@@ -669,7 +669,7 @@ describe('ConfiguratorDialogCloudComponent', () => {
       component.remoteConsoleHttpPath.set('/');
       component.usage.set('Test');
       component.node = { ...mockNode };
-      component.portsMappingUdp = mockUdpTunnelsData;
+      component.portsMappingUdp.set(mockUdpTunnelsData);
 
       // Mock udpTunnels viewChild
       Object.defineProperty(component, 'udpTunnels', {

--- a/src/app/components/project-map/node-editors/configurator/cloud/configurator-cloud.component.ts
+++ b/src/app/components/project-map/node-editors/configurator/cloud/configurator-cloud.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, inject, model, viewChild } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, inject, model, signal, viewChild } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { MatDialogRef, MatDialogModule } from '@angular/material/dialog';
@@ -65,9 +65,9 @@ export class ConfiguratorDialogCloudComponent implements OnInit {
   bootPriorities = [];
   diskInterfaces: string[] = [];
 
-  portsMappingEthernet: PortsMappingEntity[] = [];
-  portsMappingTap: PortsMappingEntity[] = [];
-  portsMappingUdp: PortsMappingEntity[] = [];
+  portsMappingEthernet = signal<PortsMappingEntity[]>([]);
+  portsMappingTap = signal<PortsMappingEntity[]>([]);
+  portsMappingUdp = signal<PortsMappingEntity[]>([]);
 
   ethernetDisplayColumns: string[] = ['name', 'ipAddresses', 'actions'];
   tapDisplayColumns: string[] = ['name', 'actions'];
@@ -75,7 +75,7 @@ export class ConfiguratorDialogCloudComponent implements OnInit {
   networkTypes = [];
   readonly tapInterface = model('');
   readonly ethernetInterface = model('');
-  availableEthernetInterfaces: NetworkInterface[] = [];
+  availableEthernetInterfaces = signal<NetworkInterface[]>([]);
 
   // Model signals for form fields
   readonly nodeName = model('');
@@ -109,16 +109,22 @@ export class ConfiguratorDialogCloudComponent implements OnInit {
 
         // Populate available ethernet interfaces from gns3server
         if (this.node.properties.interfaces) {
-          this.availableEthernetInterfaces = this.node.properties.interfaces.filter(
-            (iface) => iface.type === 'ethernet'
+          this.availableEthernetInterfaces.set(
+            this.node.properties.interfaces.filter((iface) => iface.type === 'ethernet')
           );
         }
 
-        this.portsMappingEthernet = this.node.properties.ports_mapping.filter((elem) => elem.type === 'ethernet');
+        this.portsMappingEthernet.set(
+          this.node.properties.ports_mapping.filter((elem) => elem.type === 'ethernet')
+        );
 
-        this.portsMappingTap = this.node.properties.ports_mapping.filter((elem) => elem.type === 'tap');
+        this.portsMappingTap.set(
+          this.node.properties.ports_mapping.filter((elem) => elem.type === 'tap')
+        );
 
-        this.portsMappingUdp = this.node.properties.ports_mapping.filter((elem) => elem.type === 'udp');
+        this.portsMappingUdp.set(
+          this.node.properties.ports_mapping.filter((elem) => elem.type === 'udp')
+        );
 
         this.cd.markForCheck();
       },
@@ -160,29 +166,28 @@ export class ConfiguratorDialogCloudComponent implements OnInit {
       }
 
       // Check if interface already exists
-      const existingNames = this.portsMappingEthernet.map((port) => port.name);
+      const existingNames = this.portsMappingEthernet().map((port) => port.name);
       const uniqueValidation = this.validationService.validateUniqueInterface(this.ethernetInterface(), existingNames);
       if (!uniqueValidation.isValid) {
         this.toasterService.error(uniqueValidation.errorMessage || `Interface ${this.ethernetInterface()} already configured.`);
         return;
       }
 
-      this.portsMappingEthernet.push({
-        interface: this.ethernetInterface(),
-        name: this.ethernetInterface(),
-        port_number: 0,
-        type: 'ethernet',
-      });
-      // Force array refresh for change detection
-      this.portsMappingEthernet = [...this.portsMappingEthernet];
+      this.portsMappingEthernet.update((arr) => [
+        ...arr,
+        {
+          interface: this.ethernetInterface(),
+          name: this.ethernetInterface(),
+          port_number: 0,
+          type: 'ethernet',
+        },
+      ]);
       this.ethernetInterface.set('');
-      this.cd.markForCheck();
     }
   }
 
   onDeleteEthernetInterface(port: PortsMappingEntity) {
-    this.portsMappingEthernet = this.portsMappingEthernet.filter((p) => p !== port);
-    this.cd.markForCheck();
+    this.portsMappingEthernet.update((arr) => arr.filter((p) => p !== port));
   }
 
   onAddTapInterface() {
@@ -195,29 +200,28 @@ export class ConfiguratorDialogCloudComponent implements OnInit {
       }
 
       // Check if interface already exists
-      const existingNames = this.portsMappingTap.map((port) => port.name);
+      const existingNames = this.portsMappingTap().map((port) => port.name);
       const uniqueValidation = this.validationService.validateUniqueInterface(this.tapInterface(), existingNames);
       if (!uniqueValidation.isValid) {
         this.toasterService.error(uniqueValidation.errorMessage || `Interface ${this.tapInterface()} already configured.`);
         return;
       }
 
-      this.portsMappingTap.push({
-        interface: this.tapInterface(),
-        name: this.tapInterface(),
-        port_number: 0,
-        type: 'tap',
-      });
-      // Force array refresh for change detection
-      this.portsMappingTap = [...this.portsMappingTap];
+      this.portsMappingTap.update((arr) => [
+        ...arr,
+        {
+          interface: this.tapInterface(),
+          name: this.tapInterface(),
+          port_number: 0,
+          type: 'tap',
+        },
+      ]);
       this.tapInterface.set('');
-      this.cd.markForCheck();
     }
   }
 
   onDeleteTapInterface(port: PortsMappingEntity) {
-    this.portsMappingTap = this.portsMappingTap.filter((p) => p !== port);
-    this.cd.markForCheck();
+    this.portsMappingTap.update((arr) => arr.filter((p) => p !== port));
   }
 
   onSaveClick() {
@@ -274,11 +278,11 @@ export class ConfiguratorDialogCloudComponent implements OnInit {
     this.node.properties.remote_console_http_path = this.remoteConsoleHttpPath();
     this.node.properties.usage = this.usage();
 
-    this.portsMappingUdp = this.udpTunnels().dataSourceUdp;
+    this.portsMappingUdp.set(this.udpTunnels().dataSourceUdp);
 
-    this.node.properties.ports_mapping = this.portsMappingUdp
-      .concat(this.portsMappingEthernet)
-      .concat(this.portsMappingTap);
+    this.node.properties.ports_mapping = this.portsMappingUdp()
+      .concat(this.portsMappingEthernet())
+      .concat(this.portsMappingTap());
 
     this.nodeService.updateNode(this.controller, this.node).subscribe({
       next: () => {

--- a/src/app/components/project-map/node-editors/configurator/nat/configurator-nat.component.html
+++ b/src/app/components/project-map/node-editors/configurator/nat/configurator-nat.component.html
@@ -4,7 +4,9 @@
   <div class="content">
     <div class="default-content">
       <mat-card class="matCard">
+        @if (name) {
         <div class="form-container">
+
           <mat-form-field class="form-field">
             <mat-label>Name</mat-label>
             <input matInput type="text" [value]="nodeName()" (input)="nodeName.set($event.target.value)" />
@@ -27,7 +29,52 @@
               (matChipInputTokenEnd)="addTag($event)"
             />
           </mat-form-field>
+
+          <!-- Ethernet interface read-only display -->
+          @if (portsMappingEthernet().length) {
+          <div class="interfaces-list">
+            <table mat-table [dataSource]="portsMappingEthernet()" class="interfaces-table">
+              <ng-container matColumnDef="name">
+                <th mat-header-cell *matHeaderCellDef>Interface</th>
+                <td mat-cell *matCellDef="let element">
+                  @if (getHostInterface(element.interface || element.name); as host) {
+                    <div class="cloud-iface-cell">
+                      <span [matTooltip]="formatFlags(host.flags) || null">
+                        <span
+                          class="cloud-iface-status"
+                          [class.cloud-iface-status--up]="host.status === 'up'"
+                          [class.cloud-iface-status--down]="host.status !== 'up'"
+                        ></span>
+                        {{ element.name }}
+                      </span>
+                      @if (formatInterfaceMeta(host); as meta) {
+                        <span class="cloud-iface-meta">{{ meta }}</span>
+                      }
+                    </div>
+                  } @else {
+                    {{ element.name }}
+                  }
+                </td>
+              </ng-container>
+
+              <ng-container matColumnDef="ipAddresses">
+                <th mat-header-cell *matHeaderCellDef>IP addresses</th>
+                <td mat-cell *matCellDef="let element">
+                  @for (ip of getHostInterfaceIps(element.interface || element.name); track ip.address) {
+                    <div class="cloud-ip-line">{{ formatIpAddress(ip) }}</div>
+                  } @empty {
+                    —
+                  }
+                </td>
+              </ng-container>
+
+              <tr mat-header-row *matHeaderRowDef="ethernetDisplayColumns"></tr>
+              <tr mat-row *matRowDef="let row; columns: ethernetDisplayColumns"></tr>
+            </table>
+          </div>
+          }
         </div>
+        }
       </mat-card>
     </div>
   </div>

--- a/src/app/components/project-map/node-editors/configurator/nat/configurator-nat.component.ts
+++ b/src/app/components/project-map/node-editors/configurator/nat/configurator-nat.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, inject, model } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, inject, model, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { MatDialogRef, MatDialogModule } from '@angular/material/dialog';
@@ -6,14 +6,19 @@ import { MatCardModule } from '@angular/material/card';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
-import { COMMA, ENTER } from '@angular/cdk/keycodes';
-import { MatChipGrid, MatChipInputEvent, MatChipsModule } from '@angular/material/chips';
 import { MatIconModule } from '@angular/material/icon';
+import { MatTableModule } from '@angular/material/table';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { COMMA, ENTER } from '@angular/cdk/keycodes';
+import { MatChipInputEvent, MatChipsModule } from '@angular/material/chips';
 import { Node } from '../../../../../cartography/models/node';
+import type { HostInterfaceIPAddress, NetworkInterface } from '../../../../../cartography/models/node';
+import { PortsMappingEntity } from '@models/ethernetHub/ports-mapping-enity';
 import { Controller } from '@models/controller';
 import { NodeService } from '@services/node.service';
 import { ToasterService } from '@services/toaster.service';
 import { ValidationService } from '@services/validation';
+import { formatFlags, formatIpAddress, formatIpAddresses, formatInterfaceMeta } from '../cloud/ip-address.util';
 
 @Component({
   standalone: true,
@@ -31,6 +36,8 @@ import { ValidationService } from '@services/validation';
     MatButtonModule,
     MatChipsModule,
     MatIconModule,
+    MatTableModule,
+    MatTooltipModule,
   ],
 })
 export class ConfiguratorDialogNatComponent implements OnInit {
@@ -45,8 +52,17 @@ export class ConfiguratorDialogNatComponent implements OnInit {
   name: string;
   readonly separatorKeysCodes: number[] = [ENTER, COMMA];
 
+  portsMappingEthernet = signal<PortsMappingEntity[]>([]);
+  ethernetDisplayColumns: string[] = ['name', 'ipAddresses'];
+
   // Model signals
   readonly nodeName = model('');
+
+  /** Expose the interface formatters to the template. */
+  formatIpAddresses = formatIpAddresses;
+  formatIpAddress = formatIpAddress;
+  formatInterfaceMeta = formatInterfaceMeta;
+  formatFlags = formatFlags;
 
   ngOnInit() {
     this.nodeService.getNode(this.controller, this.node).subscribe({
@@ -54,12 +70,16 @@ export class ConfiguratorDialogNatComponent implements OnInit {
         this.node = node;
         this.name = node.name;
 
-        // Update model signals with node data
         this.nodeName.set(node.name || '');
 
         if (!this.node.tags) {
           this.node.tags = [];
         }
+
+        this.portsMappingEthernet.set(
+          this.node.properties.ports_mapping.filter((elem) => elem.type === 'ethernet')
+        );
+
         this.cd.markForCheck();
       },
       error: (err) => {
@@ -68,6 +88,16 @@ export class ConfiguratorDialogNatComponent implements OnInit {
         this.cd.markForCheck();
       },
     });
+  }
+
+  /** Look up the full host interface bridged by a configured ethernet port. */
+  getHostInterface(hostInterfaceName: string): NetworkInterface | undefined {
+    return this.node?.properties?.interfaces?.find((iface) => iface.name === hostInterfaceName);
+  }
+
+  /** Look up the host interface IP addresses bridged by a configured ethernet port. */
+  getHostInterfaceIps(hostInterfaceName: string): HostInterfaceIPAddress[] {
+    return this.getHostInterface(hostInterfaceName)?.ip_addresses ?? [];
   }
 
   onSaveClick() {
@@ -79,6 +109,8 @@ export class ConfiguratorDialogNatComponent implements OnInit {
 
     this.node.name = this.nodeName();
 
+    this.node.properties.ports_mapping = this.portsMappingEthernet();
+
     this.nodeService.updateNode(this.controller, this.node).subscribe({
       next: () => {
         this.toasterService.success(`Node ${this.node.name} updated.`);
@@ -87,6 +119,7 @@ export class ConfiguratorDialogNatComponent implements OnInit {
       error: (error: unknown) => {
         const errorMessage = (error as any)?.error?.message || (error as any)?.message || 'Failed to update node';
         this.toasterService.error(errorMessage);
+        this.cd.markForCheck();
       },
     });
   }
@@ -105,7 +138,6 @@ export class ConfiguratorDialogNatComponent implements OnInit {
       this.node.tags.push(value);
     }
 
-    // Clear the input value
     if (event.chipInput) {
       event.chipInput.clear();
     }

--- a/src/app/services/info.service.spec.ts
+++ b/src/app/services/info.service.spec.ts
@@ -39,6 +39,7 @@ describe('InfoService', () => {
 
     // Mock Node
     mockNode = {
+      node_id: 'test-node-uuid',
       name: 'Test Node',
       node_type: 'qemu',
       status: 'started',
@@ -73,7 +74,7 @@ describe('InfoService', () => {
         const result = service.getInfoAboutNode(cloudNode, mockController);
 
         expect(result).toContain('Running on controller Test Controller with port 3080.');
-        expect(result).toContain('Controller ID is 1.');
+        expect(result).toContain('Controller ID: 1');
       });
     });
 
@@ -199,10 +200,16 @@ describe('InfoService', () => {
         expect(result).toContain('Running on controller Test Controller with port 3080.');
       });
 
+      it('should include node ID', () => {
+        const result = service.getInfoAboutNode(mockNode, mockController);
+
+        expect(result).toContain('Node ID: test-node-uuid');
+      });
+
       it('should include controller ID', () => {
         const result = service.getInfoAboutNode(mockNode, mockController);
 
-        expect(result).toContain('Controller ID is 1.');
+        expect(result).toContain('Controller ID: 1');
       });
 
       it('should work with different controller ports', () => {

--- a/src/app/services/info.service.ts
+++ b/src/app/services/info.service.ts
@@ -34,8 +34,9 @@ export class InfoService {
     } else if (node.node_type === 'vpcs') {
       infoList.push(`Node ${node.name} is ${node.status}.`);
     }
+    infoList.push(`Node ID: ${node.node_id}`);
     infoList.push(`Running on controller ${controller.name} with port ${controller.port}.`);
-    infoList.push(`Controller ID is ${controller.id}.`);
+    infoList.push(`Controller ID: ${controller.id}`);
     if (node.console_type !== 'none' && node.console_type !== 'null') {
       infoList.push(`Console is on port ${node.console} and type is ${node.console_type}.`);
     }


### PR DESCRIPTION
### Summary

#### 1. Hide inapplicable context menu items for cloud-like nodes
Ethernet switch, ethernet hub, and NAT nodes share the same limitations as cloud nodes — they don't have a file system, web console, or console browser. This PR hides those menu items for these node types:
- Show in file manager
- Web console / Web console (new tab) / Console device browser
- Extracted isCloudLikeNode() helper to keep template conditions clean

#### 2. NAT configurator: show ethernet interface with IP addresses
NAT nodes now return ports_mapping and interfaces data from the server (same structure as Cloud nodes). The NAT configurator now displays the bridged interface name, status indicator, speed/MTU metadata, and IP addresses in a read-only table.

#### 3. Signal refactoring (Cloud & NAT configurators)
Converted portsMappingEthernet / portsMappingTap / portsMappingUdp / availableEthernetInterfaces from plain arrays to signal<T[]>([]) for proper OnPush change detection, removing unnecessary markForCheck() calls.

#### 4. Show Node ID in info dialog
Added Node ID line to the General information tab in the Show node information dialog.