### PR TITLE
(feat): Allow enabling IOU L1 keepalive for specific node not just at the template level in the Web UI

### DIFF
--- a/src/app/cartography/models/node.ts
+++ b/src/app/cartography/models/node.ts
@@ -113,6 +113,7 @@ export class Properties {
   remote_console_port?: number;
   remote_console_http_path?: string;
   use_default_iou_values?: boolean;
+  l1_keepalives?: boolean;
   console_resolution?: string;
   console_http_port?: number;
   console_http_path?: string;

--- a/src/app/components/preferences/ios-on-unix/iou-template-details/iou-template-details.component.html
+++ b/src/app/components/preferences/ios-on-unix/iou-template-details/iou-template-details.component.html
@@ -125,7 +125,7 @@
           Auto start console
         </mat-checkbox>
         <mat-checkbox [checked]="l1Keepalives()" (change)="l1Keepalives.set($event.checked)">
-          Enable layer 1 keepalive messages (non-functional)
+          Enable Layer 1 keepalive messages
         </mat-checkbox>
         <mat-checkbox [checked]="useDefaultIouValues()" (change)="useDefaultIouValues.set($event.checked)">
           Use default IOU values for memories

--- a/src/app/components/project-map/node-editors/configurator/iou/configurator-iou.component.html
+++ b/src/app/components/project-map/node-editors/configurator/iou/configurator-iou.component.html
@@ -38,6 +38,10 @@
 
               <mat-checkbox [checked]="consoleAutoStart()" (change)="consoleAutoStart.set($event.checked)"> Auto start console </mat-checkbox>
 
+              <mat-checkbox [checked]="l1Keepalives()" (change)="l1Keepalives.set($event.checked)">
+                Enable Layer 1 keepalive messages
+              </mat-checkbox>
+
               <mat-checkbox [checked]="useDefaultIouValues()" (change)="useDefaultIouValues.set($event.checked)">
                 Use default IOU values for memories
               </mat-checkbox>

--- a/src/app/components/project-map/node-editors/configurator/iou/configurator-iou.component.spec.ts
+++ b/src/app/components/project-map/node-editors/configurator/iou/configurator-iou.component.spec.ts
@@ -54,6 +54,7 @@ describe('ConfiguratorDialogIouComponent', () => {
       properties: {
         ethernet_adapters: 2,
         serial_adapters: 0,
+        l1_keepalives: false,
         use_default_iou_values: true,
         ram: '',
         nvram: '',
@@ -258,6 +259,14 @@ describe('ConfiguratorDialogIouComponent', () => {
 
       expect(newComponent.node.tags).toEqual([]);
     });
+
+    it('should initialize L1 keepalives from node properties', () => {
+      mockNode.properties.l1_keepalives = true;
+
+      component.ngOnInit();
+
+      expect(component.l1Keepalives()).toBe(true);
+    });
   });
 
   describe('getConfiguration', () => {
@@ -323,6 +332,7 @@ describe('ConfiguratorDialogIouComponent', () => {
         properties: {
           ethernet_adapters: 4,
           serial_adapters: 2,
+          l1_keepalives: false,
           use_default_iou_values: false,
           ram: '256',
           nvram: '64',
@@ -360,6 +370,7 @@ describe('ConfiguratorDialogIouComponent', () => {
       newComponent.nodeName.set('TestNode');
       newComponent.consoleType.set('vnc');
       newComponent.consoleAutoStart.set(true);
+      newComponent.l1Keepalives.set(true);
       newComponent.useDefaultIouValues.set(false);
       newComponent.ram.set('512');
       newComponent.nvram.set('128');
@@ -371,6 +382,7 @@ describe('ConfiguratorDialogIouComponent', () => {
 
       expect(newComponent.node.properties.ram).toBe(512);
       expect(newComponent.node.properties.nvram).toBe(128);
+      expect(newComponent.node.properties.l1_keepalives).toBe(true);
       expect(newComponent.node.properties.use_default_iou_values).toBe(false);
     });
   });

--- a/src/app/components/project-map/node-editors/configurator/iou/configurator-iou.component.ts
+++ b/src/app/components/project-map/node-editors/configurator/iou/configurator-iou.component.ts
@@ -58,6 +58,7 @@ export class ConfiguratorDialogIouComponent implements OnInit {
   readonly nodeName = model('');
   readonly consoleType = model('');
   readonly consoleAutoStart = model(false);
+  readonly l1Keepalives = model(false);
   readonly useDefaultIouValues = model(true);
   readonly ram = model('');
   readonly nvram = model('');
@@ -74,6 +75,7 @@ export class ConfiguratorDialogIouComponent implements OnInit {
         this.nodeName.set(node.name || '');
         this.consoleType.set(node.console_type || '');
         this.consoleAutoStart.set(node.console_auto_start || false);
+        this.l1Keepalives.set(node.properties.l1_keepalives ?? false);
         this.useDefaultIouValues.set(
           node.properties.use_default_iou_values !== undefined ? node.properties.use_default_iou_values : true
         );
@@ -113,6 +115,7 @@ export class ConfiguratorDialogIouComponent implements OnInit {
     this.node.name = this.nodeName();
     this.node.console_type = this.consoleType();
     this.node.console_auto_start = this.consoleAutoStart();
+    this.node.properties.l1_keepalives = this.l1Keepalives();
     this.node.properties.use_default_iou_values = this.useDefaultIouValues();
     this.node.properties.ram = parseInt(this.ram(), 10) || 0;
     this.node.properties.nvram = parseInt(this.nvram(), 10) || 0;


### PR DESCRIPTION
###Summary

Implemented the IOU L1 keepalive Web UI changes:

- Removed “(non-functional)” from the IOU template page option
- Added an L1 keepalive checkbox to the individual IOU node configuration page
