### PR TITLE
feat(templates): Add a Pull image button to the General settings section of Docker container templates.

### DIFF
--- a/src/app/components/preferences/docker/docker-template-details/docker-template-details.component.html
+++ b/src/app/components/preferences/docker/docker-template-details/docker-template-details.component.html
@@ -41,16 +41,28 @@
             />
           </mat-form-field>
         </div>
-        <mat-form-field class="form-field">
-          <mat-label>Image</mat-label>
-          <input
-            matInput
-            [value]="image()"
-            (input)="image.set($event.target.value)"
-            type="text"
-            placeholder="Docker image name"
-          />
-        </mat-form-field>
+        <div class="docker-details__image-row">
+          <mat-form-field class="form-field">
+            <mat-label>Image</mat-label>
+            <input
+              matInput
+              [value]="image()"
+              (input)="image.set($event.target.value)"
+              type="text"
+              placeholder="Docker image name"
+            />
+          </mat-form-field>
+          <button
+            mat-stroked-button
+            class="docker-details__pull-btn"
+            type="button"
+            [disabled]="isPulling() || !image().trim()"
+            (click)="pullImage()"
+          >
+            <mat-icon>cloud_download</mat-icon>
+            {{ isPulling() ? 'Pulling…' : 'Pull image' }}
+          </button>
+        </div>
         <div class="docker-details__symbol-row">
           <mat-form-field class="form-field">
             <mat-label>Category</mat-label>

--- a/src/app/components/preferences/docker/docker-template-details/docker-template-details.component.scss
+++ b/src/app/components/preferences/docker/docker-template-details/docker-template-details.component.scss
@@ -142,6 +142,22 @@
   }
 }
 
+.docker-details__image-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 16px;
+
+  .form-field {
+    flex: 1;
+  }
+}
+
+.docker-details__pull-btn {
+  height: 48px;
+  margin-top: 4px;
+  white-space: nowrap;
+}
+
 .docker-details__symbol-btn {
   margin-top: 4px;
   height: 48px;
@@ -236,6 +252,11 @@
     flex-direction: column;
   }
 
+  .docker-details__image-row {
+    flex-direction: column;
+  }
+
+  .docker-details__pull-btn,
   .docker-details__symbol-btn {
     width: 100%;
   }

--- a/src/app/components/preferences/docker/docker-template-details/docker-template-details.component.spec.ts
+++ b/src/app/components/preferences/docker/docker-template-details/docker-template-details.component.spec.ts
@@ -114,6 +114,7 @@ describe('DockerTemplateDetailsComponent', () => {
     mockDockerService = {
       getTemplate: vi.fn().mockReturnValue(of(createMockDockerTemplate())),
       saveTemplate: vi.fn().mockReturnValue(templateSavedSubject.asObservable()),
+      pullImage: vi.fn().mockReturnValue(of(undefined)),
     };
 
     mockDockerConfigurationService = {
@@ -306,6 +307,60 @@ describe('DockerTemplateDetailsComponent', () => {
       templateSavedSubject.next(createMockDockerTemplate());
 
       expect(mockToasterService.success).toHaveBeenCalledWith('Changes saved');
+    });
+  });
+
+  describe('pullImage', () => {
+    beforeEach(() => {
+      component.controller = createMockController(1);
+      component.dockerTemplate = createMockDockerTemplate();
+      component.image.set('nginx:latest');
+    });
+
+    it('should pull the current image on the template compute', () => {
+      component.dockerTemplate.compute_id = 'remote-compute';
+      component.image.set('  nginx:latest  ');
+
+      component.pullImage();
+
+      expect(mockDockerService.pullImage).toHaveBeenCalledWith(component.controller, 'nginx:latest', 'remote-compute');
+    });
+
+    it('should show a success message after pulling the image', () => {
+      component.pullImage();
+
+      expect(mockToasterService.success).toHaveBeenCalledWith("Docker image 'nginx:latest' updated");
+    });
+
+    it('should disable additional pulls while one is in progress', () => {
+      const pullSubject = new Subject<void>();
+      mockDockerService.pullImage.mockReturnValue(pullSubject.asObservable());
+
+      component.pullImage();
+      component.pullImage();
+
+      expect(component.isPulling()).toBe(true);
+      expect(mockDockerService.pullImage).toHaveBeenCalledTimes(1);
+
+      pullSubject.complete();
+      expect(component.isPulling()).toBe(false);
+    });
+
+    it('should show the server error and reset the pulling state', () => {
+      mockDockerService.pullImage.mockReturnValue(throwError(() => ({ error: { message: 'Pull failed' } })));
+
+      component.pullImage();
+
+      expect(mockToasterService.error).toHaveBeenCalledWith('Pull failed');
+      expect(component.isPulling()).toBe(false);
+    });
+
+    it('should not pull an empty image', () => {
+      component.image.set('   ');
+
+      component.pullImage();
+
+      expect(mockDockerService.pullImage).not.toHaveBeenCalled();
     });
   });
 

--- a/src/app/components/preferences/docker/docker-template-details/docker-template-details.component.ts
+++ b/src/app/components/preferences/docker/docker-template-details/docker-template-details.component.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy, ChangeDetectorRef, OnInit, model, inject } from '@angular/core';
+import { Component, ChangeDetectionStrategy, ChangeDetectorRef, OnInit, model, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
@@ -11,6 +11,7 @@ import { MatChipsModule, MatChipInputEvent } from '@angular/material/chips';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatDialog } from '@angular/material/dialog';
 import { COMMA, ENTER } from '@angular/cdk/keycodes';
+import { finalize } from 'rxjs';
 import { Controller } from '@models/controller';
 import { DockerTemplate } from '@models/templates/docker-template';
 import { DockerConfigurationService } from '@services/docker-configuration.service';
@@ -90,6 +91,7 @@ export class DockerTemplateDetailsComponent implements OnInit {
   extraHosts = model('');
   extraVolumes = model('');
   usage = model('');
+  readonly isPulling = signal(false);
 
   constructor() {}
 
@@ -261,6 +263,32 @@ export class DockerTemplateDetailsComponent implements OnInit {
         this.cd.markForCheck();
       },
     });
+  }
+
+  pullImage() {
+    const image = this.image().trim();
+    if (!image || this.isPulling()) {
+      return;
+    }
+
+    this.isPulling.set(true);
+    this.dockerService
+      .pullImage(this.controller, image, this.dockerTemplate.compute_id)
+      .pipe(
+        finalize(() => {
+          this.isPulling.set(false);
+          this.cd.markForCheck();
+        })
+      )
+      .subscribe({
+        next: () => {
+          this.toasterService.success(`Docker image '${image}' updated`);
+        },
+        error: (err) => {
+          const message = err.error?.message || err.message || `Failed to pull Docker image '${image}'`;
+          this.toasterService.error(message);
+        },
+      });
   }
 
   editCustomAdapters() {

--- a/src/app/services/docker.service.spec.ts
+++ b/src/app/services/docker.service.spec.ts
@@ -102,6 +102,20 @@ describe('DockerService', () => {
     });
   });
 
+  describe('pullImage', () => {
+    it('should pull the image on the selected compute', () => {
+      mockHttpController.post.mockReturnValue(of(undefined));
+
+      service.pullImage(mockController, 'nginx:latest', 'remote-compute');
+
+      expect(mockHttpController.post).toHaveBeenCalledWith(
+        mockController,
+        '/computes/remote-compute/docker/images/pull',
+        { image: 'nginx:latest' }
+      );
+    });
+  });
+
   describe('addTemplate', () => {
     it('should call httpController.post with template', () => {
       const template: DockerTemplate = { name: 'New Docker' } as DockerTemplate;

--- a/src/app/services/docker.service.ts
+++ b/src/app/services/docker.service.ts
@@ -28,6 +28,12 @@ export class DockerService {
     ) as Observable<DockerImage[]>;
   }
 
+  pullImage(controller: Controller, image: string, computeId: string): Observable<void> {
+    return this.httpController.post<void>(controller, `/computes/${computeId}/docker/images/pull`, {
+      image,
+    }) as Observable<void>;
+  }
+
   addTemplate(controller: Controller, dockerTemplate: any): Observable<any> {
     const templateToSend = this.prepareTemplate(dockerTemplate);
     return this.httpController.post<DockerTemplate>(


### PR DESCRIPTION
## Summary

Add a **Pull image** button to the General settings section of Docker container templates.

## Purpose

Docker template images could previously only be updated by manually running `docker pull` on the GNS3 compute.

This change allows users to request an image update directly from the Docker template configuration page.

## Changes

- Add a **Pull image** button beside the Docker image field.
- Send the pull request to the compute assigned to the template.
- Trim the image name before sending the request.
- Disable the button when the image name is empty or a pull is already running.
- Display success and error notifications.
- Add responsive styling for the new action.
- Add service and component regression tests.

Related to https://github.com/GNS3/gns3-gui/issues/3772

## Server dependency

Requires the corresponding `gns3-server` change providing:

```http
POST /v3/computes/{compute_id}/docker/images/pull