### PR TITLE
fix: Fix multi-node selection context-menu actions

### DIFF
--- a/src/app/cartography/tools/selection-tool.spec.ts
+++ b/src/app/cartography/tools/selection-tool.spec.ts
@@ -1,0 +1,63 @@
+import { select } from 'd3-selection';
+import { Subject } from 'rxjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { SelectionEventSource } from '../events/selection-event-source';
+import { Context } from '../models/context';
+import { SVGSelection } from '../models/types';
+import { SelectionTool } from './selection-tool';
+
+describe('SelectionTool context menu', () => {
+  let svg: SVGSelection;
+  let tool: SelectionTool;
+
+  beforeEach(() => {
+    const context = {
+      transformation: { x: 0, y: 0, k: 1 },
+      getZeroZeroTransformationPoint: () => ({ x: 0, y: 0 }),
+    } as Context;
+    const selectionEventSource = { selected: new Subject() } as SelectionEventSource;
+    svg = select(document.createElementNS('http://www.w3.org/2000/svg', 'svg')) as SVGSelection;
+    svg.append('g').attr('class', 'canvas');
+    tool = new SelectionTool(context, selectionEventSource);
+  });
+
+  it('should emit only for an actual right-click while enabled', () => {
+    const listener = vi.fn();
+    tool.contextMenuOpened.subscribe(listener);
+    tool.setEnabled(true);
+    tool.draw(svg, null);
+
+    const event = new MouseEvent('mousedown', { button: 2 });
+    svg.node().dispatchEvent(event);
+
+    expect(listener).toHaveBeenCalledOnce();
+    expect(listener).toHaveBeenCalledWith(event);
+  });
+
+  it('should prevent the browser context menu while enabled', () => {
+    tool.setEnabled(true);
+    tool.draw(svg, null);
+    const event = new MouseEvent('contextmenu', { cancelable: true });
+
+    svg.node().dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it('should remove its mouse handlers when disabled', () => {
+    const listener = vi.fn();
+    tool.contextMenuOpened.subscribe(listener);
+    tool.setEnabled(true);
+    tool.draw(svg, null);
+    tool.setEnabled(false);
+    tool.draw(svg, null);
+
+    const mouseDown = new MouseEvent('mousedown', { button: 2 });
+    const contextMenu = new MouseEvent('contextmenu', { cancelable: true });
+    svg.node().dispatchEvent(mouseDown);
+    svg.node().dispatchEvent(contextMenu);
+
+    expect(listener).not.toHaveBeenCalled();
+    expect(contextMenu.defaultPrevented).toBe(false);
+  });
+});

--- a/src/app/cartography/tools/selection-tool.ts
+++ b/src/app/cartography/tools/selection-tool.ts
@@ -1,6 +1,5 @@
 import { EventEmitter, Injectable } from '@angular/core';
 import { select, pointer } from 'd3-selection';
-import { Subject } from 'rxjs';
 import { SelectionEventSource } from '../events/selection-event-source';
 import { Context } from '../models/context';
 import { Rectangle } from '../models/rectangle';
@@ -8,61 +7,50 @@ import { SVGSelection } from '../models/types';
 
 @Injectable()
 export class SelectionTool {
-  static readonly SELECTABLE_CLASS = '.selectable';
-
-  public rectangleSelected = new Subject<Rectangle>();
-  public contextMenuOpened = new EventEmitter<any>();
+  public contextMenuOpened = new EventEmitter<MouseEvent>();
 
   private path;
   private enabled = false;
 
   public constructor(private context: Context, private selectionEventSource: SelectionEventSource) {}
 
-  public disableContextMenu() {}
-
   public setEnabled(enabled) {
     this.enabled = enabled;
-    this.contextMenuOpened.emit(true);
   }
 
   private activate(selection) {
     const self = this;
     const svgNode = selection.node();
 
-    selection.on('mousedown', function (event: any) {
-      // prevent deselection on right click
-      if (event.button == 2) {
-        selection.on('contextmenu', () => {
-          event.preventDefault();
-        });
+    selection
+      .on('contextmenu.selection', (event: MouseEvent) => event.preventDefault())
+      .on('mousedown.selection', function (event: MouseEvent) {
+        // prevent deselection on right click
+        if (event.button === 2) {
+          self.contextMenuOpened.emit(event);
+          return;
+        }
 
-        self.contextMenuOpened.emit(event);
-        return;
-      }
+        const subject = select(window);
+        const start = self.transformation(pointer(event, svgNode));
+        self.startSelection(start);
 
-      const subject = select(window);
-      const start = self.transformation(pointer(event, svgNode));
-      self.startSelection(start);
-
-      // clear selection
-      selection.selectAll(SelectionTool.SELECTABLE_CLASS).classed('selected', false);
-
-      // In zoneless mode, mousemove events don't trigger Angular CD automatically
-      subject
-        .on('mousemove.selection', function (event: any) {
-          const end = self.transformation(pointer(event, svgNode));
-          self.moveSelection(start, end);
-        })
-        .on('mouseup.selection', function (event: any) {
-          const end = self.transformation(pointer(event, svgNode));
-          self.endSelection(start, end);
-          subject.on('mousemove.selection', null).on('mouseup.selection', null);
-        });
-    });
+        // In zoneless mode, mousemove events don't trigger Angular CD automatically
+        subject
+          .on('mousemove.selection', function (event: any) {
+            const end = self.transformation(pointer(event, svgNode));
+            self.moveSelection(start, end);
+          })
+          .on('mouseup.selection', function (event: any) {
+            const end = self.transformation(pointer(event, svgNode));
+            self.endSelection(start, end);
+            subject.on('mousemove.selection', null).on('mouseup.selection', null);
+          });
+      });
   }
 
   private deactivate(selection) {
-    selection.on('mousedown', null);
+    selection.on('mousedown.selection', null).on('contextmenu.selection', null);
   }
 
   public draw(selection: SVGSelection, context: Context) {

--- a/src/app/cartography/widgets/graph-layout.spec.ts
+++ b/src/app/cartography/widgets/graph-layout.spec.ts
@@ -1,0 +1,49 @@
+import { select } from 'd3-selection';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { SelectionManager } from '../managers/selection-manager';
+import { MapLabel } from '../models/map/map-label';
+import { MapNode } from '../models/map/map-node';
+import { SVGSelection } from '../models/types';
+import { GraphLayout } from './graph-layout';
+
+describe('GraphLayout selection highlights', () => {
+  let graphLayout: GraphLayout;
+  let selectionManager: SelectionManager;
+  let view: SVGSelection;
+  let label: MapLabel;
+
+  beforeEach(() => {
+    selectionManager = new SelectionManager();
+    graphLayout = new GraphLayout(null, null, null, null, null, null, selectionManager);
+
+    view = select(document.createElementNS('http://www.w3.org/2000/svg', 'svg')) as SVGSelection;
+    const canvas = view.append('g').attr('class', 'canvas');
+    view.append('defs');
+
+    label = Object.assign(new MapLabel(), { id: 'label-1', nodeId: 'node-1' });
+    canvas.append('rect').datum(label).attr('class', 'label_selection').attr('visibility', 'hidden');
+  });
+
+  it('should highlight a hostname as soon as its parent node is selected', () => {
+    const node = Object.assign(new MapNode(), { id: 'node-1' });
+    selectionManager.setSelected([node]);
+
+    graphLayout.updateSelectionHighlights(view);
+
+    expect(view.select('rect.label_selection').attr('visibility')).toBe('visible');
+  });
+
+  it('should keep directly selected labels highlighted', () => {
+    selectionManager.setSelected([label]);
+
+    graphLayout.updateSelectionHighlights(view);
+
+    expect(view.select('rect.label_selection').attr('visibility')).toBe('visible');
+  });
+
+  it('should hide a hostname when neither it nor its parent node is selected', () => {
+    graphLayout.updateSelectionHighlights(view);
+
+    expect(view.select('rect.label_selection').attr('visibility')).toBe('hidden');
+  });
+});

--- a/src/app/cartography/widgets/graph-layout.ts
+++ b/src/app/cartography/widgets/graph-layout.ts
@@ -12,6 +12,8 @@ import { NodesWidget } from './nodes';
 import { Widget } from './widget';
 import { CurveElement } from '../models/drawings/curve-element';
 import { MapDrawing } from '../models/map/map-drawing';
+import { MapLabel } from '../models/map/map-label';
+import { MapNode } from '../models/map/map-node';
 
 @Injectable()
 export class GraphLayout implements Widget {
@@ -68,6 +70,18 @@ export class GraphLayout implements Widget {
 
     canvas.selectAll<SVGGElement, any>('g.node_body').classed('selected', (n) => this.selectionManager.isSelected(n));
     canvas.selectAll<SVGGElement, any>('g.link_body').classed('selected', (l) => this.selectionManager.isSelected(l));
+
+    const selectedNodeIds = new Set(
+      this.selectionManager
+        .getSelected()
+        .filter((item): item is MapNode => item instanceof MapNode)
+        .map((node) => node.id)
+    );
+    canvas
+      .selectAll<SVGRectElement, MapLabel>('rect.label_selection')
+      .attr('visibility', (label) =>
+        this.selectionManager.isSelected(label) || selectedNodeIds.has(label.nodeId) ? 'visible' : 'hidden'
+      );
 
     const drawingBodies = canvas.selectAll<SVGGElement, MapDrawing>('g.drawing_body');
     drawingBodies.classed('drawing_selected', (d) => this.selectionManager.isSelected(d));

--- a/src/app/cartography/widgets/label.ts
+++ b/src/app/cartography/widgets/label.ts
@@ -43,6 +43,11 @@ export class LabelWidget implements Widget {
 
     const merge = label_view
       .merge(label_enter)
+      .on('mousedown.context-menu', function (this: SVGGElement, event: MouseEvent) {
+        if (event.button === 2) {
+          event.stopPropagation();
+        }
+      })
       .on('contextmenu', function (this: SVGGElement, event: MouseEvent, n: MapLabel) {
         event.preventDefault();
         self.onContextMenu.emit(new LabelContextMenu(event, n));

--- a/src/app/cartography/widgets/node.ts
+++ b/src/app/cartography/widgets/node.ts
@@ -150,6 +150,11 @@ export class NodeWidget implements Widget {
     // update image of node
     node_body_merge
       .select<SVGImageElement>('image')
+      .on('mousedown.context-menu', function (this: SVGImageElement, event: MouseEvent) {
+        if (event.button === 2) {
+          event.stopPropagation();
+        }
+      })
       .on('contextmenu', function (this: SVGImageElement, event: MouseEvent, n: MapNode) {
         event.preventDefault();
         self.onContextMenu.emit(new NodeContextMenu(event, n));

--- a/src/app/components/project-map/project-map.component.spec.ts
+++ b/src/app/components/project-map/project-map.component.spec.ts
@@ -141,6 +141,10 @@ import { Symbol } from '@models/symbol';
 import { Controller } from '@models/controller';
 import { Project } from '@models/project';
 import { Node } from '../../cartography/models/node';
+import { MapNode } from '../../cartography/models/map/map-node';
+import { NodeContextMenu } from '../../cartography/events/nodes';
+import { MapLabel } from '../../cartography/models/map/map-label';
+import { LabelContextMenu } from '../../cartography/events/event-source';
 import { D3MapComponent } from '../../cartography/components/d3-map/d3-map.component';
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
@@ -368,7 +372,7 @@ describe('ProjectMapComponent', () => {
     };
 
     mockNodeWidget = {
-      onContextMenu: of(null),
+      onContextMenu: new Subject<NodeContextMenu>(),
     };
 
     mockDrawingsWidget = {
@@ -380,7 +384,7 @@ describe('ProjectMapComponent', () => {
     };
 
     mockLabelWidget = {
-      onContextMenu: of(null),
+      onContextMenu: new Subject<LabelContextMenu>(),
     };
 
     mockInterfaceLabelWidget = {
@@ -467,10 +471,11 @@ describe('ProjectMapComponent', () => {
     mockSelectionManager = {
       setSelected: vi.fn(),
       getSelected: vi.fn().mockReturnValue([]),
+      isSelected: vi.fn().mockReturnValue(false),
     };
 
     mockSelectionTool = {
-      contextMenuOpened: of(null),
+      contextMenuOpened: new Subject<MouseEvent>(),
     };
 
     mockRecentlyOpenedProjectService = {
@@ -877,6 +882,93 @@ describe('ProjectMapComponent', () => {
       expect(component.toolbarVisibility).toBe(true);
       expect(component.symbolScaling).toBe(true);
       expect(component.isAIChatVisible).toBe(false);
+    });
+  });
+
+  describe('Node context menu selection', () => {
+    let mockContextMenu: any;
+
+    beforeEach(() => {
+      mockContextMenu = {
+        openMenuForNode: vi.fn(),
+        openMenuForLabel: vi.fn(),
+        openMenuForListOfElements: vi.fn(),
+      };
+      vi.spyOn(component as any, 'contextMenu').mockReturnValue(mockContextMenu);
+    });
+
+    it('should preserve a multi-selection when right-clicking one of its nodes', () => {
+      const firstNode = Object.assign(new MapNode(), { id: 'node-1' });
+      const secondNode = Object.assign(new MapNode(), { id: 'node-2' });
+      const firstConvertedNode = { node_id: 'node-1' } as Node;
+      const secondConvertedNode = { node_id: 'node-2' } as Node;
+      mockSelectionManager.getSelected.mockReturnValue([firstNode, secondNode]);
+      mockSelectionManager.isSelected.mockReturnValue(true);
+      mockMapNodeToNode.convert.mockImplementation((node: MapNode) =>
+        node.id === firstNode.id ? firstConvertedNode : secondConvertedNode
+      );
+      component.setUpMapCallbacks();
+
+      mockNodeWidget.onContextMenu.next(
+        new NodeContextMenu(new MouseEvent('contextmenu', { clientX: 10, clientY: 20 }), firstNode)
+      );
+
+      expect(mockSelectionManager.setSelected).not.toHaveBeenCalled();
+      expect(mockContextMenu.openMenuForNode).not.toHaveBeenCalled();
+      expect(mockContextMenu.openMenuForListOfElements).toHaveBeenCalledWith(
+        [],
+        [firstConvertedNode, secondConvertedNode],
+        [],
+        [],
+        20,
+        10
+      );
+    });
+
+    it('should select only an unselected right-clicked node', () => {
+      const selectedNode = Object.assign(new MapNode(), { id: 'node-1' });
+      const clickedNode = Object.assign(new MapNode(), { id: 'node-2' });
+      const convertedNode = { node_id: 'node-2' } as Node;
+      mockSelectionManager.getSelected.mockReturnValue([selectedNode]);
+      mockSelectionManager.isSelected.mockReturnValue(false);
+      mockMapNodeToNode.convert.mockReturnValue(convertedNode);
+      component.setUpMapCallbacks();
+
+      mockNodeWidget.onContextMenu.next(
+        new NodeContextMenu(new MouseEvent('contextmenu', { clientX: 30, clientY: 40 }), clickedNode)
+      );
+
+      expect(mockSelectionManager.setSelected).toHaveBeenCalledWith([clickedNode]);
+      expect(mockContextMenu.openMenuForNode).toHaveBeenCalledWith(convertedNode, 40, 30);
+      expect(mockContextMenu.openMenuForListOfElements).not.toHaveBeenCalled();
+    });
+
+    it('should preserve the node selection when right-clicking a selected node hostname', () => {
+      const firstNode = Object.assign(new MapNode(), { id: 'node-1' });
+      const secondNode = Object.assign(new MapNode(), { id: 'node-2' });
+      const firstLabel = Object.assign(new MapLabel(), { id: 'label-1', nodeId: 'node-1' });
+      const firstConvertedNode = { node_id: 'node-1' } as Node;
+      const secondConvertedNode = { node_id: 'node-2' } as Node;
+      mockSelectionManager.getSelected.mockReturnValue([firstNode, secondNode]);
+      mockSelectionManager.isSelected.mockReturnValue(false);
+      mockMapNodeToNode.convert.mockImplementation((node: MapNode) =>
+        node.id === firstNode.id ? firstConvertedNode : secondConvertedNode
+      );
+      component.setUpMapCallbacks();
+
+      mockLabelWidget.onContextMenu.next(
+        new LabelContextMenu(new MouseEvent('contextmenu', { clientX: 50, clientY: 60 }), firstLabel)
+      );
+
+      expect(mockContextMenu.openMenuForLabel).not.toHaveBeenCalled();
+      expect(mockContextMenu.openMenuForListOfElements).toHaveBeenCalledWith(
+        [],
+        [firstConvertedNode, secondConvertedNode],
+        [],
+        [],
+        60,
+        50
+      );
     });
   });
 

--- a/src/app/components/project-map/project-map.component.ts
+++ b/src/app/components/project-map/project-map.component.ts
@@ -815,6 +815,13 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
     });
 
     const onNodeContextMenu = this.nodeWidget.onContextMenu.subscribe((eventNode: NodeContextMenu) => {
+      const selectedItems = this.selectionManager.getSelected();
+
+      if (this.selectionManager.isSelected(eventNode.node) && this.openMenuForSelection(selectedItems, eventNode.event)) {
+        return;
+      }
+
+      this.selectionManager.setSelected([eventNode.node]);
       const node = this.mapNodeToNode.convert(eventNode.node);
       this.contextMenu().openMenuForNode(node, eventNode.event.clientY, eventNode.event.clientX);
     });
@@ -825,6 +832,15 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
     });
 
     const onLabelContextMenu = this.labelWidget.onContextMenu.subscribe((eventLabel: LabelContextMenu) => {
+      const selectedItems = this.selectionManager.getSelected();
+      const isLabelOrParentSelected =
+        this.selectionManager.isSelected(eventLabel.label) ||
+        selectedItems.some((item) => item instanceof MapNode && item.id === eventLabel.label.nodeId);
+
+      if (isLabelOrParentSelected && this.openMenuForSelection(selectedItems, eventLabel.event)) {
+        return;
+      }
+
       const label = this.mapLabelToLabel.convert(eventLabel.label);
       const node = this.nodes().find((n) => n.node_id === eventLabel.label.nodeId);
       this.contextMenu().openMenuForLabel(label, node, eventLabel.event.clientY, eventLabel.event.clientX);
@@ -845,26 +861,7 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
 
     const onContextMenu = this.selectionTool.contextMenuOpened.subscribe((event) => {
       const selectedItems = this.selectionManager.getSelected();
-      if (selectedItems.length < 2 || !(event instanceof MouseEvent)) return;
-
-      let drawings: Drawing[] = [];
-      let nodes: Node[] = [];
-      let labels: Label[] = [];
-      let links: Link[] = [];
-
-      selectedItems.forEach((elem) => {
-        if (elem instanceof MapDrawing) {
-          drawings.push(this.mapDrawingToDrawing.convert(elem));
-        } else if (elem instanceof MapNode) {
-          nodes.push(this.mapNodeToNode.convert(elem));
-        } else if (elem instanceof MapLabel) {
-          labels.push(this.mapLabelToLabel.convert(elem));
-        } else if (elem instanceof MapLink) {
-          links.push(this.mapLinkToLink.convert(elem));
-        }
-      });
-
-      this.contextMenu().openMenuForListOfElements(drawings, nodes, labels, links, event.clientY, event.clientX);
+      this.openMenuForSelection(selectedItems, event);
     });
 
     this.projectMapSubscription.add(onLinkContextMenu);
@@ -876,6 +873,32 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
     this.projectMapSubscription.add(onLabelContextMenu);
     this.projectMapSubscription.add(onInterfaceLabelContextMenu);
     this.mapChangeDetectorRef.detectChanges();
+  }
+
+  private openMenuForSelection(selectedItems: Indexed[], event: Event): boolean {
+    if (selectedItems.length < 2 || !(event instanceof MouseEvent)) {
+      return false;
+    }
+
+    const drawings: Drawing[] = [];
+    const nodes: Node[] = [];
+    const labels: Label[] = [];
+    const links: Link[] = [];
+
+    selectedItems.forEach((elem) => {
+      if (elem instanceof MapDrawing) {
+        drawings.push(this.mapDrawingToDrawing.convert(elem));
+      } else if (elem instanceof MapNode) {
+        nodes.push(this.mapNodeToNode.convert(elem));
+      } else if (elem instanceof MapLabel) {
+        labels.push(this.mapLabelToLabel.convert(elem));
+      } else if (elem instanceof MapLink) {
+        links.push(this.mapLinkToLink.convert(elem));
+      }
+    });
+
+    this.contextMenu().openMenuForListOfElements(drawings, nodes, labels, links, event.clientY, event.clientX);
+    return true;
   }
 
   onNodeCreation(nodeAddedEvent: NodeAddedEvent) {


### PR DESCRIPTION
### Purpose

Fix an issue where right-clicking a node within a multi-node selection replaced the existing selection with only the clicked node. As a result, context-menu actions such as **Start**, **Stop**, or **Suspend** were applied to only one node.

### Changes

- Preserve the current multi-selection when right-clicking any selected node.
- Pass all selected nodes to the context-menu actions.
- Select only the clicked node when right-clicking a node outside the current selection.
- Preserve the multi-selection when right-clicking a selected node hostname.
- Display hostname selection focus immediately when its parent node is selected.
- Prevent duplicate node, hostname, and canvas context-menu events.
- Clean up unused selection-tool code and properly register and remove its event handlers.
- Add regression tests covering:
  - Right-clicking a node within a multi-selection.
  - Right-clicking an unselected node.
  - Right-clicking a selected node hostname.
  - Immediate hostname focus.
  - Selection-tool context-menu behavior.

### Validation

- 43 selection-related tests passed.
- Angular development build passed.
- `git diff --check` passed.