### PR TITLE
refine(menu): Reduce Angular Material menu item height to minimize unnecessary scrolling in lage context menus

### DIFF
--- a/src/app/components/project-map/project-map.component.scss
+++ b/src/app/components/project-map/project-map.component.scss
@@ -458,38 +458,8 @@ g.node text,
   padding-right: 16px;
 }
 
-.context-menu-items .mat-menu-item {
-  line-height: 32px;
-  height: 32px;
-  font-size: 12px;
-  padding: 0 6px;
-  outline: none;
-}
-
-.context-menu-items .mat-menu-item .mat-icon {
-  margin-right: 3px;
-}
-
-.context-menu-items .mat-menu-item:focus {
-  background: none;
-}
-
-.context-menu-items .mat-menu-item.cdk-focused:not(:hover),
-.context-menu-items .mat-menu-item.cdk-program-focused:not(:hover),
-.context-menu-items .mat-menu-item.cdk-keyboard-focused:not(:hover) {
-  background: none;
-}
-
-.context-menu-items .mat-menu-item:hover {
-  background-color: var(--mat-sys-surface-container);
-}
-
 .visible {
   display: none;
-}
-
-mat-menu-panel {
-  min-height: 0;
 }
 
 .unmarked {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -519,3 +519,29 @@ mat-form-field {
 .mat-mdc-form-field-text-prefix {
   align-self: center;
 }
+
+/* =============================================
+// Menu Density
+// ============================================= */
+.mat-mdc-menu-panel {
+  --gns3-menu-item-min-height: 40px;
+}
+
+.mat-mdc-menu-panel.context-menu-items {
+  --gns3-menu-item-min-height: 36px;
+
+  .mat-mdc-menu-content {
+    padding: 4px 0;
+  }
+}
+
+.mat-mdc-menu-panel .mat-mdc-menu-item {
+  min-height: var(--gns3-menu-item-min-height);
+}
+
+// Restore Material's touch-friendly target size on coarse-pointer devices.
+@media (pointer: coarse) {
+  .mat-mdc-menu-panel {
+    --gns3-menu-item-min-height: 48px;
+  }
+}


### PR DESCRIPTION
## Summary

Reduce Angular Material menu item height to provide a more compact interface and minimize unnecessary scrolling in menus containing many actions.

## Changes

- Set the default menu item minimum height to `40px`.
- Set project context menu items to `36px`.
- Reduce context menu vertical padding from `8px` to `4px`.
- Restore the Material default `48px` target size on coarse-pointer and touch devices.
- Remove obsolete styles targeting the pre-MDC `.mat-menu-item` class.

## Scope

The `40px` density applies to Angular Material menus throughout the WebUI.

The denser `36px` style is limited to project context menus using the `context-menu-items` panel class. Other controls and non-Material menus are unaffected.

Touch-oriented environments retain `48px` menu items for accessibility and usability.

## Purpose

GNS3 is primarily a desktop application operated with a mouse or other precision pointer. Large menus can contain more than ten actions, and the previous `48px` minimum height introduced unnecessary scrolling.

The new density improves information visibility and reduces scrolling while preserving readable labels, full-row click targets, keyboard behavior, and touch-friendly sizing where appropriate.

## Validation

- Prettier formatting check passed.
- Angular lint passed.
- Development build completed successfully.
- `git diff --check` passed.