### PR TITLE
Fix LoginGuard crash when controller is null

### DIFF
--- a/src/app/guards/login-guard.ts
+++ b/src/app/guards/login-guard.ts
@@ -20,10 +20,18 @@ export class LoginGuard implements CanActivate {
       await this.loginService.getLoggedUser(controller);
     } catch (e) {}
     return this.controllerService.get(parseInt(controller_id, 10)).then((controller: Controller) => {
+      // Controller is absent from local storage (e.g. after clearing site data).
+      // There is nothing to authenticate against, so go back to the server list
+      // instead of dereferencing a null controller.
+      if (!controller) {
+        this.router.navigate(['/controllers']);
+        return false;
+      }
       if (controller.authToken && !controller.tokenExpired) {
         return true;
       }
       this.router.navigate(['/controller', controller.id, 'login'], { queryParams: { returnUrl: state.url } });
+      return false;
     });
   }
 }


### PR DESCRIPTION
## Summary

Fix a crash on refresh after clearing local cache. `LoginGuard.canActivate` dereferenced `controller.authToken` without a null check, but `ControllerService.get(id)` resolves to `null` when the `controller-<id>` localStorage key is missing.

## Root cause

After clearing site data and reloading a guarded route (e.g. `/controller/1/preferences/...`), `ControllerService.get(id)` resolves to `null` (`JSON.parse(localStorage.getItem('controller-<id>'))` → `JSON.parse(null)` → `null`), so the guard threw:

> Cannot read properties of null (reading 'authToken')

## Fix

Handle the `null` controller in `LoginGuard` by redirecting to the server list (`/controllers`) instead of dereferencing it. Also add the missing `return false` after the login redirect so the current navigation is properly cancelled.

## How to test

On a guarded preferences page, clear the site's local storage and reload: the app should land on the server list instead of throwing.
