### PR TITLE
Make QEMU add-template disk image picker filterable

### DIFF
--- a/src/app/components/preferences/qemu/add-qemu-vm-template/add-qemu-vm-template.component.html
+++ b/src/app/components/preferences/qemu/add-qemu-vm-template/add-qemu-vm-template.component.html
@@ -124,17 +124,20 @@
             @if (!newImageSelected()) {
             <mat-form-field appearance="fill" class="qemu-add__field">
               <mat-label>Disk image (hda)</mat-label>
-              <mat-select
+              <input
+                matInput
+                type="text"
+                [matAutocomplete]="hdaAuto"
+                (input)="onDiskImageInput($event)"
                 placeholder="Disk image (hda)"
-                [value]="selectedImage()"
-                (selectionChange)="selectedImage.set($event.value)"
-              >
-                @for (image of qemuImages(); track image.filename) {
-                <mat-option [value]="image">
+              />
+              <mat-autocomplete #hdaAuto="matAutocomplete" (optionSelected)="onDiskImageSelected($event.option.value)">
+                @for (image of filteredImages(); track image.filename) {
+                <mat-option [value]="image.filename">
                   {{ image.filename }}
                 </mat-option>
                 }
-              </mat-select>
+              </mat-autocomplete>
             </mat-form-field>
             } @if (newImageSelected()) {
             <div class="qemu-add__file-row">

--- a/src/app/components/preferences/qemu/add-qemu-vm-template/add-qemu-vm-template.component.ts
+++ b/src/app/components/preferences/qemu/add-qemu-vm-template/add-qemu-vm-template.component.ts
@@ -10,6 +10,7 @@ import { MatRadioModule } from '@angular/material/radio';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
+import { MatAutocompleteModule } from '@angular/material/autocomplete';
 import { MatStepperModule } from '@angular/material/stepper';
 import { UploadServiceService } from '../../../../common/uploading-processbar/upload-service.service';
 import { UploadingProcessbarComponent } from 'app/common/uploading-processbar/uploading-processbar.component';
@@ -43,6 +44,7 @@ import { ToasterService } from '@services/toaster.service';
     MatFormFieldModule,
     MatInputModule,
     MatSelectModule,
+    MatAutocompleteModule,
     MatStepperModule,
     FileUploadModule,
   ],
@@ -69,6 +71,7 @@ export class AddQemuVmTemplateComponent implements OnInit, OnDestroy {
   readonly newImageSelected = signal<boolean>(false);
   readonly qemuImages = signal<QemuImage[]>([]);
   readonly selectedImage = signal<QemuImage | undefined>(undefined);
+  readonly filteredImages = signal<QemuImage[]>([]);
   readonly chosenImage = signal<string>('');
   readonly qemuTemplate = signal<QemuTemplate>(new QemuTemplate());
   readonly uploader = signal<FileUploader | undefined>(undefined);
@@ -110,6 +113,7 @@ export class AddQemuVmTemplateComponent implements OnInit, OnDestroy {
     ) => {
       this.qemuService.getImages(this.controller()).subscribe((qemuImages: QemuImage[]) => {
         this.qemuImages.set(qemuImages);
+        this.filteredImages.set(qemuImages);
       });
       this.toasterService.success('Image uploaded');
     };
@@ -136,6 +140,7 @@ export class AddQemuVmTemplateComponent implements OnInit, OnDestroy {
         this.qemuService.getImages(this.controller()).subscribe({
           next: (qemuImages: QemuImage[]) => {
             this.qemuImages.set(qemuImages);
+            this.filteredImages.set(qemuImages);
           },
           error: (err) => {
             const message = err.error?.message || err.message || 'Failed to load QEMU images';
@@ -171,6 +176,26 @@ export class AddQemuVmTemplateComponent implements OnInit, OnDestroy {
 
   setDiskImage(value: string) {
     this.newImageSelected.set(value === 'newImage');
+    if (value === 'newImage') {
+      this.selectedImage.set(undefined);
+    }
+  }
+
+  filterImages(event: Event): QemuImage[] {
+    const filterValue = (event.target as HTMLInputElement).value.toLowerCase();
+    return this.qemuImages().filter((image) => image.filename.toLowerCase().includes(filterValue));
+  }
+
+  onDiskImageInput(event: Event) {
+    this.filteredImages.set(this.filterImages(event));
+    // Typing free text invalidates any previously picked image so we never
+    // save a stale path. A valid selection is only restored via onDiskImageSelected.
+    this.selectedImage.set(undefined);
+  }
+
+  onDiskImageSelected(filename: string) {
+    const image = this.qemuImages().find((img) => img.filename === filename);
+    this.selectedImage.set(image);
   }
 
   uploadImageFile(event) {


### PR DESCRIPTION
## Summary

On `/controller/:controller_id/preferences/qemu/addtemplate`, the **Disk image (hda)** field was a plain `mat-select`, which is hard to use when many images are installed. It is now an autocomplete input so the list can be filtered by typing — matching the behavior already available on the QEMU template details/edit page (`qemu-vm-template-details`), which reads from the same `QemuService.getImages()` source.

## Changes
- New `filteredImages` signal, populated whenever the image list is loaded.
- `filterImages` / `onDiskImageInput` drive the autocomplete options.
- `onDiskImageSelected` resolves the picked filename back to a `QemuImage`, keeping the existing `selectedImage` + `addTemplate().path` flow intact.
- `selectedImage` is cleared on free-text input and when switching to **New image**, so a stale path can never be saved.

## How to test
Open the QEMU add-template page, choose *Existing image*, and start typing in the *Disk image (hda)* field: the list filters live; selecting an option still populates `hda_disk_image` with the correct path.
