### PR TITLE
feat(marker): direction filter, capture node, serial/WAN encapsulation & enable/pause toggles

### DIFF
--- a/src/app/cartography/tools/selection-tool.spec.ts
+++ b/src/app/cartography/tools/selection-tool.spec.ts
@@ -3,6 +3,7 @@ import { Subject } from 'rxjs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { SelectionEventSource } from '../events/selection-event-source';
 import { Context } from '../models/context';
+import { Rectangle } from '../models/rectangle';
 import { SVGSelection } from '../models/types';
 import { SelectionTool } from './selection-tool';
 
@@ -59,5 +60,54 @@ describe('SelectionTool context menu', () => {
 
     expect(listener).not.toHaveBeenCalled();
     expect(contextMenu.defaultPrevented).toBe(false);
+  });
+});
+
+describe('SelectionTool rubber-band rectangle', () => {
+  /** Build a tool wired to a fake context + a capture Subject for emitted rects. */
+  const makeTool = (k: number) => {
+    const context = {
+      transformation: { x: 0, y: 0, k },
+      getZeroZeroTransformationPoint: () => ({ x: 0, y: 0 }),
+    } as Context;
+    const selected$ = new Subject<Rectangle>();
+    const selectionEventSource = { selected: selected$ } as SelectionEventSource;
+    const tool = new SelectionTool(context, selectionEventSource);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const fire = (start: [number, number], end: [number, number]) =>
+      (tool as any).selectedEvent(start, end);
+    return { fire, selected$ };
+  };
+
+  it('divides the rectangle by zoom k so hit-testing uses canvas space', () => {
+    const { fire, selected$ } = makeTool(2);
+    const emitted: Rectangle[] = [];
+    selected$.subscribe((r) => emitted.push(r));
+
+    // start/end are what transformation() yields (screen minus pan, NOT /k);
+    // with k=2 the emitted canvas-space rectangle must be halved.
+    fire([0, 0], [200, 100]);
+
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0]).toMatchObject({ x: 0, y: 0, width: 100, height: 50 });
+  });
+
+  it('keeps a 1:1 mapping when k is 1 (no zoom)', () => {
+    const { fire, selected$ } = makeTool(1);
+    const emitted: Rectangle[] = [];
+    selected$.subscribe((r) => emitted.push(r));
+
+    fire([10, 20], [110, 70]);
+
+    expect(emitted[0]).toMatchObject({ x: 10, y: 20, width: 100, height: 50 });
+  });
+
+  it('does not emit when k is 0 (guards against NaN / divide-by-zero)', () => {
+    const { fire, selected$ } = makeTool(0);
+    const emitted: Rectangle[] = [];
+    selected$.subscribe((r) => emitted.push(r));
+
+    fire([0, 0], [100, 100]);
+    expect(emitted).toHaveLength(0);
   });
 });

--- a/src/app/cartography/tools/selection-tool.ts
+++ b/src/app/cartography/tools/selection-tool.ts
@@ -117,10 +117,26 @@ export class SelectionTool {
   }
 
   private selectedEvent(start, end) {
-    const x = Math.min(start[0], end[0]);
-    const y = Math.min(start[1], end[1]);
-    const width = Math.abs(start[0] - end[0]);
-    const height = Math.abs(start[1] - end[1]);
+    // `start`/`end` come from `transformation()`, which subtracts the pan
+    // (zeroZero + transformation.x/y) but does NOT divide by the scale k — so
+    // they are in screen-pixel space, not canvas space. Node/link coordinates
+    // live in canvas space, so we must divide by k before hit-testing.
+    // Without this, the emitted Rectangle is the wrong size and position
+    // whenever the canvas is zoomed: zoomed-out selection captures too few
+    // nodes, zoomed-in captures too many. (`moveSelection` already divides by
+    // k for the visible path, which is why the drawn box looks correct.)
+    const k = this.context.transformation.k;
+    if (!k || k === 0 || isNaN(k)) {
+      return;
+    }
+    const sx = start[0] / k;
+    const sy = start[1] / k;
+    const ex = end[0] / k;
+    const ey = end[1] / k;
+    const x = Math.min(sx, ex);
+    const y = Math.min(sy, ey);
+    const width = Math.abs(sx - ex);
+    const height = Math.abs(sy - ey);
     this.selectionEventSource.selected.next(new Rectangle(x, y, width, height));
   }
 

--- a/src/app/components/project-map/marker-manager/marker-form.component.scss
+++ b/src/app/components/project-map/marker-manager/marker-form.component.scss
@@ -47,3 +47,8 @@
   align-self: start;
   margin-top: 18px;
 }
+
+.marker-form__submit-spinner {
+  // Spinner inside mat-flat-button color="primary": arc matches the on-primary label.
+  --mdc-circular-progress-active-indicator-color: var(--mat-sys-on-primary);
+}

--- a/src/app/components/project-map/marker-manager/marker-form.component.scss
+++ b/src/app/components/project-map/marker-manager/marker-form.component.scss
@@ -1,0 +1,49 @@
+// Presentational marker create/edit form. Kept flat (no SCSS nesting) so the
+// grid columns apply regardless of how the styles are processed.
+.marker-form {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin: 8px 0 4px;
+  padding: 8px;
+  background: var(--mat-sys-surface-container);
+  border-radius: 6px;
+}
+
+.marker-form__row {
+  display: grid;
+  align-items: start;
+  gap: 16px;
+}
+
+.marker-form__row--full {
+  grid-template-columns: 1fr;
+}
+
+.marker-form__row--identity {
+  grid-template-columns: 2.5fr 1.5fr 0.9fr;
+}
+
+.marker-form__row--style {
+  grid-template-columns: minmax(7rem, 1.3fr) minmax(6rem, 1fr) minmax(6rem, 1fr) 1fr;
+}
+
+.marker-form__field {
+  width: 100%;
+  margin-bottom: 4px;
+}
+
+.marker-form__color {
+  cursor: pointer;
+  block-size: 20px;
+  inline-size: 100%;
+  box-sizing: border-box;
+}
+
+.marker-form__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  align-self: start;
+  margin-top: 18px;
+}

--- a/src/app/components/project-map/marker-manager/marker-form.component.ts
+++ b/src/app/components/project-map/marker-manager/marker-form.component.ts
@@ -78,10 +78,11 @@ export interface MarkerCaptureOption {
           </mat-select>
         </mat-form-field>
         <mat-form-field class="marker-form__field">
+          <mat-label>Direction</mat-label>
           <mat-select formControlName="direction">
             <mat-option value="both">Both</mat-option>
-            <mat-option value="tx">Tx →</mat-option>
-            <mat-option value="rx">← Rx</mat-option>
+            <mat-option value="tx">Tx</mat-option>
+            <mat-option value="rx">Rx</mat-option>
           </mat-select>
         </mat-form-field>
       </div>

--- a/src/app/components/project-map/marker-manager/marker-form.component.ts
+++ b/src/app/components/project-map/marker-manager/marker-form.component.ts
@@ -5,6 +5,7 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { MatButtonModule } from '@angular/material/button';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { CdkTextareaAutosize } from '@angular/cdk/text-field';
 
 /** A capture-node dropdown option — one of the link's endpoints. */
@@ -37,6 +38,7 @@ export interface MarkerCaptureOption {
     MatInputModule,
     MatSelectModule,
     MatButtonModule,
+    MatProgressSpinnerModule,
     CdkTextareaAutosize,
   ],
   template: `
@@ -106,8 +108,13 @@ export interface MarkerCaptureOption {
           <input matInput type="number" formControlName="tag" placeholder="—" />
         </mat-form-field>
         <div class="marker-form__actions">
-          <button mat-flat-button color="primary" type="submit" [disabled]="form().invalid">
-            {{ submitLabel() }}
+          <button mat-flat-button color="primary" type="submit" [disabled]="form().invalid || submitting()">
+            @if (submitting()) {
+              <mat-spinner class="marker-form__submit-spinner" [diameter]="16" />
+              {{ mode() === 'edit' ? 'Saving…' : 'Adding…' }}
+            } @else {
+              {{ submitLabel() }}
+            }
           </button>
           <button mat-stroked-button type="button" (click)="cancel.emit()">Cancel</button>
         </div>
@@ -125,6 +132,8 @@ export class MarkerFormComponent {
   readonly captureOptions = input<MarkerCaptureOption[]>([]);
   /** Submit button label, derived from mode (`Add` / `Save`). */
   readonly submitLabel = computed(() => (this.mode() === 'edit' ? 'Save' : 'Add'));
+  /** When true, the submit button shows a spinner and the label changes to "Saving…" / "Adding…". */
+  readonly submitting = input<boolean>(false);
   readonly save = output<void>();
   readonly cancel = output<void>();
 }

--- a/src/app/components/project-map/marker-manager/marker-form.component.ts
+++ b/src/app/components/project-map/marker-manager/marker-form.component.ts
@@ -5,6 +5,7 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { MatButtonModule } from '@angular/material/button';
+import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { CdkTextareaAutosize } from '@angular/cdk/text-field';
 
@@ -38,6 +39,7 @@ export interface MarkerCaptureOption {
     MatInputModule,
     MatSelectModule,
     MatButtonModule,
+    MatTooltipModule,
     MatProgressSpinnerModule,
     CdkTextareaAutosize,
   ],
@@ -87,6 +89,16 @@ export interface MarkerCaptureOption {
             <mat-option value="rx">Rx</mat-option>
           </mat-select>
         </mat-form-field>
+        @if (isSerial()) {
+          <mat-form-field class="marker-form__field">
+            <mat-label>Serial encapsulation</mat-label>
+            <mat-select formControlName="data_link_type" matTooltip="WAN encapsulation (matches the router's IOS setting)">
+              @for (dlt of dataLinkOptions(); track dlt.value) {
+                <mat-option [value]="dlt.value">{{ dlt.label }}</mat-option>
+              }
+            </mat-select>
+          </mat-form-field>
+        }
       </div>
       <div class="marker-form__row marker-form__row--style">
         <mat-form-field class="marker-form__field">
@@ -130,6 +142,12 @@ export class MarkerFormComponent {
   readonly mode = input<'create' | 'edit'>('create');
   /** Endpoint options for the Capture node dropdown (the link's nodes). */
   readonly captureOptions = input<MarkerCaptureOption[]>([]);
+  /** Encapsulation (uBridge DLT) options for the Data link type dropdown. */
+  readonly dataLinkOptions = input<{ label: string; value: string }[]>([]);
+  /** Protocol `link_type` of the link this form targets (`'ethernet'` / `'serial`). */
+  readonly linkType = input<string>('ethernet');
+  /** WAN encapsulation only applies to serial links — hide the picker on Ethernet. */
+  readonly isSerial = computed(() => this.linkType() === 'serial');
   /** Submit button label, derived from mode (`Add` / `Save`). */
   readonly submitLabel = computed(() => (this.mode() === 'edit' ? 'Save' : 'Add'));
   /** When true, the submit button shows a spinner and the label changes to "Saving…" / "Adding…". */

--- a/src/app/components/project-map/marker-manager/marker-form.component.ts
+++ b/src/app/components/project-map/marker-manager/marker-form.component.ts
@@ -1,0 +1,129 @@
+import { ChangeDetectionStrategy, Component, computed, input, output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule, UntypedFormGroup } from '@angular/forms';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { MatButtonModule } from '@angular/material/button';
+import { CdkTextareaAutosize } from '@angular/cdk/text-field';
+
+/** A capture-node dropdown option — one of the link's endpoints. */
+export interface MarkerCaptureOption {
+  id: string;
+  name: string;
+}
+
+/**
+ * Shared create/edit form for per-link markers — the single source of truth for the
+ * marker field layout (BPF, Name, Capture node, Direction, Highlight ms, Color).
+ *
+ * Presentational: the {@link UntypedFormGroup} (and which controls are disabled) is
+ * owned by the parent ({@link MarkerManagerComponent}); this component only renders
+ * it and emits {@link save} / {@link cancel}. Because disabled-state is driven by the
+ * reactive form control, edit mode (name + `capture_node_id` disabled) just works —
+ * the parent disables those controls on the group it passes in.
+ *
+ * `capture_node_id` is honored only on create (immutable afterwards); definitions
+ * don't have it, so this component is used for private per-link markers only.
+ */
+@Component({
+  selector: 'app-marker-form',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSelectModule,
+    MatButtonModule,
+    CdkTextareaAutosize,
+  ],
+  template: `
+    <form class="marker-form" [formGroup]="form()" (ngSubmit)="save.emit()">
+      <div class="marker-form__row marker-form__row--full">
+        <mat-form-field class="marker-form__field">
+          <mat-label>BPF expression</mat-label>
+          <textarea
+            matInput
+            formControlName="bpf"
+            placeholder="tcp port 80"
+            rows="1"
+            cdkTextareaAutosize
+            cdkAutosizeMinRows="1"
+            cdkAutosizeMaxRows="4"
+          ></textarea>
+          @if (form().get('bpf')?.hasError('required')) {
+            <mat-error>BPF is required</mat-error>
+          }
+        </mat-form-field>
+      </div>
+      <div class="marker-form__row marker-form__row--identity">
+        <mat-form-field class="marker-form__field">
+          <mat-label>Name</mat-label>
+          <input matInput formControlName="name" placeholder="my-filter" />
+          @if (form().get('name')?.hasError('required')) {
+            <mat-error>Name is required</mat-error>
+          } @if (form().get('name')?.hasError('notGlobalName')) {
+            <mat-error>Name cannot start with "global"</mat-error>
+          }
+        </mat-form-field>
+        <mat-form-field class="marker-form__field">
+          <mat-label>Capture node</mat-label>
+          <mat-select formControlName="capture_node_id">
+            <mat-option [value]="null">Auto</mat-option>
+            @for (ep of captureOptions(); track ep.id) {
+              <mat-option [value]="ep.id">{{ ep.name }}</mat-option>
+            }
+          </mat-select>
+        </mat-form-field>
+        <mat-form-field class="marker-form__field">
+          <mat-select formControlName="direction">
+            <mat-option value="both">Both</mat-option>
+            <mat-option value="tx">Tx →</mat-option>
+            <mat-option value="rx">← Rx</mat-option>
+          </mat-select>
+        </mat-form-field>
+      </div>
+      <div class="marker-form__row marker-form__row--style">
+        <mat-form-field class="marker-form__field">
+          <mat-label>Highlight ms</mat-label>
+          <input matInput type="number" formControlName="highlight_duration" placeholder="500" />
+          @if (form().get('highlight_duration')?.hasError('required')) {
+            <mat-error>Required</mat-error>
+          }
+          @if (form().get('highlight_duration')?.hasError('min')) {
+            <mat-error>Must be ≥ 1</mat-error>
+          }
+        </mat-form-field>
+        <mat-form-field class="marker-form__field">
+          <mat-label>Color</mat-label>
+          <input matInput type="color" formControlName="color" class="marker-form__color" />
+        </mat-form-field>
+        <mat-form-field class="marker-form__field">
+          <mat-label>Tag</mat-label>
+          <input matInput type="number" formControlName="tag" placeholder="—" />
+        </mat-form-field>
+        <div class="marker-form__actions">
+          <button mat-flat-button color="primary" type="submit" [disabled]="form().invalid">
+            {{ submitLabel() }}
+          </button>
+          <button mat-stroked-button type="button" (click)="cancel.emit()">Cancel</button>
+        </div>
+      </div>
+    </form>
+  `,
+  styleUrl: './marker-form.component.scss',
+})
+export class MarkerFormComponent {
+  /** The reactive form group — owned by the parent. */
+  readonly form = input.required<UntypedFormGroup>();
+  /** `'create'` (name + capture_node_id editable) or `'edit'` (both disabled by parent). */
+  readonly mode = input<'create' | 'edit'>('create');
+  /** Endpoint options for the Capture node dropdown (the link's nodes). */
+  readonly captureOptions = input<MarkerCaptureOption[]>([]);
+  /** Submit button label, derived from mode (`Add` / `Save`). */
+  readonly submitLabel = computed(() => (this.mode() === 'edit' ? 'Save' : 'Add'));
+  readonly save = output<void>();
+  readonly cancel = output<void>();
+}

--- a/src/app/components/project-map/marker-manager/marker-manager.component.html
+++ b/src/app/components/project-map/marker-manager/marker-manager.component.html
@@ -74,8 +74,6 @@
                   <mat-label>Direction</mat-label>
                   <mat-select formControlName="direction">
                     <mat-option value="both">Both</mat-option>
-                    <mat-option value="tx">Tx</mat-option>
-                    <mat-option value="rx">Rx</mat-option>
                   </mat-select>
                 </mat-form-field>
                 <mat-form-field class="form-field">

--- a/src/app/components/project-map/marker-manager/marker-manager.component.html
+++ b/src/app/components/project-map/marker-manager/marker-manager.component.html
@@ -142,7 +142,6 @@
                 <button
                   mat-icon-button
                   (click)="toggleDefinitionPaused(row)"
-                  [disabled]="togglingDefinition() === row.name"
                   [matTooltip]="row.paused ? 'Resume rule (all copies)' : 'Pause rule (disables all copies)'"
                 >
                   <mat-icon>{{ row.paused ? 'sensors_off' : 'sensors' }}</mat-icon>

--- a/src/app/components/project-map/marker-manager/marker-manager.component.html
+++ b/src/app/components/project-map/marker-manager/marker-manager.component.html
@@ -71,9 +71,11 @@
                     }
                 </mat-form-field>
                 <mat-form-field class="form-field">
-                  <mat-label>Direction</mat-label>
-                  <mat-select formControlName="direction">
-                    <mat-option value="both">Both</mat-option>
+                  <mat-label>Serial encapsulation</mat-label>
+                  <mat-select formControlName="data_link_type" placeholder="Ethernet only">
+                    @for (dlt of serialDataLinkTypes; track dlt.value) {
+                    <mat-option [value]="dlt.value">{{ dlt.label }}</mat-option>
+                    }
                   </mat-select>
                 </mat-form-field>
                 <mat-form-field class="form-field">
@@ -247,6 +249,8 @@
                 [form]="markerForm"
                 mode="create"
                 [captureOptions]="linkEndpoints(group.linkId)"
+                [dataLinkOptions]="serialDataLinkTypes"
+                [linkType]="linkTypeOf(group.linkId)"
                 [submitting]="submittingMarker() === group.linkId"
                 (save)="submitMarker(group.linkId)"
                 (cancel)="toggleAddMarker(group.linkId)"
@@ -296,6 +300,8 @@
                   [form]="markerForm"
                   mode="create"
                   [captureOptions]="linkEndpoints(group.linkId)"
+                  [dataLinkOptions]="serialDataLinkTypes"
+                  [linkType]="linkTypeOf(group.linkId)"
                   [submitting]="submittingMarker() === group.linkId"
                   (save)="submitMarker(group.linkId)"
                   (cancel)="toggleAddMarker(group.linkId)"
@@ -339,6 +345,8 @@
       [form]="markerEditForm"
       mode="edit"
       [captureOptions]="linkEndpoints(linkId)"
+      [dataLinkOptions]="serialDataLinkTypes"
+      [linkType]="linkTypeOf(linkId)"
       [submitting]="submittingEditMarker()"
       (save)="submitEditMarker(linkId)"
       (cancel)="cancelEditMarker()"

--- a/src/app/components/project-map/marker-manager/marker-manager.component.html
+++ b/src/app/components/project-map/marker-manager/marker-manager.component.html
@@ -171,7 +171,7 @@
         <!-- ===================== Links (aggregate) ===================== -->
         <mat-tab label="Links">
           <div class="marker-manager__panel">
-            @if (linkError()) {
+            @if (linkError() && !selectedLinkId()) {
             <div class="marker-manager__error">{{ linkError() }}</div>
             }
 

--- a/src/app/components/project-map/marker-manager/marker-manager.component.html
+++ b/src/app/components/project-map/marker-manager/marker-manager.component.html
@@ -144,7 +144,10 @@
                   (click)="toggleDefinitionPaused(row)"
                   [matTooltip]="row.paused ? 'Resume rule (all copies)' : 'Pause rule (disables all copies)'"
                 >
-                  <mat-icon>{{ row.paused ? 'sensors_off' : 'sensors' }}</mat-icon>
+                  <ng-container
+                    [ngTemplateOutlet]="onOffIcon"
+                    [ngTemplateOutletContext]="{ $implicit: togglingDefinition() === row.name, off: row.paused }"
+                  />
                 </button>
                 <button mat-icon-button (click)="startEditDefinition(row)" matTooltip="Edit">
                   <mat-icon>edit</mat-icon>
@@ -302,6 +305,17 @@
   </div>
 </div>
 
+<!-- Shared spinner-or-icon for the per-definition pause and per-marker enable toggles.
+     `$implicit` = a request is in flight (show a spinner); `off` = the toggle is in its
+     "off" state (paused / disabled) ⇒ sensors_off, else sensors. -->
+<ng-template #onOffIcon let-loading let-off="off">
+  @if (loading) {
+  <mat-spinner class="marker-manager__toggle-spinner" [diameter]="18" />
+  } @else {
+  <mat-icon>{{ off ? 'sensors_off' : 'sensors' }}</mat-icon>
+  }
+</ng-template>
+
 <!-- Shared per-marker slot: the edit form when this marker is being edited, otherwise
      the read-only row. Rendered in both the selected-link view and the aggregate view
      via [ngTemplateOutlet]="markerSlot" so the markup lives in one place. Kept inside
@@ -349,7 +363,10 @@
       (click)="toggleMarkerEnabled(linkId, m)"
       [matTooltip]="m.enabled === false ? 'Enable (signal + capture)' : 'Disable (signal + capture)'"
     >
-      <mat-icon>{{ m.enabled === false ? 'sensors_off' : 'sensors' }}</mat-icon>
+      <ng-container
+        [ngTemplateOutlet]="onOffIcon"
+        [ngTemplateOutletContext]="{ $implicit: isTogglingMarker(linkId, m.name), off: m.enabled === false }"
+      />
     </button>
     <button mat-icon-button (click)="startEditMarker(linkId, m)" matTooltip="Edit">
       <mat-icon>edit</mat-icon>

--- a/src/app/components/project-map/marker-manager/marker-manager.component.html
+++ b/src/app/components/project-map/marker-manager/marker-manager.component.html
@@ -59,7 +59,7 @@
                   }
                 </mat-form-field>
               </div>
-              <div style="display: grid; grid-template-columns: 3fr 0.8fr 0.8fr 0.6fr 0.6fr auto auto; gap: 16px; align-items: start;">
+              <div style="display: grid; grid-template-columns: 3.2fr 0.8fr 0.6fr 0.6fr auto auto; gap: 16px; align-items: start;">
                 <mat-form-field class="form-field">
                   <mat-label>Name</mat-label>
                   <span matTextPrefix class="global-prefix">global-&nbsp;</span>
@@ -69,10 +69,6 @@
                     } @if (definitionForm.get('name')?.hasError('notGlobalName')) {
                     <mat-error>Name cannot start with "global"</mat-error>
                     }
-                </mat-form-field>
-                <mat-form-field class="form-field">
-                  <mat-label>Tag</mat-label>
-                  <input matInput type="number" formControlName="tag" />
                 </mat-form-field>
                 <mat-form-field class="form-field">
                   <mat-label>Highlight ms</mat-label>
@@ -128,9 +124,7 @@
                 ></span>
                 <span class="marker-manager__row-name">global-{{ row.name }}</span>
                 <span class="marker-manager__row-bpf">{{ row.bpf }}</span>
-                @if (row.tag !== null) {
-                <span class="marker-manager__chip">tag {{ row.tag }}</span>
-                }
+
                 @if (row.highlight_duration !== null) {
                 <span class="marker-manager__chip">{{ row.highlight_duration }}ms</span>
                 }
@@ -232,7 +226,7 @@
                     }
                   </mat-form-field>
                 </div>
-                <div style="display: grid; grid-template-columns: 3fr 0.8fr 0.8fr 0.6fr 0.6fr auto auto; gap: 16px; align-items: start;">
+                <div style="display: grid; grid-template-columns: 3.2fr 0.8fr 0.6fr 0.6fr auto auto; gap: 16px; align-items: start;">
                   <mat-form-field class="form-field">
                     <mat-label>Name</mat-label>
                     <input matInput formControlName="name" placeholder="my-filter" />
@@ -241,10 +235,6 @@
                     } @if (markerForm.get('name')?.hasError('notGlobalName')) {
                     <mat-error>Name cannot start with "global"</mat-error>
                     }
-                  </mat-form-field>
-                  <mat-form-field class="form-field">
-                    <mat-label>Tag</mat-label>
-                    <input matInput type="number" formControlName="tag" />
                   </mat-form-field>
                   <mat-form-field class="form-field">
                     <mat-label>Highlight ms</mat-label>
@@ -286,7 +276,7 @@
                     }
                   </mat-form-field>
                 </div>
-                <div style="display: grid; grid-template-columns: 3fr 0.8fr 0.8fr 0.6fr 0.6fr auto auto; gap: 16px; align-items: start;">
+                <div style="display: grid; grid-template-columns: 3.2fr 0.8fr 0.6fr 0.6fr auto auto; gap: 16px; align-items: start;">
                   <mat-form-field class="form-field">
                     <mat-label>Name</mat-label>
                     <input matInput formControlName="name" />
@@ -295,10 +285,6 @@
                     } @if (markerEditForm.get('name')?.hasError('notGlobalName')) {
                     <mat-error>Name cannot start with "global"</mat-error>
                     }
-                  </mat-form-field>
-                  <mat-form-field class="form-field">
-                    <mat-label>Tag</mat-label>
-                    <input matInput type="number" formControlName="tag" />
                   </mat-form-field>
                   <mat-form-field class="form-field">
                     <mat-label>Highlight ms</mat-label>
@@ -336,9 +322,7 @@
                 ></span>
                 <span class="marker-manager__row-name">{{ m.name }}</span>
                 <span class="marker-manager__row-bpf">{{ m.bpf }}</span>
-                @if (m.tag !== null && m.tag !== undefined) {
-                <span class="marker-manager__chip">tag {{ m.tag }}</span>
-                }
+
                 @if (m.direction) {
                 <span class="marker-manager__chip marker-manager__chip--dir" title="Direction filter">{{ m.direction }}</span>
                 }
@@ -406,7 +390,7 @@
                       }
                     </mat-form-field>
                   </div>
-                  <div style="display: grid; grid-template-columns: 3fr 0.8fr 0.8fr 0.6fr 0.6fr auto auto; gap: 16px; align-items: start;">
+                  <div style="display: grid; grid-template-columns: 3.2fr 0.8fr 0.6fr 0.6fr auto auto; gap: 16px; align-items: start;">
                     <mat-form-field class="form-field">
                       <mat-label>Name</mat-label>
                       <input matInput formControlName="name" placeholder="my-filter" />
@@ -415,10 +399,6 @@
                       } @if (markerForm.get('name')?.hasError('notGlobalName')) {
                       <mat-error>Name cannot start with "global"</mat-error>
                       }
-                    </mat-form-field>
-                    <mat-form-field class="form-field">
-                      <mat-label>Tag</mat-label>
-                      <input matInput type="number" formControlName="tag" />
                     </mat-form-field>
                     <mat-form-field class="form-field">
                       <mat-label>Highlight ms</mat-label>
@@ -461,7 +441,7 @@
                       }
                     </mat-form-field>
                   </div>
-                  <div style="display: grid; grid-template-columns: 3fr 0.8fr 0.8fr 0.6fr 0.6fr auto auto; gap: 16px; align-items: start;">
+                  <div style="display: grid; grid-template-columns: 3.2fr 0.8fr 0.6fr 0.6fr auto auto; gap: 16px; align-items: start;">
                     <mat-form-field class="form-field">
                       <mat-label>Name</mat-label>
                       <input matInput formControlName="name" />
@@ -470,10 +450,6 @@
                       } @if (markerEditForm.get('name')?.hasError('notGlobalName')) {
                       <mat-error>Name cannot start with "global"</mat-error>
                       }
-                    </mat-form-field>
-                    <mat-form-field class="form-field">
-                      <mat-label>Tag</mat-label>
-                      <input matInput type="number" formControlName="tag" />
                     </mat-form-field>
                     <mat-form-field class="form-field">
                       <mat-label>Highlight ms</mat-label>
@@ -503,9 +479,7 @@
                   ></span>
                   <span class="marker-manager__row-name">{{ m.name }}</span>
                   <span class="marker-manager__row-bpf">{{ m.bpf }}</span>
-                  @if (m.tag !== null && m.tag !== undefined) {
-                  <span class="marker-manager__chip">tag {{ m.tag }}</span>
-                  }
+
                   @if (m.direction) {
                   <span class="marker-manager__chip marker-manager__chip--dir" title="Direction filter">{{ m.direction }}</span>
                   }

--- a/src/app/components/project-map/marker-manager/marker-manager.component.html
+++ b/src/app/components/project-map/marker-manager/marker-manager.component.html
@@ -115,7 +115,11 @@
               <div class="marker-manager__empty">No definitions. Create one above — it applies to all capable links.</div>
               }
               @for (row of definitions(); track row.name) {
-              <div class="marker-manager__row" [class.marker-manager__row--editing]="editingDefinition() === row.name">
+              <div
+                class="marker-manager__row"
+                [class.marker-manager__row--editing]="editingDefinition() === row.name"
+                [class.marker-manager__row--paused]="row.paused"
+              >
                 <span
                   class="marker-manager__swatch"
                   [style.background]="row.color"
@@ -135,6 +139,14 @@
                   → {{ row.linkCount }} link{{ row.linkCount === 1 ? '' : 's' }}
                 </span>
                 <span class="marker-manager__row-spacer"></span>
+                <button
+                  mat-icon-button
+                  (click)="toggleDefinitionPaused(row)"
+                  [disabled]="togglingDefinition() === row.name"
+                  [matTooltip]="row.paused ? 'Resume rule (all copies)' : 'Pause rule (disables all copies)'"
+                >
+                  <mat-icon>{{ row.paused ? 'sensors_off' : 'sensors' }}</mat-icon>
+                </button>
                 <button mat-icon-button (click)="startEditDefinition(row)" matTooltip="Edit">
                   <mat-icon>edit</mat-icon>
                 </button>
@@ -307,7 +319,7 @@
     />
     }
   } @else {
-  <div class="marker-manager__row">
+  <div class="marker-manager__row" [class.marker-manager__row--disabled]="m.enabled === false">
     <span
       class="marker-manager__swatch"
       [style.background]="m.color"
@@ -333,6 +345,13 @@
       <mat-icon>lock</mat-icon>
     </button>
     } @else {
+    <button
+      mat-icon-button
+      (click)="toggleMarkerEnabled(linkId, m)"
+      [matTooltip]="m.enabled === false ? 'Enable (signal + capture)' : 'Disable (signal + capture)'"
+    >
+      <mat-icon>{{ m.enabled === false ? 'sensors_off' : 'sensors' }}</mat-icon>
+    </button>
     <button mat-icon-button (click)="startEditMarker(linkId, m)" matTooltip="Edit">
       <mat-icon>edit</mat-icon>
     </button>

--- a/src/app/components/project-map/marker-manager/marker-manager.component.html
+++ b/src/app/components/project-map/marker-manager/marker-manager.component.html
@@ -92,8 +92,13 @@
                   <mat-label>Color</mat-label>
                   <input matInput type="color" formControlName="color" class="color-input" />
                 </mat-form-field>
-                <button mat-flat-button color="primary" type="submit" [disabled]="definitionForm.invalid" style="align-self: start; margin-top: 18px;">
-                  {{ editingDefinition() ? 'Save' : 'Create' }}
+                <button mat-flat-button color="primary" type="submit" [disabled]="definitionForm.invalid || submittingDefinition()" style="align-self: start; margin-top: 18px;">
+                  @if (submittingDefinition()) {
+                    <mat-spinner class="marker-manager__btn-spinner" [diameter]="18" />
+                    {{ editingDefinition() ? 'Saving…' : 'Creating…' }}
+                  } @else {
+                    {{ editingDefinition() ? 'Save' : 'Create' }}
+                  }
                 </button>
                 @if (editingDefinition()) {
                 <button mat-stroked-button type="button" (click)="cancelEditDefinition()" style="align-self: start; margin-top: 18px;">Cancel</button>
@@ -153,7 +158,11 @@
                   <mat-icon>edit</mat-icon>
                 </button>
                 <button mat-icon-button (click)="deleteDefinition(row)" matTooltip="Delete (clears all copies)">
-                  <mat-icon>delete</mat-icon>
+                  @if (deletingDefinition() === row.name) {
+                    <mat-spinner class="marker-manager__toggle-spinner" [diameter]="18" />
+                  } @else {
+                    <mat-icon>delete</mat-icon>
+                  }
                 </button>
               </div>
               }
@@ -240,6 +249,7 @@
                 [form]="markerForm"
                 mode="create"
                 [captureOptions]="linkEndpoints(group.linkId)"
+                [submitting]="submittingMarker() === group.linkId"
                 (save)="submitMarker(group.linkId)"
                 (cancel)="toggleAddMarker(group.linkId)"
               />
@@ -285,6 +295,7 @@
                   [form]="markerForm"
                   mode="create"
                   [captureOptions]="linkEndpoints(group.linkId)"
+                  [submitting]="submittingMarker() === group.linkId"
                   (save)="submitMarker(group.linkId)"
                   (cancel)="toggleAddMarker(group.linkId)"
                 />
@@ -327,6 +338,7 @@
       [form]="markerEditForm"
       mode="edit"
       [captureOptions]="linkEndpoints(linkId)"
+      [submitting]="submittingEditMarker()"
       (save)="submitEditMarker(linkId)"
       (cancel)="cancelEditMarker()"
     />
@@ -372,7 +384,11 @@
       <mat-icon>edit</mat-icon>
     </button>
     <button mat-icon-button (click)="deleteMarker(linkId, m.name)" matTooltip="Delete">
-      <mat-icon>delete</mat-icon>
+      @if (isDeletingMarker(linkId, m.name)) {
+        <mat-spinner class="marker-manager__toggle-spinner" [diameter]="18" />
+      } @else {
+        <mat-icon>delete</mat-icon>
+      }
     </button>
     }
   </div>

--- a/src/app/components/project-map/marker-manager/marker-manager.component.html
+++ b/src/app/components/project-map/marker-manager/marker-manager.component.html
@@ -59,7 +59,7 @@
                   }
                 </mat-form-field>
               </div>
-              <div style="display: grid; grid-template-columns: 3.2fr 0.8fr 0.6fr 0.6fr auto auto; gap: 16px; align-items: start;">
+              <div style="display: grid; grid-template-columns: 3.0fr 0.9fr 0.8fr 0.5fr auto auto; gap: 16px; align-items: start;">
                 <mat-form-field class="form-field">
                   <mat-label>Name</mat-label>
                   <span matTextPrefix class="global-prefix">global-&nbsp;</span>
@@ -69,6 +69,13 @@
                     } @if (definitionForm.get('name')?.hasError('notGlobalName')) {
                     <mat-error>Name cannot start with "global"</mat-error>
                     }
+                </mat-form-field>
+                <mat-form-field class="form-field">
+                  <mat-select formControlName="direction">
+                    <mat-option [ngValue]="null">Both</mat-option>
+                    <mat-option value="tx">Tx →</mat-option>
+                    <mat-option value="rx">← Rx</mat-option>
+                  </mat-select>
                 </mat-form-field>
                 <mat-form-field class="form-field">
                   <mat-label>Highlight ms</mat-label>
@@ -83,14 +90,6 @@
                 <mat-form-field class="form-field">
                   <mat-label>Color</mat-label>
                   <input matInput type="color" formControlName="color" class="color-input" />
-                </mat-form-field>
-                <mat-form-field class="form-field">
-                  <mat-label>Direction</mat-label>
-                  <mat-select formControlName="direction">
-                    <mat-option [value]="null">Both</mat-option>
-                    <mat-option value="tx">Tx only</mat-option>
-                    <mat-option value="rx">Rx only</mat-option>
-                  </mat-select>
                 </mat-form-field>
                 <button mat-flat-button color="primary" type="submit" [disabled]="definitionForm.invalid" style="align-self: start; margin-top: 18px;">
                   {{ editingDefinition() ? 'Save' : 'Create' }}
@@ -226,7 +225,7 @@
                     }
                   </mat-form-field>
                 </div>
-                <div style="display: grid; grid-template-columns: 3.2fr 0.8fr 0.6fr 0.6fr auto auto; gap: 16px; align-items: start;">
+                <div style="display: grid; grid-template-columns: 3.0fr 0.9fr 0.8fr 0.5fr auto auto; gap: 16px; align-items: start;">
                   <mat-form-field class="form-field">
                     <mat-label>Name</mat-label>
                     <input matInput formControlName="name" placeholder="my-filter" />
@@ -235,6 +234,13 @@
                     } @if (markerForm.get('name')?.hasError('notGlobalName')) {
                     <mat-error>Name cannot start with "global"</mat-error>
                     }
+                  </mat-form-field>
+                  <mat-form-field class="form-field">
+                      <mat-select formControlName="direction">
+                      <mat-option [ngValue]="null">Both</mat-option>
+                      <mat-option value="tx">Tx →</mat-option>
+                      <mat-option value="rx">← Rx</mat-option>
+                    </mat-select>
                   </mat-form-field>
                   <mat-form-field class="form-field">
                     <mat-label>Highlight ms</mat-label>
@@ -249,14 +255,6 @@
                   <mat-form-field class="form-field">
                     <mat-label>Color</mat-label>
                     <input matInput type="color" formControlName="color" class="color-input" />
-                  </mat-form-field>
-                  <mat-form-field class="form-field">
-                    <mat-label>Direction</mat-label>
-                    <mat-select formControlName="direction">
-                      <mat-option [value]="null">Both</mat-option>
-                      <mat-option value="tx">Tx only</mat-option>
-                      <mat-option value="rx">Rx only</mat-option>
-                    </mat-select>
                   </mat-form-field>
                   <button mat-flat-button color="primary" type="submit" [disabled]="markerForm.invalid" style="align-self: start; margin-top: 18px;">Add</button>
                   <button mat-stroked-button type="button" (click)="markerForm.reset(); linkError.set(null); selectedLinkId.set(null)" style="align-self: start; margin-top: 18px;">Back</button>
@@ -276,7 +274,7 @@
                     }
                   </mat-form-field>
                 </div>
-                <div style="display: grid; grid-template-columns: 3.2fr 0.8fr 0.6fr 0.6fr auto auto; gap: 16px; align-items: start;">
+                <div style="display: grid; grid-template-columns: 3.0fr 0.9fr 0.8fr 0.5fr auto auto; gap: 16px; align-items: start;">
                   <mat-form-field class="form-field">
                     <mat-label>Name</mat-label>
                     <input matInput formControlName="name" />
@@ -285,6 +283,13 @@
                     } @if (markerEditForm.get('name')?.hasError('notGlobalName')) {
                     <mat-error>Name cannot start with "global"</mat-error>
                     }
+                  </mat-form-field>
+                  <mat-form-field class="form-field">
+                      <mat-select formControlName="direction">
+                      <mat-option [ngValue]="null">Both</mat-option>
+                      <mat-option value="tx">Tx →</mat-option>
+                      <mat-option value="rx">← Rx</mat-option>
+                    </mat-select>
                   </mat-form-field>
                   <mat-form-field class="form-field">
                     <mat-label>Highlight ms</mat-label>
@@ -299,14 +304,6 @@
                   <mat-form-field class="form-field">
                     <mat-label>Color</mat-label>
                     <input matInput type="color" formControlName="color" class="color-input" />
-                  </mat-form-field>
-                  <mat-form-field class="form-field">
-                    <mat-label>Direction</mat-label>
-                    <mat-select formControlName="direction">
-                      <mat-option [value]="null">Both</mat-option>
-                      <mat-option value="tx">Tx only</mat-option>
-                      <mat-option value="rx">Rx only</mat-option>
-                    </mat-select>
                   </mat-form-field>
                   <button mat-flat-button color="primary" type="submit" [disabled]="markerEditForm.invalid" style="align-self: start; margin-top: 18px;">Save</button>
                   <button mat-stroked-button type="button" (click)="cancelEditMarker()" style="align-self: start; margin-top: 18px;">Cancel</button>
@@ -390,7 +387,7 @@
                       }
                     </mat-form-field>
                   </div>
-                  <div style="display: grid; grid-template-columns: 3.2fr 0.8fr 0.6fr 0.6fr auto auto; gap: 16px; align-items: start;">
+                  <div style="display: grid; grid-template-columns: 3.0fr 0.9fr 0.8fr 0.5fr auto auto; gap: 16px; align-items: start;">
                     <mat-form-field class="form-field">
                       <mat-label>Name</mat-label>
                       <input matInput formControlName="name" placeholder="my-filter" />
@@ -399,6 +396,13 @@
                       } @if (markerForm.get('name')?.hasError('notGlobalName')) {
                       <mat-error>Name cannot start with "global"</mat-error>
                       }
+                    </mat-form-field>
+                    <mat-form-field class="form-field">
+                          <mat-select formControlName="direction">
+                        <mat-option [ngValue]="null">Both</mat-option>
+                        <mat-option value="tx">Tx →</mat-option>
+                        <mat-option value="rx">← Rx</mat-option>
+                      </mat-select>
                     </mat-form-field>
                     <mat-form-field class="form-field">
                       <mat-label>Highlight ms</mat-label>
@@ -413,14 +417,6 @@
                     <mat-form-field class="form-field">
                       <mat-label>Color</mat-label>
                       <input matInput type="color" formControlName="color" class="color-input" />
-                    </mat-form-field>
-                    <mat-form-field class="form-field">
-                      <mat-label>Direction</mat-label>
-                      <mat-select formControlName="direction">
-                        <mat-option [value]="null">Both</mat-option>
-                        <mat-option value="tx">Tx only</mat-option>
-                        <mat-option value="rx">Rx only</mat-option>
-                      </mat-select>
                     </mat-form-field>
                     <button mat-flat-button color="primary" type="submit" [disabled]="markerForm.invalid" style="align-self: start; margin-top: 18px;">Add</button>
                     <button mat-stroked-button type="button" (click)="toggleAddMarker(group.linkId)" style="align-self: start; margin-top: 18px;">Cancel</button>
@@ -441,7 +437,7 @@
                       }
                     </mat-form-field>
                   </div>
-                  <div style="display: grid; grid-template-columns: 3.2fr 0.8fr 0.6fr 0.6fr auto auto; gap: 16px; align-items: start;">
+                  <div style="display: grid; grid-template-columns: 3.0fr 0.9fr 0.8fr 0.5fr auto auto; gap: 16px; align-items: start;">
                     <mat-form-field class="form-field">
                       <mat-label>Name</mat-label>
                       <input matInput formControlName="name" />

--- a/src/app/components/project-map/marker-manager/marker-manager.component.html
+++ b/src/app/components/project-map/marker-manager/marker-manager.component.html
@@ -72,7 +72,7 @@
                 </mat-form-field>
                 <mat-form-field class="form-field">
                   <mat-select formControlName="direction">
-                    <mat-option [ngValue]="null">Both</mat-option>
+                    <mat-option [value]="null">Both</mat-option>
                     <mat-option value="tx">Tx →</mat-option>
                     <mat-option value="rx">← Rx</mat-option>
                   </mat-select>
@@ -237,7 +237,7 @@
                   </mat-form-field>
                   <mat-form-field class="form-field">
                       <mat-select formControlName="direction">
-                      <mat-option [ngValue]="null">Both</mat-option>
+                      <mat-option [value]="null">Both</mat-option>
                       <mat-option value="tx">Tx →</mat-option>
                       <mat-option value="rx">← Rx</mat-option>
                     </mat-select>
@@ -286,7 +286,7 @@
                   </mat-form-field>
                   <mat-form-field class="form-field">
                       <mat-select formControlName="direction">
-                      <mat-option [ngValue]="null">Both</mat-option>
+                      <mat-option [value]="null">Both</mat-option>
                       <mat-option value="tx">Tx →</mat-option>
                       <mat-option value="rx">← Rx</mat-option>
                     </mat-select>
@@ -399,7 +399,7 @@
                     </mat-form-field>
                     <mat-form-field class="form-field">
                           <mat-select formControlName="direction">
-                        <mat-option [ngValue]="null">Both</mat-option>
+                        <mat-option [value]="null">Both</mat-option>
                         <mat-option value="tx">Tx →</mat-option>
                         <mat-option value="rx">← Rx</mat-option>
                       </mat-select>

--- a/src/app/components/project-map/marker-manager/marker-manager.component.html
+++ b/src/app/components/project-map/marker-manager/marker-manager.component.html
@@ -71,10 +71,11 @@
                     }
                 </mat-form-field>
                 <mat-form-field class="form-field">
+                  <mat-label>Direction</mat-label>
                   <mat-select formControlName="direction">
                     <mat-option value="both">Both</mat-option>
-                    <mat-option value="tx">Tx →</mat-option>
-                    <mat-option value="rx">← Rx</mat-option>
+                    <mat-option value="tx">Tx</mat-option>
+                    <mat-option value="rx">Rx</mat-option>
                   </mat-select>
                 </mat-form-field>
                 <mat-form-field class="form-field">
@@ -231,52 +232,7 @@
               }
 
               @for (m of group.markers; track m.name) {
-                @if (editingMarker(); as edit) {
-                  @if (edit.linkId === group.linkId && edit.name === m.name) {
-                  <app-marker-form
-                    [form]="markerEditForm"
-                    mode="edit"
-                    [captureOptions]="linkEndpoints(group.linkId)"
-                    (save)="submitEditMarker(group.linkId)"
-                    (cancel)="cancelEditMarker()"
-                  />
-                  }
-                } @else {
-                <div class="marker-manager__row">
-                  <span
-                    class="marker-manager__swatch"
-                    [style.background]="m.color"
-                    [class.marker-manager__swatch--default]="!m.color"
-                  ></span>
-                  <span class="marker-manager__row-name">{{ m.name }}</span>
-                  <span class="marker-manager__row-bpf">{{ m.bpf }}</span>
-
-                  @if (m.capture_node_id) {
-                  <span class="marker-manager__chip" title="Capture node (observer)">{{ nodeName(m.capture_node_id) }}</span>
-                  }
-                  @if (m.direction) {
-                  <span class="marker-manager__chip marker-manager__chip--dir" title="Direction filter">{{ m.direction }}</span>
-                  }
-                  @if (m.inherited_from) {
-                  <span class="marker-manager__chip marker-manager__chip--inherited" matTooltip="Inherited — edit via Definitions">
-                    inherited
-                  </span>
-                  }
-                  <span class="marker-manager__row-spacer"></span>
-                  @if (m.inherited_from) {
-                  <button mat-icon-button disabled matTooltip="Inherited — edit via Definitions">
-                    <mat-icon>lock</mat-icon>
-                  </button>
-                  } @else {
-                  <button mat-icon-button (click)="startEditMarker(group.linkId, m)" matTooltip="Edit">
-                    <mat-icon>edit</mat-icon>
-                  </button>
-                  <button mat-icon-button (click)="deleteMarker(group.linkId, m.name)" matTooltip="Delete">
-                    <mat-icon>delete</mat-icon>
-                  </button>
-                  }
-                </div>
-                }
+                <ng-container [ngTemplateOutlet]="markerSlot" [ngTemplateOutletContext]="{ $implicit: m, linkId: group.linkId }" />
               }
             </div>
             }
@@ -321,52 +277,7 @@
                 }
 
                 @for (m of group.markers; track m.name) {
-                  @if (editingMarker(); as edit) {
-                    @if (edit.linkId === group.linkId && edit.name === m.name) {
-                    <app-marker-form
-                      [form]="markerEditForm"
-                      mode="edit"
-                      [captureOptions]="linkEndpoints(group.linkId)"
-                      (save)="submitEditMarker(group.linkId)"
-                      (cancel)="cancelEditMarker()"
-                    />
-                    }
-                  } @else {
-                  <div class="marker-manager__row">
-                    <span
-                      class="marker-manager__swatch"
-                      [style.background]="m.color"
-                      [class.marker-manager__swatch--default]="!m.color"
-                    ></span>
-                    <span class="marker-manager__row-name">{{ m.name }}</span>
-                    <span class="marker-manager__row-bpf">{{ m.bpf }}</span>
-
-                    @if (m.capture_node_id) {
-                    <span class="marker-manager__chip" title="Capture node (observer)">{{ nodeName(m.capture_node_id) }}</span>
-                    }
-                    @if (m.direction) {
-                    <span class="marker-manager__chip marker-manager__chip--dir" title="Direction filter">{{ m.direction }}</span>
-                    }
-                    @if (m.inherited_from) {
-                    <span class="marker-manager__chip marker-manager__chip--inherited" matTooltip="Inherited — edit via Definitions">
-                      inherited
-                    </span>
-                    }
-                    <span class="marker-manager__row-spacer"></span>
-                    @if (m.inherited_from) {
-                    <button mat-icon-button disabled matTooltip="Inherited — edit via Definitions">
-                      <mat-icon>lock</mat-icon>
-                    </button>
-                    } @else {
-                    <button mat-icon-button (click)="startEditMarker(group.linkId, m)" matTooltip="Edit">
-                      <mat-icon>edit</mat-icon>
-                    </button>
-                    <button mat-icon-button (click)="deleteMarker(group.linkId, m.name)" matTooltip="Delete">
-                      <mat-icon>delete</mat-icon>
-                    </button>
-                    }
-                  </div>
-                  }
+                  <ng-container [ngTemplateOutlet]="markerSlot" [ngTemplateOutletContext]="{ $implicit: m, linkId: group.linkId }" />
                 }
                 }
               </div>
@@ -379,3 +290,56 @@
     </div>
   </div>
 </div>
+
+<!-- Shared per-marker slot: the edit form when this marker is being edited, otherwise
+     the read-only row. Rendered in both the selected-link view and the aggregate view
+     via [ngTemplateOutlet]="markerSlot" so the markup lives in one place. Kept inside
+     this component's template so the marker-manager__* (BEM) styles still apply. -->
+<ng-template #markerSlot let-m let-linkId="linkId">
+  @if (editingMarker(); as edit) {
+    @if (edit.linkId === linkId && edit.name === m.name) {
+    <app-marker-form
+      [form]="markerEditForm"
+      mode="edit"
+      [captureOptions]="linkEndpoints(linkId)"
+      (save)="submitEditMarker(linkId)"
+      (cancel)="cancelEditMarker()"
+    />
+    }
+  } @else {
+  <div class="marker-manager__row">
+    <span
+      class="marker-manager__swatch"
+      [style.background]="m.color"
+      [class.marker-manager__swatch--default]="!m.color"
+    ></span>
+    <span class="marker-manager__row-name">{{ m.name }}</span>
+    <span class="marker-manager__row-bpf">{{ m.bpf }}</span>
+
+    @if (m.capture_node_id) {
+    <span class="marker-manager__chip" title="Capture node (observer)">{{ nodeName(m.capture_node_id) }}</span>
+    }
+    @if (m.direction) {
+    <span class="marker-manager__chip marker-manager__chip--dir" title="Direction filter">{{ m.direction }}</span>
+    }
+    @if (m.inherited_from) {
+    <span class="marker-manager__chip marker-manager__chip--inherited" matTooltip="Inherited — edit via Definitions">
+      inherited
+    </span>
+    }
+    <span class="marker-manager__row-spacer"></span>
+    @if (m.inherited_from) {
+    <button mat-icon-button disabled matTooltip="Inherited — edit via Definitions">
+      <mat-icon>lock</mat-icon>
+    </button>
+    } @else {
+    <button mat-icon-button (click)="startEditMarker(linkId, m)" matTooltip="Edit">
+      <mat-icon>edit</mat-icon>
+    </button>
+    <button mat-icon-button (click)="deleteMarker(linkId, m.name)" matTooltip="Delete">
+      <mat-icon>delete</mat-icon>
+    </button>
+    }
+  </div>
+  }
+</ng-template>

--- a/src/app/components/project-map/marker-manager/marker-manager.component.html
+++ b/src/app/components/project-map/marker-manager/marker-manager.component.html
@@ -72,7 +72,7 @@
                 </mat-form-field>
                 <mat-form-field class="form-field">
                   <mat-select formControlName="direction">
-                    <mat-option [value]="null">Both</mat-option>
+                    <mat-option value="both">Both</mat-option>
                     <mat-option value="tx">Tx →</mat-option>
                     <mat-option value="rx">← Rx</mat-option>
                   </mat-select>
@@ -164,7 +164,7 @@
                   [matAutocomplete]="nodeAuto"
                   placeholder="Filter by node…"
                 />
-                <mat-autocomplete #nodeAuto="matAutocomplete" (optionSelected)="onNodeSelect($event.option.value)">
+                <mat-autocomplete #nodeAuto="matAutocomplete" [displayWith]="displayNode" (optionSelected)="onNodeSelect($event.option.value)">
                   <mat-option [value]="null">All nodes</mat-option>
                   @for (opt of filteredNodeOptions(); track opt.id) {
                   <mat-option [value]="opt.id">{{ opt.name }}</mat-option>
@@ -180,7 +180,7 @@
                   [matAutocomplete]="linkAuto"
                   [placeholder]="selectedNodeId() ? 'Select a link…' : 'Pick a node first…'"
                 />
-                <mat-autocomplete #linkAuto="matAutocomplete" (optionSelected)="onLinkSelect($event.option.value)">
+                <mat-autocomplete #linkAuto="matAutocomplete" [displayWith]="displayLink" (optionSelected)="onLinkSelect($event.option.value)">
                   <mat-option [value]="null">All links</mat-option>
                   @for (opt of filteredLinkOptions(); track opt.id) {
                   <mat-option [value]="opt.id">{{ opt.name }}</mat-option>
@@ -211,262 +211,26 @@
               </div>
               }
 
-                            <form
-                class="marker-manager__form--inline"
-                [formGroup]="markerForm"
-                (ngSubmit)="submitMarker(group.linkId)"
-              >
-                <div style="display: grid; grid-template-columns: 1fr; gap: 16px; align-items: start;">
-                  <mat-form-field class="form-field">
-                    <mat-label>BPF expression</mat-label>
-                    <textarea matInput formControlName="bpf" placeholder="tcp port 80" rows="1" cdkTextareaAutosize cdkAutosizeMinRows="1" cdkAutosizeMaxRows="4"></textarea>
-                    @if (markerForm.get('bpf')?.hasError('required')) {
-                    <mat-error>BPF is required</mat-error>
-                    }
-                  </mat-form-field>
-                </div>
-                <div style="display: grid; grid-template-columns: 3.0fr 0.9fr 0.8fr 0.5fr auto auto; gap: 16px; align-items: start;">
-                  <mat-form-field class="form-field">
-                    <mat-label>Name</mat-label>
-                    <input matInput formControlName="name" placeholder="my-filter" />
-                    @if (markerForm.get('name')?.hasError('required')) {
-                    <mat-error>Name is required</mat-error>
-                    } @if (markerForm.get('name')?.hasError('notGlobalName')) {
-                    <mat-error>Name cannot start with "global"</mat-error>
-                    }
-                  </mat-form-field>
-                  <mat-form-field class="form-field">
-                      <mat-select formControlName="direction">
-                      <mat-option [value]="null">Both</mat-option>
-                      <mat-option value="tx">Tx →</mat-option>
-                      <mat-option value="rx">← Rx</mat-option>
-                    </mat-select>
-                  </mat-form-field>
-                  <mat-form-field class="form-field">
-                    <mat-label>Highlight ms</mat-label>
-                    <input matInput type="number" formControlName="highlight_duration" placeholder="500" />
-                    @if (markerForm.get('highlight_duration')?.hasError('required')) {
-                    <mat-error>Required</mat-error>
-                    }
-                    @if (markerForm.get('highlight_duration')?.hasError('min')) {
-                    <mat-error>Must be ≥ 1</mat-error>
-                    }
-                  </mat-form-field>
-                  <mat-form-field class="form-field">
-                    <mat-label>Color</mat-label>
-                    <input matInput type="color" formControlName="color" class="color-input" />
-                  </mat-form-field>
-                  <button mat-flat-button color="primary" type="submit" [disabled]="markerForm.invalid" style="align-self: start; margin-top: 18px;">Add</button>
-                  <button mat-stroked-button type="button" (click)="markerForm.reset(); linkError.set(null); selectedLinkId.set(null)" style="align-self: start; margin-top: 18px;">Back</button>
-                </div>
-              </form>
+              <app-marker-form
+                [form]="markerForm"
+                mode="create"
+                [captureOptions]="linkEndpoints(group.linkId)"
+                (save)="submitMarker(group.linkId)"
+                (cancel)="markerForm.reset(); linkError.set(null); selectedLinkId.set(null)"
+              />
 
               @for (m of group.markers; track m.name) {
                 @if (editingMarker(); as edit) {
                   @if (edit.linkId === group.linkId && edit.name === m.name) {
-              <form class="marker-manager__form--inline" [formGroup]="markerEditForm" (ngSubmit)="submitEditMarker(group.linkId)">
-                <div style="display: grid; grid-template-columns: 1fr; gap: 16px; align-items: start;">
-                  <mat-form-field class="form-field">
-                    <mat-label>BPF expression</mat-label>
-                    <textarea matInput formControlName="bpf" placeholder="tcp port 80" rows="1" cdkTextareaAutosize cdkAutosizeMinRows="1" cdkAutosizeMaxRows="4"></textarea>
-                    @if (markerEditForm.get('bpf')?.hasError('required')) {
-                    <mat-error>BPF is required</mat-error>
-                    }
-                  </mat-form-field>
-                </div>
-                <div style="display: grid; grid-template-columns: 3.0fr 0.9fr 0.8fr 0.5fr auto auto; gap: 16px; align-items: start;">
-                  <mat-form-field class="form-field">
-                    <mat-label>Name</mat-label>
-                    <input matInput formControlName="name" />
-                    @if (markerEditForm.get('name')?.hasError('required')) {
-                    <mat-error>Name is required</mat-error>
-                    } @if (markerEditForm.get('name')?.hasError('notGlobalName')) {
-                    <mat-error>Name cannot start with "global"</mat-error>
-                    }
-                  </mat-form-field>
-                  <mat-form-field class="form-field">
-                      <mat-select formControlName="direction">
-                      <mat-option [value]="null">Both</mat-option>
-                      <mat-option value="tx">Tx →</mat-option>
-                      <mat-option value="rx">← Rx</mat-option>
-                    </mat-select>
-                  </mat-form-field>
-                  <mat-form-field class="form-field">
-                    <mat-label>Highlight ms</mat-label>
-                    <input matInput type="number" formControlName="highlight_duration" placeholder="500" />
-                    @if (markerEditForm.get('highlight_duration')?.hasError('required')) {
-                    <mat-error>Required</mat-error>
-                    }
-                    @if (markerEditForm.get('highlight_duration')?.hasError('min')) {
-                    <mat-error>Must be ≥ 1</mat-error>
-                    }
-                  </mat-form-field>
-                  <mat-form-field class="form-field">
-                    <mat-label>Color</mat-label>
-                    <input matInput type="color" formControlName="color" class="color-input" />
-                  </mat-form-field>
-                  <button mat-flat-button color="primary" type="submit" [disabled]="markerEditForm.invalid" style="align-self: start; margin-top: 18px;">Save</button>
-                  <button mat-stroked-button type="button" (click)="cancelEditMarker()" style="align-self: start; margin-top: 18px;">Cancel</button>
-                </div>
-              </form>
+                  <app-marker-form
+                    [form]="markerEditForm"
+                    mode="edit"
+                    [captureOptions]="linkEndpoints(group.linkId)"
+                    (save)="submitEditMarker(group.linkId)"
+                    (cancel)="cancelEditMarker()"
+                  />
                   }
                 } @else {
-              <div class="marker-manager__row">
-                <span
-                  class="marker-manager__swatch"
-                  [style.background]="m.color"
-                  [class.marker-manager__swatch--default]="!m.color"
-                ></span>
-                <span class="marker-manager__row-name">{{ m.name }}</span>
-                <span class="marker-manager__row-bpf">{{ m.bpf }}</span>
-
-                @if (m.direction) {
-                <span class="marker-manager__chip marker-manager__chip--dir" title="Direction filter">{{ m.direction }}</span>
-                }
-                @if (m.inherited_from) {
-                <span class="marker-manager__chip marker-manager__chip--inherited" matTooltip="Inherited — edit via Definitions">
-                  inherited
-                </span>
-                }
-                <span class="marker-manager__row-spacer"></span>
-                @if (m.inherited_from) {
-                <button mat-icon-button disabled matTooltip="Inherited — edit via Definitions">
-                  <mat-icon>lock</mat-icon>
-                </button>
-                } @else {
-                <button mat-icon-button (click)="startEditMarker(group.linkId, m)" matTooltip="Edit">
-                  <mat-icon>edit</mat-icon>
-                </button>
-                <button mat-icon-button (click)="deleteMarker(group.linkId, m.name)" matTooltip="Delete">
-                  <mat-icon>delete</mat-icon>
-                </button>
-                }
-              </div>
-                }
-              }
-            </div>
-            }
-
-            <!-- Aggregate view (when no link selected) -->
-            @if (!selectedLinkId()) {
-            <div class="marker-manager__list">
-              @if (linkGroups().length === 0) {
-              <div class="marker-manager__empty">
-                No markers on any link yet. Use the selector above to pick a link and add one.
-              </div>
-              }
-              @for (group of linkGroups(); track group.linkId) {
-              <div class="marker-manager__group">
-                <div class="marker-manager__group-header">
-                  <span class="marker-manager__group-name" [title]="group.linkId">{{ group.name }}</span>
-                  <span class="marker-manager__group-count">{{ group.markers.length }}</span>
-                  <span class="marker-manager__row-spacer"></span>
-                  <button
-                    mat-stroked-button
-                    class="add-button"
-                    (click)="toggleAddMarker(group.linkId)"
-                    [class.add-button--active]="addingToLink() === group.linkId"
-                  >
-                    <mat-icon>add</mat-icon>
-                    Marker
-                  </button>
-                </div>
-
-                @if (addingToLink() === group.linkId) {
-                <form
-                  class="marker-manager__form--inline"
-                  [formGroup]="markerForm"
-                  (ngSubmit)="submitMarker(group.linkId)"
-                >
-                  <div style="display: grid; grid-template-columns: 1fr; gap: 16px; align-items: start;">
-                    <mat-form-field class="form-field">
-                      <mat-label>BPF expression</mat-label>
-                      <textarea matInput formControlName="bpf" placeholder="tcp port 80" rows="1" cdkTextareaAutosize cdkAutosizeMinRows="1" cdkAutosizeMaxRows="4"></textarea>
-                      @if (markerForm.get('bpf')?.hasError('required')) {
-                      <mat-error>BPF is required</mat-error>
-                      }
-                    </mat-form-field>
-                  </div>
-                  <div style="display: grid; grid-template-columns: 3.0fr 0.9fr 0.8fr 0.5fr auto auto; gap: 16px; align-items: start;">
-                    <mat-form-field class="form-field">
-                      <mat-label>Name</mat-label>
-                      <input matInput formControlName="name" placeholder="my-filter" />
-                      @if (markerForm.get('name')?.hasError('required')) {
-                      <mat-error>Name is required</mat-error>
-                      } @if (markerForm.get('name')?.hasError('notGlobalName')) {
-                      <mat-error>Name cannot start with "global"</mat-error>
-                      }
-                    </mat-form-field>
-                    <mat-form-field class="form-field">
-                          <mat-select formControlName="direction">
-                        <mat-option [value]="null">Both</mat-option>
-                        <mat-option value="tx">Tx →</mat-option>
-                        <mat-option value="rx">← Rx</mat-option>
-                      </mat-select>
-                    </mat-form-field>
-                    <mat-form-field class="form-field">
-                      <mat-label>Highlight ms</mat-label>
-                      <input matInput type="number" formControlName="highlight_duration" placeholder="500" />
-                      @if (markerForm.get('highlight_duration')?.hasError('required')) {
-                      <mat-error>Required</mat-error>
-                      }
-                      @if (markerForm.get('highlight_duration')?.hasError('min')) {
-                      <mat-error>Must be ≥ 1</mat-error>
-                      }
-                    </mat-form-field>
-                    <mat-form-field class="form-field">
-                      <mat-label>Color</mat-label>
-                      <input matInput type="color" formControlName="color" class="color-input" />
-                    </mat-form-field>
-                    <button mat-flat-button color="primary" type="submit" [disabled]="markerForm.invalid" style="align-self: start; margin-top: 18px;">Add</button>
-                    <button mat-stroked-button type="button" (click)="toggleAddMarker(group.linkId)" style="align-self: start; margin-top: 18px;">Cancel</button>
-                  </div>
-                </form>
-                }
-
-                @for (m of group.markers; track m.name) {
-                  @if (editingMarker(); as edit) {
-                    @if (edit.linkId === group.linkId && edit.name === m.name) {
-                <form class="marker-manager__form--inline" [formGroup]="markerEditForm" (ngSubmit)="submitEditMarker(group.linkId)">
-                  <div style="display: grid; grid-template-columns: 1fr; gap: 16px; align-items: start;">
-                    <mat-form-field class="form-field">
-                      <mat-label>BPF expression</mat-label>
-                      <textarea matInput formControlName="bpf" placeholder="tcp port 80" rows="1" cdkTextareaAutosize cdkAutosizeMinRows="1" cdkAutosizeMaxRows="4"></textarea>
-                      @if (markerEditForm.get('bpf')?.hasError('required')) {
-                      <mat-error>BPF is required</mat-error>
-                      }
-                    </mat-form-field>
-                  </div>
-                  <div style="display: grid; grid-template-columns: 3.0fr 0.9fr 0.8fr 0.5fr auto auto; gap: 16px; align-items: start;">
-                    <mat-form-field class="form-field">
-                      <mat-label>Name</mat-label>
-                      <input matInput formControlName="name" />
-                      @if (markerEditForm.get('name')?.hasError('required')) {
-                      <mat-error>Name is required</mat-error>
-                      } @if (markerEditForm.get('name')?.hasError('notGlobalName')) {
-                      <mat-error>Name cannot start with "global"</mat-error>
-                      }
-                    </mat-form-field>
-                    <mat-form-field class="form-field">
-                      <mat-label>Highlight ms</mat-label>
-                      <input matInput type="number" formControlName="highlight_duration" placeholder="500" />
-                      @if (markerEditForm.get('highlight_duration')?.hasError('required')) {
-                      <mat-error>Required</mat-error>
-                      }
-                      @if (markerEditForm.get('highlight_duration')?.hasError('min')) {
-                      <mat-error>Must be ≥ 1</mat-error>
-                      }
-                    </mat-form-field>
-                    <mat-form-field class="form-field">
-                      <mat-label>Color</mat-label>
-                      <input matInput type="color" formControlName="color" class="color-input" />
-                    </mat-form-field>
-                    <button mat-flat-button color="primary" type="submit" [disabled]="markerEditForm.invalid" style="align-self: start; margin-top: 18px;">Save</button>
-                    <button mat-stroked-button type="button" (click)="cancelEditMarker()" style="align-self: start; margin-top: 18px;">Cancel</button>
-                  </div>
-                </form>
-                    }
-                  } @else {
                 <div class="marker-manager__row">
                   <span
                     class="marker-manager__swatch"
@@ -476,6 +240,9 @@
                   <span class="marker-manager__row-name">{{ m.name }}</span>
                   <span class="marker-manager__row-bpf">{{ m.bpf }}</span>
 
+                  @if (m.capture_node_id) {
+                  <span class="marker-manager__chip" title="Capture node (observer)">{{ nodeName(m.capture_node_id) }}</span>
+                  }
                   @if (m.direction) {
                   <span class="marker-manager__chip marker-manager__chip--dir" title="Direction filter">{{ m.direction }}</span>
                   }
@@ -498,7 +265,98 @@
                   </button>
                   }
                 </div>
+                }
+              }
+            </div>
+            }
+
+            <!-- Aggregate view (when no link selected) -->
+            @if (!selectedLinkId()) {
+            <div class="marker-manager__list">
+              @if (linkGroups().length === 0) {
+              <div class="marker-manager__empty">
+                No markers on any link yet. Use the selector above to pick a link and add one.
+              </div>
+              }
+              @for (group of linkGroups(); track group.linkId) {
+              <div class="marker-manager__group">
+                <div class="marker-manager__group-header" (click)="toggleGroup(group.linkId)">
+                  <mat-icon class="marker-manager__group-chevron">
+                    {{ isGroupCollapsed(group.linkId) ? 'chevron_right' : 'expand_more' }}
+                  </mat-icon>
+                  <span class="marker-manager__group-name" [title]="group.linkId">{{ group.name }}</span>
+                  <span class="marker-manager__group-count">{{ group.markers.length }}</span>
+                  <span class="marker-manager__row-spacer"></span>
+                  <button
+                    mat-stroked-button
+                    class="add-button"
+                    (click)="$event.stopPropagation(); toggleAddMarker(group.linkId)"
+                    [class.add-button--active]="addingToLink() === group.linkId"
+                  >
+                    <mat-icon>add</mat-icon>
+                    Marker
+                  </button>
+                </div>
+
+                @if (!isGroupCollapsed(group.linkId)) {
+                @if (addingToLink() === group.linkId) {
+                <app-marker-form
+                  [form]="markerForm"
+                  mode="create"
+                  [captureOptions]="linkEndpoints(group.linkId)"
+                  (save)="submitMarker(group.linkId)"
+                  (cancel)="toggleAddMarker(group.linkId)"
+                />
+                }
+
+                @for (m of group.markers; track m.name) {
+                  @if (editingMarker(); as edit) {
+                    @if (edit.linkId === group.linkId && edit.name === m.name) {
+                    <app-marker-form
+                      [form]="markerEditForm"
+                      mode="edit"
+                      [captureOptions]="linkEndpoints(group.linkId)"
+                      (save)="submitEditMarker(group.linkId)"
+                      (cancel)="cancelEditMarker()"
+                    />
+                    }
+                  } @else {
+                  <div class="marker-manager__row">
+                    <span
+                      class="marker-manager__swatch"
+                      [style.background]="m.color"
+                      [class.marker-manager__swatch--default]="!m.color"
+                    ></span>
+                    <span class="marker-manager__row-name">{{ m.name }}</span>
+                    <span class="marker-manager__row-bpf">{{ m.bpf }}</span>
+
+                    @if (m.capture_node_id) {
+                    <span class="marker-manager__chip" title="Capture node (observer)">{{ nodeName(m.capture_node_id) }}</span>
+                    }
+                    @if (m.direction) {
+                    <span class="marker-manager__chip marker-manager__chip--dir" title="Direction filter">{{ m.direction }}</span>
+                    }
+                    @if (m.inherited_from) {
+                    <span class="marker-manager__chip marker-manager__chip--inherited" matTooltip="Inherited — edit via Definitions">
+                      inherited
+                    </span>
+                    }
+                    <span class="marker-manager__row-spacer"></span>
+                    @if (m.inherited_from) {
+                    <button mat-icon-button disabled matTooltip="Inherited — edit via Definitions">
+                      <mat-icon>lock</mat-icon>
+                    </button>
+                    } @else {
+                    <button mat-icon-button (click)="startEditMarker(group.linkId, m)" matTooltip="Edit">
+                      <mat-icon>edit</mat-icon>
+                    </button>
+                    <button mat-icon-button (click)="deleteMarker(group.linkId, m.name)" matTooltip="Delete">
+                      <mat-icon>delete</mat-icon>
+                    </button>
+                    }
+                  </div>
                   }
+                }
                 }
               </div>
               }

--- a/src/app/components/project-map/marker-manager/marker-manager.component.html
+++ b/src/app/components/project-map/marker-manager/marker-manager.component.html
@@ -196,6 +196,15 @@
                 <span class="marker-manager__group-name" [title]="group.linkId">{{ group.name }}</span>
                 <span class="marker-manager__group-count">{{ group.markers.length }}</span>
                 <span class="marker-manager__row-spacer"></span>
+                <button
+                  mat-stroked-button
+                  class="add-button"
+                  (click)="toggleAddMarker(group.linkId)"
+                  [class.add-button--active]="addingToLink() === group.linkId"
+                >
+                  <mat-icon>add</mat-icon>
+                  Marker
+                </button>
                 <button mat-icon-button (click)="resetLinkSelect()" matTooltip="Back to all links">
                   <mat-icon>arrow_back</mat-icon>
                 </button>
@@ -211,13 +220,15 @@
               </div>
               }
 
+              @if (addingToLink() === group.linkId) {
               <app-marker-form
                 [form]="markerForm"
                 mode="create"
                 [captureOptions]="linkEndpoints(group.linkId)"
                 (save)="submitMarker(group.linkId)"
-                (cancel)="markerForm.reset(); linkError.set(null); selectedLinkId.set(null)"
+                (cancel)="toggleAddMarker(group.linkId)"
               />
+              }
 
               @for (m of group.markers; track m.name) {
                 @if (editingMarker(); as edit) {

--- a/src/app/components/project-map/marker-manager/marker-manager.component.html
+++ b/src/app/components/project-map/marker-manager/marker-manager.component.html
@@ -171,8 +171,8 @@
         <!-- ===================== Links (aggregate) ===================== -->
         <mat-tab label="Links">
           <div class="marker-manager__panel">
-            @if (linkError() && !selectedLinkId()) {
-            <div class="marker-manager__error">{{ linkError() }}</div>
+            @if (panelError(); as msg) {
+            <div class="marker-manager__error">{{ msg }}</div>
             }
 
             <!-- Node + Link selector (cascading filter) -->
@@ -232,8 +232,8 @@
                 </button>
               </div>
 
-              @if (linkError()) {
-              <div class="marker-manager__error">{{ linkError() }}</div>
+              @if (groupError(group.linkId); as msg) {
+              <div class="marker-manager__error">{{ msg }}</div>
               }
               @if (definitions().length > 0) {
               <div class="marker-manager__hint">
@@ -288,6 +288,9 @@
                 </div>
 
                 @if (!isGroupCollapsed(group.linkId)) {
+                @if (groupError(group.linkId); as msg) {
+                <div class="marker-manager__error">{{ msg }}</div>
+                }
                 @if (addingToLink() === group.linkId) {
                 <app-marker-form
                   [form]="markerForm"

--- a/src/app/components/project-map/marker-manager/marker-manager.component.html
+++ b/src/app/components/project-map/marker-manager/marker-manager.component.html
@@ -59,7 +59,7 @@
                   }
                 </mat-form-field>
               </div>
-              <div style="display: grid; grid-template-columns: 3fr 0.8fr 0.8fr 0.6fr auto auto; gap: 16px; align-items: start;">
+              <div style="display: grid; grid-template-columns: 3fr 0.8fr 0.8fr 0.6fr 0.6fr auto auto; gap: 16px; align-items: start;">
                 <mat-form-field class="form-field">
                   <mat-label>Name</mat-label>
                   <span matTextPrefix class="global-prefix">global-&nbsp;</span>
@@ -87,6 +87,14 @@
                 <mat-form-field class="form-field">
                   <mat-label>Color</mat-label>
                   <input matInput type="color" formControlName="color" class="color-input" />
+                </mat-form-field>
+                <mat-form-field class="form-field">
+                  <mat-label>Direction</mat-label>
+                  <mat-select formControlName="direction">
+                    <mat-option [value]="null">Both</mat-option>
+                    <mat-option value="tx">Tx only</mat-option>
+                    <mat-option value="rx">Rx only</mat-option>
+                  </mat-select>
                 </mat-form-field>
                 <button mat-flat-button color="primary" type="submit" [disabled]="definitionForm.invalid" style="align-self: start; margin-top: 18px;">
                   {{ editingDefinition() ? 'Save' : 'Create' }}
@@ -125,6 +133,9 @@
                 }
                 @if (row.highlight_duration !== null) {
                 <span class="marker-manager__chip">{{ row.highlight_duration }}ms</span>
+                }
+                @if (row.direction) {
+                <span class="marker-manager__chip marker-manager__chip--dir" title="Direction filter">{{ row.direction }}</span>
                 }
                 <span class="marker-manager__chip marker-manager__chip--links" title="Links carrying this definition">
                   → {{ row.linkCount }} link{{ row.linkCount === 1 ? '' : 's' }}
@@ -221,7 +232,7 @@
                     }
                   </mat-form-field>
                 </div>
-                <div style="display: grid; grid-template-columns: 3fr 0.8fr 0.8fr 0.6fr auto auto; gap: 16px; align-items: start;">
+                <div style="display: grid; grid-template-columns: 3fr 0.8fr 0.8fr 0.6fr 0.6fr auto auto; gap: 16px; align-items: start;">
                   <mat-form-field class="form-field">
                     <mat-label>Name</mat-label>
                     <input matInput formControlName="name" placeholder="my-filter" />
@@ -249,6 +260,14 @@
                     <mat-label>Color</mat-label>
                     <input matInput type="color" formControlName="color" class="color-input" />
                   </mat-form-field>
+                  <mat-form-field class="form-field">
+                    <mat-label>Direction</mat-label>
+                    <mat-select formControlName="direction">
+                      <mat-option [value]="null">Both</mat-option>
+                      <mat-option value="tx">Tx only</mat-option>
+                      <mat-option value="rx">Rx only</mat-option>
+                    </mat-select>
+                  </mat-form-field>
                   <button mat-flat-button color="primary" type="submit" [disabled]="markerForm.invalid" style="align-self: start; margin-top: 18px;">Add</button>
                   <button mat-stroked-button type="button" (click)="markerForm.reset(); linkError.set(null); selectedLinkId.set(null)" style="align-self: start; margin-top: 18px;">Back</button>
                 </div>
@@ -267,7 +286,7 @@
                     }
                   </mat-form-field>
                 </div>
-                <div style="display: grid; grid-template-columns: 3fr 0.8fr 0.8fr 0.6fr auto auto; gap: 16px; align-items: start;">
+                <div style="display: grid; grid-template-columns: 3fr 0.8fr 0.8fr 0.6fr 0.6fr auto auto; gap: 16px; align-items: start;">
                   <mat-form-field class="form-field">
                     <mat-label>Name</mat-label>
                     <input matInput formControlName="name" />
@@ -295,6 +314,14 @@
                     <mat-label>Color</mat-label>
                     <input matInput type="color" formControlName="color" class="color-input" />
                   </mat-form-field>
+                  <mat-form-field class="form-field">
+                    <mat-label>Direction</mat-label>
+                    <mat-select formControlName="direction">
+                      <mat-option [value]="null">Both</mat-option>
+                      <mat-option value="tx">Tx only</mat-option>
+                      <mat-option value="rx">Rx only</mat-option>
+                    </mat-select>
+                  </mat-form-field>
                   <button mat-flat-button color="primary" type="submit" [disabled]="markerEditForm.invalid" style="align-self: start; margin-top: 18px;">Save</button>
                   <button mat-stroked-button type="button" (click)="cancelEditMarker()" style="align-self: start; margin-top: 18px;">Cancel</button>
                 </div>
@@ -311,6 +338,9 @@
                 <span class="marker-manager__row-bpf">{{ m.bpf }}</span>
                 @if (m.tag !== null && m.tag !== undefined) {
                 <span class="marker-manager__chip">tag {{ m.tag }}</span>
+                }
+                @if (m.direction) {
+                <span class="marker-manager__chip marker-manager__chip--dir" title="Direction filter">{{ m.direction }}</span>
                 }
                 @if (m.inherited_from) {
                 <span class="marker-manager__chip marker-manager__chip--inherited" matTooltip="Inherited — edit via Definitions">
@@ -376,7 +406,7 @@
                       }
                     </mat-form-field>
                   </div>
-                  <div style="display: grid; grid-template-columns: 3fr 0.8fr 0.8fr 0.6fr auto auto; gap: 16px; align-items: start;">
+                  <div style="display: grid; grid-template-columns: 3fr 0.8fr 0.8fr 0.6fr 0.6fr auto auto; gap: 16px; align-items: start;">
                     <mat-form-field class="form-field">
                       <mat-label>Name</mat-label>
                       <input matInput formControlName="name" placeholder="my-filter" />
@@ -404,6 +434,14 @@
                       <mat-label>Color</mat-label>
                       <input matInput type="color" formControlName="color" class="color-input" />
                     </mat-form-field>
+                    <mat-form-field class="form-field">
+                      <mat-label>Direction</mat-label>
+                      <mat-select formControlName="direction">
+                        <mat-option [value]="null">Both</mat-option>
+                        <mat-option value="tx">Tx only</mat-option>
+                        <mat-option value="rx">Rx only</mat-option>
+                      </mat-select>
+                    </mat-form-field>
                     <button mat-flat-button color="primary" type="submit" [disabled]="markerForm.invalid" style="align-self: start; margin-top: 18px;">Add</button>
                     <button mat-stroked-button type="button" (click)="toggleAddMarker(group.linkId)" style="align-self: start; margin-top: 18px;">Cancel</button>
                   </div>
@@ -423,7 +461,7 @@
                       }
                     </mat-form-field>
                   </div>
-                  <div style="display: grid; grid-template-columns: 3fr 0.8fr 0.8fr 0.6fr auto auto; gap: 16px; align-items: start;">
+                  <div style="display: grid; grid-template-columns: 3fr 0.8fr 0.8fr 0.6fr 0.6fr auto auto; gap: 16px; align-items: start;">
                     <mat-form-field class="form-field">
                       <mat-label>Name</mat-label>
                       <input matInput formControlName="name" />
@@ -467,6 +505,9 @@
                   <span class="marker-manager__row-bpf">{{ m.bpf }}</span>
                   @if (m.tag !== null && m.tag !== undefined) {
                   <span class="marker-manager__chip">tag {{ m.tag }}</span>
+                  }
+                  @if (m.direction) {
+                  <span class="marker-manager__chip marker-manager__chip--dir" title="Direction filter">{{ m.direction }}</span>
                   }
                   @if (m.inherited_from) {
                   <span class="marker-manager__chip marker-manager__chip--inherited" matTooltip="Inherited — edit via Definitions">

--- a/src/app/components/project-map/marker-manager/marker-manager.component.scss
+++ b/src/app/components/project-map/marker-manager/marker-manager.component.scss
@@ -349,7 +349,12 @@
   }
 
   &__toggle-spinner {
-    color: var(--mat-sys-primary);
+    --mdc-circular-progress-active-indicator-color: var(--mat-sys-primary);
+  }
+
+  &__btn-spinner {
+    // Inside mat-flat-button color="primary": arc matches the on-primary label.
+    --mdc-circular-progress-active-indicator-color: var(--mat-sys-on-primary);
   }
 }
 

--- a/src/app/components/project-map/marker-manager/marker-manager.component.scss
+++ b/src/app/components/project-map/marker-manager/marker-manager.component.scss
@@ -234,6 +234,11 @@
     &--editing {
       background: var(--mat-sys-secondary-container);
     }
+
+    &--disabled,
+    &--paused {
+      opacity: 0.5;
+    }
   }
 
   &__row-name {

--- a/src/app/components/project-map/marker-manager/marker-manager.component.scss
+++ b/src/app/components/project-map/marker-manager/marker-manager.component.scss
@@ -272,6 +272,12 @@
       color: var(--mat-sys-primary);
     }
 
+    &--dir {
+      color: var(--mat-sys-on-tertiary-container);
+      background: var(--mat-sys-tertiary-container);
+      text-transform: uppercase;
+    }
+
     &--inherited {
       color: var(--mat-sys-on-secondary-container);
       background: var(--mat-sys-secondary-container);

--- a/src/app/components/project-map/marker-manager/marker-manager.component.scss
+++ b/src/app/components/project-map/marker-manager/marker-manager.component.scss
@@ -347,6 +347,10 @@
       vertical-align: middle;
     }
   }
+
+  &__toggle-spinner {
+    color: var(--mat-sys-primary);
+  }
 }
 
 // ---- resize handles (cloned from node-file-manager-inline) ----

--- a/src/app/components/project-map/marker-manager/marker-manager.component.scss
+++ b/src/app/components/project-map/marker-manager/marker-manager.component.scss
@@ -192,6 +192,15 @@
     align-items: center;
     gap: 8px;
     margin-bottom: 4px;
+    cursor: pointer;
+  }
+
+  &__group-chevron {
+    font-size: 18px;
+    width: 18px;
+    height: 18px;
+    color: var(--mat-sys-on-surface-variant);
+    flex-shrink: 0;
   }
 
   &__group-name {

--- a/src/app/components/project-map/marker-manager/marker-manager.component.spec.ts
+++ b/src/app/components/project-map/marker-manager/marker-manager.component.spec.ts
@@ -108,6 +108,7 @@ describe('MarkerManagerComponent', () => {
         color: null,
         highlight_duration: 800,
         direction: null,
+        data_link_type: null,
       });
       component.submitDefinition();
 
@@ -116,6 +117,7 @@ describe('MarkerManagerComponent', () => {
         'proj-1',
         // Definitions are direction-agnostic, so the form always maps to 'both'
         // (dirToBody) and submitDefinition() sends it explicitly to clear any filter.
+        // data_link_type is null (Ethernet-only default) ⇒ omitted from the body.
         { name: 'icmp', bpf: 'icmp', tag: 1, highlight_duration: 800, direction: 'both' }
       );
       expect(markerService.listDefinitions).toHaveBeenCalled();
@@ -131,6 +133,7 @@ describe('MarkerManagerComponent', () => {
         color: null,
         highlight_duration: null,
         direction: null,
+        data_link_type: null,
       });
       component.submitDefinition();
       expect(markerService.createDefinition).not.toHaveBeenCalled();
@@ -147,6 +150,7 @@ describe('MarkerManagerComponent', () => {
         color: null,
         highlight_duration: 500,
         direction: null,
+        data_link_type: null,
       });
       component.submitDefinition();
       expect(component.defError()).toContain('Invalid BPF expression');

--- a/src/app/components/project-map/marker-manager/marker-manager.component.spec.ts
+++ b/src/app/components/project-map/marker-manager/marker-manager.component.spec.ts
@@ -107,6 +107,7 @@ describe('MarkerManagerComponent', () => {
         tag: 1,
         color: null,
         highlight_duration: 800,
+        direction: null,
       });
       component.submitDefinition();
 
@@ -127,6 +128,7 @@ describe('MarkerManagerComponent', () => {
         tag: null,
         color: null,
         highlight_duration: null,
+        direction: null,
       });
       component.submitDefinition();
       expect(markerService.createDefinition).not.toHaveBeenCalled();
@@ -142,6 +144,7 @@ describe('MarkerManagerComponent', () => {
         tag: null,
         color: null,
         highlight_duration: 500,
+        direction: null,
       });
       component.submitDefinition();
       expect(component.defError()).toContain('Invalid BPF expression');

--- a/src/app/components/project-map/marker-manager/marker-manager.component.spec.ts
+++ b/src/app/components/project-map/marker-manager/marker-manager.component.spec.ts
@@ -114,7 +114,9 @@ describe('MarkerManagerComponent', () => {
       expect(markerService.createDefinition).toHaveBeenCalledWith(
         controller,
         'proj-1',
-        { name: 'icmp', bpf: 'icmp', tag: 1, highlight_duration: 800 }
+        // Definitions are direction-agnostic, so the form always maps to 'both'
+        // (dirToBody) and submitDefinition() sends it explicitly to clear any filter.
+        { name: 'icmp', bpf: 'icmp', tag: 1, highlight_duration: 800, direction: 'both' }
       );
       expect(markerService.listDefinitions).toHaveBeenCalled();
       expect(markerService.aggregateList).toHaveBeenCalled();

--- a/src/app/components/project-map/marker-manager/marker-manager.component.ts
+++ b/src/app/components/project-map/marker-manager/marker-manager.component.ts
@@ -740,6 +740,13 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
     const project = this.project();
     if (!controller || !project) return;
     const wantPaused = !row.paused;
+    // Optimistically flip the row so the icon reacts instantly. We deliberately do NOT
+    // call loadDefinitions() on success — it sets `loading`, flashing the "Loading…"
+    // block and re-rendering the whole list (the "refresh" blink). The 204 confirms the
+    // server persisted `paused`, so the optimistic value is authoritative; loadAggregate
+    // still refreshes the Links tab, whose inherited copies flip `enabled` with the rule.
+    // Mirrors toggleMarkerEnabled / applyEnabledLocal (which never hit a loading flag).
+    this.applyDefinitionPausedLocal(row.name, wantPaused);
     this.togglingDefinition.set(row.name);
     const req$ = wantPaused
       ? this.markerService.pauseDefinition(controller, project.project_id, row.name)
@@ -747,17 +754,22 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
     req$.pipe(takeUntil(this.destroy$)).subscribe({
       next: () => {
         this.togglingDefinition.set(null);
-        // Authoritative: GET /marker-definitions returns the persisted `paused` flag.
-        this.loadDefinitions();
-        // The rule's inherited copies flip `enabled` too — refresh the aggregate view.
         this.loadAggregate();
       },
       error: (err) => {
         this.togglingDefinition.set(null);
+        this.applyDefinitionPausedLocal(row.name, !wantPaused); // revert optimistic flip
         this.defError.set(err.error?.message || err.message || 'Failed to toggle definition');
         this.cdr.markForCheck();
       },
     });
+  }
+
+  /** Optimistically set a definition's `paused` in the local {@link definitions} signal
+   *  (pre-response) so the row's icon swaps instantly and no list reload is needed. */
+  private applyDefinitionPausedLocal(name: string, paused: boolean) {
+    const rows = this.definitions().map((r) => (r.name === name ? { ...r, paused } : r));
+    this.definitions.set(rows);
   }
 
   // ---- per-marker enable/disable (server fast path: no rebuild, no pcap flush) ----

--- a/src/app/components/project-map/marker-manager/marker-manager.component.ts
+++ b/src/app/components/project-map/marker-manager/marker-manager.component.ts
@@ -890,10 +890,11 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
   /**
    * Map a form direction value to the backend value. The form uses the `'both'` sentinel
    * because mat-select clears its selection model on `null` — a null-valued option never
-   * displays in the trigger. `'both'` maps to absent/null (both directions) on the wire.
+   * displays in the trigger. `'both'` is sent as `'both'` on the wire (the server treats
+   * it as "no direction filter", same as null/absent on GET).
    */
-  private dirToBody(d: unknown): 'tx' | 'rx' | null {
-    return d === 'tx' || d === 'rx' ? d : null;
+  private dirToBody(d: unknown): 'tx' | 'rx' | 'both' {
+    return d === 'tx' || d === 'rx' ? d : 'both';
   }
 
   /** Map a stored/backend direction back to the form value (`null`/`undefined` → `'both'`). */

--- a/src/app/components/project-map/marker-manager/marker-manager.component.ts
+++ b/src/app/components/project-map/marker-manager/marker-manager.component.ts
@@ -23,6 +23,7 @@ import { MatTabsModule } from '@angular/material/tabs';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatAutocompleteModule } from '@angular/material/autocomplete';
+import { MatSelectModule } from '@angular/material/select';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatDividerModule } from '@angular/material/divider';
 import { CdkTextareaAutosize } from '@angular/cdk/text-field';
@@ -54,6 +55,7 @@ interface DefinitionRow {
   tag: number | null;
   color: string | null;
   highlight_duration: number | null;
+  direction: 'tx' | 'rx' | null;
   linkCount: number;
 }
 
@@ -102,6 +104,7 @@ function notGlobalName(control: UntypedFormControl): { notGlobalName: true } | n
     MatFormFieldModule,
     MatInputModule,
     MatAutocompleteModule,
+    MatSelectModule,
     MatTooltipModule,
     MatDividerModule,
     CdkTextareaAutosize,
@@ -209,6 +212,7 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
     tag: new UntypedFormControl(null),
     color: new UntypedFormControl(null),
     highlight_duration: new UntypedFormControl(800, [Validators.required, Validators.min(1)]),
+    direction: new UntypedFormControl(null),
   });
 
   readonly markerForm = new UntypedFormGroup({
@@ -217,6 +221,7 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
     tag: new UntypedFormControl(null),
     color: new UntypedFormControl(null),
     highlight_duration: new UntypedFormControl(800, [Validators.required, Validators.min(1)]),
+    direction: new UntypedFormControl(null),
   });
 
   readonly markerEditForm = new UntypedFormGroup({
@@ -225,6 +230,7 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
     tag: new UntypedFormControl(null),
     color: new UntypedFormControl(null),
     highlight_duration: new UntypedFormControl(800, [Validators.required, Validators.min(1)]),
+    direction: new UntypedFormControl(null),
   });
 
   private boundaryService = inject(WindowBoundaryService);
@@ -356,6 +362,7 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
       tag: d.tag ?? null,
       color: d.color ?? null,
       highlight_duration: d.highlight_duration ?? null,
+      direction: (d.direction as 'tx' | 'rx' | null) ?? null,
       linkCount: d.link_ids?.length ?? 0,
     }));
   }
@@ -409,6 +416,7 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
     if (v.color) body.color = v.color;
     const hd = this.asNumber(v.highlight_duration);
     if (hd !== null) body.highlight_duration = hd;
+    if (v.direction) body.direction = v.direction;
 
     const editing = this.editingDefinition();
     const done = () => {
@@ -445,6 +453,7 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
       tag: row.tag,
       color: row.color,
       highlight_duration: row.highlight_duration,
+      direction: row.direction,
     });
     // Name is immutable on update; disable to communicate that.
     this.definitionForm.get('name')?.disable();
@@ -539,6 +548,7 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
     if (v.color) body.color = v.color;
     const hd = this.asNumber(v.highlight_duration);
     if (hd !== null) body.highlight_duration = hd;
+    if (v.direction) body.direction = v.direction;
 
     this.markerService.create(controller, project.project_id, linkId, body).subscribe({
       next: () => {
@@ -583,6 +593,7 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
       tag: marker.tag ?? null,
       color: marker.color ?? null,
       highlight_duration: marker.highlight_duration ?? 800,
+      direction: marker.direction ?? null,
     });
     this.markerEditForm.get('name')?.disable();
     this.cdr.markForCheck();
@@ -612,6 +623,7 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
     if (v.color) body.color = v.color;
     const hd = this.asNumber(v.highlight_duration);
     if (hd !== null) body.highlight_duration = hd;
+    if (v.direction) body.direction = v.direction;
 
     this.markerService.update(controller, project.project_id, linkId, editing.name, body).subscribe({
       next: () => {

--- a/src/app/components/project-map/marker-manager/marker-manager.component.ts
+++ b/src/app/components/project-map/marker-manager/marker-manager.component.ts
@@ -58,6 +58,7 @@ interface DefinitionRow {
   highlight_duration: number | null;
   direction: 'tx' | 'rx' | null;
   linkCount: number;
+  paused: boolean;
 }
 
 interface LinkGroup {
@@ -164,6 +165,8 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
   readonly editingMarker = signal<{ linkId: string; name: string } | null>(null);
   /** LinkIds whose marker list is collapsed in the aggregate Links view. */
   readonly collapsedGroups = signal<Set<string>>(new Set());
+  /** Definition name whose pause/resume request is in flight — disables just that row's button. */
+  readonly togglingDefinition = signal<string | null>(null);
   // ---- Node selector (first step in Links tab) ----
   /** Node options (id + display name). Built once from NodesDataSource. */
   readonly nodeOptions = signal<{ id: string; name: string }[]>([]);
@@ -382,6 +385,7 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
       highlight_duration: d.highlight_duration ?? null,
       direction: (d.direction as 'tx' | 'rx' | null) ?? null,
       linkCount: d.link_ids?.length ?? 0,
+      paused: d.paused ?? false,
     }));
   }
 
@@ -726,6 +730,78 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
         this.cdr.markForCheck();
       },
     });
+  }
+
+  // ---- per-definition pause/resume (toggles every inherited copy of a rule) ----
+
+  toggleDefinitionPaused(row: DefinitionRow) {
+    if (this.togglingDefinition() === row.name) return;
+    const controller = this.controller();
+    const project = this.project();
+    if (!controller || !project) return;
+    const wantPaused = !row.paused;
+    this.togglingDefinition.set(row.name);
+    const req$ = wantPaused
+      ? this.markerService.pauseDefinition(controller, project.project_id, row.name)
+      : this.markerService.resumeDefinition(controller, project.project_id, row.name);
+    req$.pipe(takeUntil(this.destroy$)).subscribe({
+      next: () => {
+        this.togglingDefinition.set(null);
+        // Authoritative: GET /marker-definitions returns the persisted `paused` flag.
+        this.loadDefinitions();
+        // The rule's inherited copies flip `enabled` too — refresh the aggregate view.
+        this.loadAggregate();
+      },
+      error: (err) => {
+        this.togglingDefinition.set(null);
+        this.defError.set(err.error?.message || err.message || 'Failed to toggle definition');
+        this.cdr.markForCheck();
+      },
+    });
+  }
+
+  // ---- per-marker enable/disable (server fast path: no rebuild, no pcap flush) ----
+
+  toggleMarkerEnabled(linkId: string, marker: GroupMarker) {
+    // Inherited markers are read-only — managed via the Definitions tab.
+    if (marker.inherited_from) return;
+    const controller = this.controller();
+    const project = this.project();
+    if (!controller || !project) return;
+
+    // `enabled` defaults to true when undefined; only an explicit `false` is "off".
+    const nextEnabled = marker.enabled === false;
+    // Optimistically flip the local row so the icon reacts before the round-trip.
+    this.applyEnabledLocal(linkId, marker.name, nextEnabled);
+
+    this.markerService
+      .setEnabled(controller, project.project_id, linkId, marker.name, nextEnabled)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: () => {
+          this.refreshLink(linkId);
+          this.loadAggregate();
+        },
+        error: (err) => {
+          this.applyEnabledLocal(linkId, marker.name, !nextEnabled); // revert optimistic flip
+          this.toasterService.error(err.error?.message || err.message || 'Failed to toggle marker');
+          this.cdr.markForCheck();
+        },
+      });
+  }
+
+  /**
+   * Optimistically set a marker's `enabled` in the local {@link linkGroups} signal
+   * (pre-response). {@link selectedLinkGroup} recomputes from `linkGroups`, so both the
+   * selected-link and aggregate views update together.
+   */
+  private applyEnabledLocal(linkId: string, name: string, enabled: boolean) {
+    const groups = this.linkGroups().map((g) =>
+      g.linkId !== linkId
+        ? g
+        : { ...g, markers: g.markers.map((m) => (m.name === name ? { ...m, enabled } : m)) }
+    );
+    this.linkGroups.set(groups);
   }
 
   /** Canonical 5-step refresh after a private-marker mutation on a single link. */

--- a/src/app/components/project-map/marker-manager/marker-manager.component.ts
+++ b/src/app/components/project-map/marker-manager/marker-manager.component.ts
@@ -26,6 +26,7 @@ import { MatAutocompleteModule } from '@angular/material/autocomplete';
 import { MatSelectModule } from '@angular/material/select';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatDividerModule } from '@angular/material/divider';
+import { MatDialog } from '@angular/material/dialog';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { CdkTextareaAutosize } from '@angular/cdk/text-field';
 import { Subject, animationFrameScheduler, fromEvent } from 'rxjs';
@@ -50,6 +51,7 @@ import { ToasterService } from '@services/toaster.service';
 import { WindowBoundaryService, WindowStyle } from '@services/window-boundary.service';
 import { WindowManagementService } from '@services/window-management.service';
 import { MarkerFormComponent } from './marker-form.component';
+import { ConfirmationDialogComponent } from '@components/dialogs/confirmation-dialog/confirmation-dialog.component';
 
 interface DefinitionRow {
   name: string;
@@ -301,6 +303,7 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
   private nodesDataSource = inject(NodesDataSource);
   private markerRegistryService = inject(MarkerRegistryService);
   private toasterService = inject(ToasterService);
+  private dialog = inject(MatDialog);
 
   private dragStartX = 0;
   private dragStartY = 0;
@@ -504,6 +507,11 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
     if (v.data_link_type) body.data_link_type = v.data_link_type;
 
     const editing = this.editingDefinition();
+    // An encapsulation change re-fans-out the definition: every inherited copy is rebuilt
+    // and capture restarts on each affected link (uBridge itself is unaffected). Confirm
+    // with the user before sending the PUT so they can back out.
+    const origDlt = editing ? this.definitions().find((d) => d.name === editing)?.data_link_type ?? null : null;
+    const dltChanged = !!editing && origDlt !== (v.data_link_type ?? null);
     const done = () => {
       this.submittingDefinition.set(false);
       this.cancelEditDefinition();
@@ -517,12 +525,38 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
       this.defError.set(err.error?.message || err.message || 'Failed to save definition');
       this.cdr.markForCheck();
     };
-
-    if (editing) {
-      this.markerService.updateDefinition(controller, project.project_id, editing, body).pipe(takeUntil(this.destroy$)).subscribe({
+    const runUpdate = () => {
+      this.markerService.updateDefinition(controller, project.project_id, editing!, body).pipe(takeUntil(this.destroy$)).subscribe({
         next: () => done(),
         error: fail,
       });
+    };
+
+    if (editing) {
+      if (dltChanged) {
+        const ref = this.dialog.open(ConfirmationDialogComponent, {
+          data: {
+            title: 'Confirm encapsulation change',
+            message:
+              'Changing the encapsulation rebuilds this definition’s markers and restarts capture on every link it applies to. uBridge itself is unaffected. Continue?',
+            confirmButtonText: 'Save',
+            cancelButtonText: 'Cancel',
+          },
+          panelClass: ['base-confirmation-dialog-panel', 'confirmation-warning-panel'],
+          autoFocus: false,
+          restoreFocus: false,
+        });
+        ref.afterClosed().subscribe((ok: boolean) => {
+          if (ok) {
+            runUpdate();
+          } else {
+            this.submittingDefinition.set(false);
+            this.cdr.markForCheck();
+          }
+        });
+      } else {
+        runUpdate();
+      }
     } else {
       this.markerService.createDefinition(controller, project.project_id, body).pipe(takeUntil(this.destroy$)).subscribe({
         next: () => done(),

--- a/src/app/components/project-map/marker-manager/marker-manager.component.ts
+++ b/src/app/components/project-map/marker-manager/marker-manager.component.ts
@@ -159,7 +159,7 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
   readonly linkGroups = signal<LinkGroup[]>([]);
   readonly loading = signal(false);
   readonly defError = signal<string | null>(null);
-  readonly linkError = signal<string | null>(null);
+  readonly linkError = signal<{ linkId: string | null; message: string } | null>(null);
   readonly editingDefinition = signal<string | null>(null);
   /** linkId currently showing its inline "add private marker" form (Links tab). */
   readonly addingToLink = signal<string | null>(null);
@@ -384,7 +384,7 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
         this.cdr.markForCheck();
       },
       error: (err) => {
-        this.linkError.set(err.error?.message || err.message || 'Failed to load markers');
+        this.linkError.set({ linkId: null, message: err.error?.message || err.message || 'Failed to load markers' });
         this.cdr.markForCheck();
       },
     });
@@ -622,6 +622,22 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
     return this.deletingMarker() === `${linkId}/${name}`;
   }
 
+  /**
+   * Panel-level error (not scoped to a link) — e.g. an aggregate load failure. Shown at the
+   * top of the Links panel. Per-link create/edit/delete errors are scoped via {@link groupError}
+   * so they render next to the form that produced them, not up here.
+   */
+  panelError(): string | null {
+    const err = this.linkError();
+    return err && !err.linkId ? err.message : null;
+  }
+
+  /** Error message scoped to a specific link group's create/edit/delete action, or null. */
+  groupError(linkId: string): string | null {
+    const err = this.linkError();
+    return err && err.linkId === linkId ? err.message : null;
+  }
+
   /** Toggle a link group's collapsed state (click on its header). */
   toggleGroup(linkId: string) {
     const next = new Set(this.collapsedGroups());
@@ -684,7 +700,7 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
       },
       error: (err) => {
         this.submittingMarker.set(null);
-        this.linkError.set(err.error?.message || err.message || 'Failed to create marker');
+        this.linkError.set({ linkId, message: err.error?.message || err.message || 'Failed to create marker' });
         this.cdr.markForCheck();
       },
     });
@@ -706,7 +722,7 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
       },
       error: (err) => {
         this.deletingMarker.set(null);
-        this.linkError.set(err.error?.message || err.message || 'Failed to delete marker');
+        this.linkError.set({ linkId, message: err.error?.message || err.message || 'Failed to delete marker' });
         this.cdr.markForCheck();
       },
     });
@@ -769,7 +785,7 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
       },
       error: (err) => {
         this.submittingEditMarker.set(false);
-        this.linkError.set(err.error?.message || err.message || 'Failed to update marker');
+        this.linkError.set({ linkId, message: err.error?.message || err.message || 'Failed to update marker' });
         this.cdr.markForCheck();
       },
     });

--- a/src/app/components/project-map/marker-manager/marker-manager.component.ts
+++ b/src/app/components/project-map/marker-manager/marker-manager.component.ts
@@ -524,6 +524,8 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
   onNodeSelect(nodeId: string | null) {
     this.selectedNodeId.set(nodeId);
     this.selectedLinkId.set(null);
+    this.addingToLink.set(null);
+    this.editingMarker.set(null);
     this.linkSearchText.set('');
     this.markerForm.reset();
     this.linkError.set(null);
@@ -540,6 +542,7 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
   onLinkSelect(linkId: string | null) {
     this.selectedLinkId.set(linkId);
     this.addingToLink.set(null);
+    this.editingMarker.set(null);
     this.markerForm.reset();
     this.linkError.set(null);
     this.linkSearchText.set(linkId ? this.linkName(linkId) : '');
@@ -568,6 +571,8 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
     this.selectedNodeId.set(null);
     this.nodeSearchText.set('');
     this.selectedLinkId.set(null);
+    this.addingToLink.set(null);
+    this.editingMarker.set(null);
     this.linkSearchText.set('');
     this.linkError.set(null);
     this.cdr.markForCheck();
@@ -629,11 +634,10 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
 
     this.markerService.create(controller, project.project_id, linkId, body).subscribe({
       next: () => {
-        if (this.selectedLinkId()) {
-          this.markerForm.reset();
-        } else {
-          this.toggleAddMarker(linkId);
-        }
+        // Close the create form and return to the list — same behavior in the
+        // selected-link and aggregate views. (The selected-link view previously
+        // kept the form open via markerForm.reset().)
+        this.toggleAddMarker(linkId);
         this.refreshLink(linkId);
         this.loadAggregate();
       },

--- a/src/app/components/project-map/marker-manager/marker-manager.component.ts
+++ b/src/app/components/project-map/marker-manager/marker-manager.component.ts
@@ -213,6 +213,9 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
   readonly definitionForm = new UntypedFormGroup({
     name: new UntypedFormControl('', [Validators.required, notGlobalName]),
     bpf: new UntypedFormControl('', [Validators.required]),
+    // `tag` is reserved for the upcoming traffic-replay feature. There's no UI for it
+    // on definitions yet, so it stays null and submitDefinition()'s tag read is a no-op
+    // until the field ships — kept here deliberately, not dead code.
     tag: new UntypedFormControl(null),
     color: new UntypedFormControl(null),
     highlight_duration: new UntypedFormControl(800, {
@@ -318,7 +321,7 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
     const project = this.project();
     if (!controller || !project) return;
     this.loading.set(true);
-    this.markerService.listDefinitions(controller, project.project_id).subscribe({
+    this.markerService.listDefinitions(controller, project.project_id).pipe(takeUntil(this.destroy$)).subscribe({
       next: (map: MarkerDefinitionMap) => {
         this.definitions.set(this.toDefinitionRows(map));
         this.loading.set(false);
@@ -358,7 +361,7 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
     const controller = this.controller();
     const project = this.project();
     if (!controller || !project) return;
-    this.markerService.aggregateList(controller, project.project_id).subscribe({
+    this.markerService.aggregateList(controller, project.project_id).pipe(takeUntil(this.destroy$)).subscribe({
       next: (map: AggregateMarkerMap) => {
         this.linkGroups.set(this.buildGroups(map));
         this.cdr.markForCheck();
@@ -464,12 +467,12 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
     };
 
     if (editing) {
-      this.markerService.updateDefinition(controller, project.project_id, editing, body).subscribe({
+      this.markerService.updateDefinition(controller, project.project_id, editing, body).pipe(takeUntil(this.destroy$)).subscribe({
         next: () => done(),
         error: fail,
       });
     } else {
-      this.markerService.createDefinition(controller, project.project_id, body).subscribe({
+      this.markerService.createDefinition(controller, project.project_id, body).pipe(takeUntil(this.destroy$)).subscribe({
         next: () => done(),
         error: fail,
       });
@@ -505,7 +508,7 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
     const project = this.project();
     if (!controller || !project) return;
     this.defError.set(null);
-    this.markerService.deleteDefinition(controller, project.project_id, row.name).subscribe({
+    this.markerService.deleteDefinition(controller, project.project_id, row.name).pipe(takeUntil(this.destroy$)).subscribe({
       next: () => {
         if (this.editingDefinition() === row.name) this.cancelEditDefinition();
         this.loadDefinitions();
@@ -632,7 +635,7 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
     if (dir) body.direction = dir;
     if (v.capture_node_id) body.capture_node_id = v.capture_node_id;
 
-    this.markerService.create(controller, project.project_id, linkId, body).subscribe({
+    this.markerService.create(controller, project.project_id, linkId, body).pipe(takeUntil(this.destroy$)).subscribe({
       next: () => {
         // Close the create form and return to the list — same behavior in the
         // selected-link and aggregate views. (The selected-link view previously
@@ -653,7 +656,7 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
     const project = this.project();
     if (!controller || !project) return;
     this.linkError.set(null);
-    this.markerService.delete(controller, project.project_id, linkId, name).subscribe({
+    this.markerService.delete(controller, project.project_id, linkId, name).pipe(takeUntil(this.destroy$)).subscribe({
       next: () => {
         this.refreshLink(linkId);
         this.loadAggregate();
@@ -712,7 +715,7 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
     const dir = this.dirToBody(v.direction);
     if (dir) body.direction = dir;
 
-    this.markerService.update(controller, project.project_id, linkId, editing.name, body).subscribe({
+    this.markerService.update(controller, project.project_id, linkId, editing.name, body).pipe(takeUntil(this.destroy$)).subscribe({
       next: () => {
         this.editingMarker.set(null);
         this.refreshLink(linkId);
@@ -730,7 +733,7 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
     const controller = this.controller();
     const project = this.project();
     if (!controller || !project) return;
-    this.linkService.getLink(controller, project.project_id, linkId).subscribe({
+    this.linkService.getLink(controller, project.project_id, linkId).pipe(takeUntil(this.destroy$)).subscribe({
       next: (link) => {
         this.linksDataSource.update(link);
         const mapLink = this.mapLinksDataSource.get(linkId);

--- a/src/app/components/project-map/marker-manager/marker-manager.component.ts
+++ b/src/app/components/project-map/marker-manager/marker-manager.component.ts
@@ -58,6 +58,7 @@ interface DefinitionRow {
   color: string | null;
   highlight_duration: number | null;
   direction: 'tx' | 'rx' | null;
+  data_link_type: string;
   linkCount: number;
   paused: boolean;
 }
@@ -240,6 +241,9 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
       validators: [Validators.required, Validators.min(1)],
     }),
     direction: new UntypedFormControl('both'),
+    // `null` ⇒ Ethernet-only definition (serial links skipped). A WAN value makes the
+    // definition also cover serial links of that encapsulation; Ethernet stays EN10MB.
+    data_link_type: new UntypedFormControl(null),
   });
 
   readonly markerForm = new UntypedFormGroup({
@@ -252,6 +256,9 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
       validators: [Validators.required, Validators.min(1)],
     }),
     direction: new UntypedFormControl('both'),
+    // `null` on Ethernet (picker hidden, backend defaults to DLT_EN10MB); seeded with the
+    // first WAN encapsulation when the form opens on a serial link (see toggleAddMarker).
+    data_link_type: new UntypedFormControl(null),
     capture_node_id: new UntypedFormControl(null),
   });
 
@@ -265,8 +272,24 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
       validators: [Validators.required, Validators.min(1)],
     }),
     direction: new UntypedFormControl('both'),
+    // Create-only on per-link markers — disabled in edit (recreate to switch encapsulation).
+    data_link_type: new UntypedFormControl({ value: 'DLT_EN10MB', disabled: true }),
     capture_node_id: new UntypedFormControl({ value: null, disabled: true }),
   });
+
+  /**
+   * WAN encapsulations — the only options offered in the marker forms. Setting one
+   * on a definition/per-link serial marker makes it decode serial traffic; leaving
+   * it unset means Ethernet-only (the server's default DLT_EN10MB). Same values the
+   * capture dialog uses (`start-capture.component.ts`). Cisco PPP is
+   * `DLT_PPP_SERIAL` (50), not raw `DLT_PPP` (9).
+   */
+  readonly serialDataLinkTypes: readonly { label: string; value: string }[] = [
+    { label: 'Cisco HDLC', value: 'DLT_C_HDLC' },
+    { label: 'Cisco PPP', value: 'DLT_PPP_SERIAL' },
+    { label: 'Frame Relay', value: 'DLT_FRELAY' },
+    { label: 'ATM', value: 'DLT_ATM_RFC1483' },
+  ];
 
   private boundaryService = inject(WindowBoundaryService);
   private windowManagement = inject(WindowManagementService);
@@ -398,6 +421,8 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
       color: d.color ?? null,
       highlight_duration: d.highlight_duration ?? null,
       direction: (d.direction as 'tx' | 'rx' | null) ?? null,
+      // Normalize EN10MB → null so the picker shows "Ethernet only" (blank) for defaults.
+      data_link_type: d.data_link_type && d.data_link_type !== 'DLT_EN10MB' ? d.data_link_type : null,
       linkCount: d.link_ids?.length ?? 0,
       paused: d.paused ?? false,
     }));
@@ -449,6 +474,11 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
     return this.nodesDataSource.get(nodeId)?.name ?? nodeId;
   }
 
+  /** The protocol link_type of a link (`'ethernet'` / `'serial'`; defaults to ethernet). */
+  linkTypeOf(linkId: string): string {
+    return this.linksDataSource.get(linkId)?.link_type ?? 'ethernet';
+  }
+
   // ---- definitions CRUD ----
 
   submitDefinition() {
@@ -471,6 +501,7 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
     if (hd !== null) body.highlight_duration = hd;
     const dir = this.dirToBody(v.direction);
     if (dir) body.direction = dir;
+    if (v.data_link_type) body.data_link_type = v.data_link_type;
 
     const editing = this.editingDefinition();
     const done = () => {
@@ -510,6 +541,7 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
       color: row.color,
       highlight_duration: row.highlight_duration,
       direction: this.dirFromMarker(row.direction),
+      data_link_type: row.data_link_type ?? null,
     });
     // Name is immutable on update; disable to communicate that.
     this.definitionForm.get('name')?.disable();
@@ -662,6 +694,11 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
     this.editingMarker.set(null);
     if (opening) this.expandGroup(linkId);
     this.markerForm.reset();
+    // A serial link needs a WAN encapsulation; default to the first one (Cisco HDLC),
+    // matching the capture dialog's auto-select. Ethernet links leave it null (hidden).
+    if (opening && this.linkTypeOf(linkId) === 'serial') {
+      this.markerForm.get('data_link_type')?.setValue(this.serialDataLinkTypes[0]?.value ?? null);
+    }
     this.linkError.set(null);
     this.cdr.markForCheck();
   }
@@ -687,6 +724,7 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
     const dir = this.dirToBody(v.direction);
     if (dir) body.direction = dir;
     if (v.capture_node_id) body.capture_node_id = v.capture_node_id;
+    if (v.data_link_type) body.data_link_type = v.data_link_type;
 
     this.markerService.create(controller, project.project_id, linkId, body).pipe(takeUntil(this.destroy$)).subscribe({
       next: () => {
@@ -741,9 +779,12 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
       color: marker.color ?? null,
       highlight_duration: marker.highlight_duration ?? 800,
       direction: this.dirFromMarker(marker.direction),
+      data_link_type: marker.data_link_type ?? 'DLT_EN10MB',
       capture_node_id: marker.capture_node_id ?? null,
     });
     this.markerEditForm.get('name')?.disable();
+    // data_link_type is create-only on per-link markers — keep it disabled in edit.
+    this.markerEditForm.get('data_link_type')?.disable();
     this.markerEditForm.get('capture_node_id')?.disable();
     this.cdr.markForCheck();
   }

--- a/src/app/components/project-map/marker-manager/marker-manager.component.ts
+++ b/src/app/components/project-map/marker-manager/marker-manager.component.ts
@@ -171,6 +171,16 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
   readonly togglingDefinition = signal<string | null>(null);
   /** `${linkId}/${name}` of the per-marker enable request in flight — guards + drives that row's spinner. */
   readonly togglingMarker = signal<string | null>(null);
+  /** Definition name whose delete request is in flight — drives that row's spinner. */
+  readonly deletingDefinition = signal<string | null>(null);
+  /** Whether the definition create/update form is currently submitting. */
+  readonly submittingDefinition = signal(false);
+  /** `${linkId}/${name}` of the per-marker delete request in flight — drives that row's spinner. */
+  readonly deletingMarker = signal<string | null>(null);
+  /** linkId whose per-marker create form is currently submitting. */
+  readonly submittingMarker = signal<string | null>(null);
+  /** Whether the per-marker edit form is currently submitting. */
+  readonly submittingEditMarker = signal(false);
   // ---- Node selector (first step in Links tab) ----
   /** Node options (id + display name). Built once from NodesDataSource. */
   readonly nodeOptions = signal<{ id: string; name: string }[]>([]);
@@ -450,6 +460,7 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
     const project = this.project();
     if (!controller || !project) return;
     this.defError.set(null);
+    this.submittingDefinition.set(true);
 
     const v = this.definitionForm.getRawValue();
     const body: MarkerDefinitionCreateBody = { name: v.name.trim(), bpf: v.bpf.trim() };
@@ -463,6 +474,7 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
 
     const editing = this.editingDefinition();
     const done = () => {
+      this.submittingDefinition.set(false);
       this.cancelEditDefinition();
       this.loadDefinitions();
       // The fan-out emits link.updated → registry reconciles (legend/icons); also refresh
@@ -470,6 +482,7 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
       this.loadAggregate();
     };
     const fail = (err: any) => {
+      this.submittingDefinition.set(false);
       this.defError.set(err.error?.message || err.message || 'Failed to save definition');
       this.cdr.markForCheck();
     };
@@ -515,14 +528,19 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
     const controller = this.controller();
     const project = this.project();
     if (!controller || !project) return;
+    // Guard against double-fires while a delete is already in flight.
+    if (this.deletingDefinition() === row.name) return;
     this.defError.set(null);
+    this.deletingDefinition.set(row.name);
     this.markerService.deleteDefinition(controller, project.project_id, row.name).pipe(takeUntil(this.destroy$)).subscribe({
       next: () => {
+        this.deletingDefinition.set(null);
         if (this.editingDefinition() === row.name) this.cancelEditDefinition();
         this.loadDefinitions();
         this.loadAggregate();
       },
       error: (err) => {
+        this.deletingDefinition.set(null);
         this.defError.set(err.error?.message || err.message || 'Failed to delete definition');
         this.cdr.markForCheck();
       },
@@ -599,6 +617,11 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
     return this.togglingMarker() === `${linkId}/${name}`;
   }
 
+  /** Whether a per-marker delete request is in flight for this marker (drives its spinner). */
+  isDeletingMarker(linkId: string, name: string): boolean {
+    return this.deletingMarker() === `${linkId}/${name}`;
+  }
+
   /** Toggle a link group's collapsed state (click on its header). */
   toggleGroup(linkId: string) {
     const next = new Set(this.collapsedGroups());
@@ -636,6 +659,7 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
     const project = this.project();
     if (!controller || !project) return;
     this.linkError.set(null);
+    this.submittingMarker.set(linkId);
 
     const v = this.markerForm.getRawValue();
     const body: MarkerWriteBody = { bpf: v.bpf.trim(), name: v.name.trim() };
@@ -650,6 +674,7 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
 
     this.markerService.create(controller, project.project_id, linkId, body).pipe(takeUntil(this.destroy$)).subscribe({
       next: () => {
+        this.submittingMarker.set(null);
         // Close the create form and return to the list — same behavior in the
         // selected-link and aggregate views. (The selected-link view previously
         // kept the form open via markerForm.reset().)
@@ -658,6 +683,7 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
         this.loadAggregate();
       },
       error: (err) => {
+        this.submittingMarker.set(null);
         this.linkError.set(err.error?.message || err.message || 'Failed to create marker');
         this.cdr.markForCheck();
       },
@@ -668,13 +694,18 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
     const controller = this.controller();
     const project = this.project();
     if (!controller || !project) return;
+    const key = `${linkId}/${name}`;
+    if (this.deletingMarker() === key) return;
     this.linkError.set(null);
+    this.deletingMarker.set(key);
     this.markerService.delete(controller, project.project_id, linkId, name).pipe(takeUntil(this.destroy$)).subscribe({
       next: () => {
+        this.deletingMarker.set(null);
         this.refreshLink(linkId);
         this.loadAggregate();
       },
       error: (err) => {
+        this.deletingMarker.set(null);
         this.linkError.set(err.error?.message || err.message || 'Failed to delete marker');
         this.cdr.markForCheck();
       },
@@ -717,6 +748,7 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
     const project = this.project();
     if (!controller || !project) return;
     this.linkError.set(null);
+    this.submittingEditMarker.set(true);
 
     const v = this.markerEditForm.getRawValue();
     const body: MarkerWriteBody = { bpf: v.bpf.trim() };
@@ -730,11 +762,13 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
 
     this.markerService.update(controller, project.project_id, linkId, editing.name, body).pipe(takeUntil(this.destroy$)).subscribe({
       next: () => {
+        this.submittingEditMarker.set(false);
         this.editingMarker.set(null);
         this.refreshLink(linkId);
         this.loadAggregate();
       },
       error: (err) => {
+        this.submittingEditMarker.set(false);
         this.linkError.set(err.error?.message || err.message || 'Failed to update marker');
         this.cdr.markForCheck();
       },

--- a/src/app/components/project-map/marker-manager/marker-manager.component.ts
+++ b/src/app/components/project-map/marker-manager/marker-manager.component.ts
@@ -26,6 +26,7 @@ import { MatAutocompleteModule } from '@angular/material/autocomplete';
 import { MatSelectModule } from '@angular/material/select';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatDividerModule } from '@angular/material/divider';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { CdkTextareaAutosize } from '@angular/cdk/text-field';
 import { Subject, animationFrameScheduler, fromEvent } from 'rxjs';
 import { auditTime, switchMap, takeUntil, tap } from 'rxjs/operators';
@@ -109,6 +110,7 @@ function notGlobalName(control: UntypedFormControl): { notGlobalName: true } | n
     MatSelectModule,
     MatTooltipModule,
     MatDividerModule,
+    MatProgressSpinnerModule,
     CdkTextareaAutosize,
     ResizableDirective,
     ResizeHandleDirective,
@@ -165,8 +167,10 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
   readonly editingMarker = signal<{ linkId: string; name: string } | null>(null);
   /** LinkIds whose marker list is collapsed in the aggregate Links view. */
   readonly collapsedGroups = signal<Set<string>>(new Set());
-  /** Definition name whose pause/resume request is in flight — disables just that row's button. */
+  /** Definition name whose pause/resume request is in flight — guards double-fires + drives that row's spinner. */
   readonly togglingDefinition = signal<string | null>(null);
+  /** `${linkId}/${name}` of the per-marker enable request in flight — guards + drives that row's spinner. */
+  readonly togglingMarker = signal<string | null>(null);
   // ---- Node selector (first step in Links tab) ----
   /** Node options (id + display name). Built once from NodesDataSource. */
   readonly nodeOptions = signal<{ id: string; name: string }[]>([]);
@@ -590,6 +594,11 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
     return this.collapsedGroups().has(linkId);
   }
 
+  /** Whether a per-marker enable request is in flight for this marker (drives its spinner). */
+  isTogglingMarker(linkId: string, name: string): boolean {
+    return this.togglingMarker() === `${linkId}/${name}`;
+  }
+
   /** Toggle a link group's collapsed state (click on its header). */
   toggleGroup(linkId: string) {
     const next = new Set(this.collapsedGroups());
@@ -740,13 +749,11 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
     const project = this.project();
     if (!controller || !project) return;
     const wantPaused = !row.paused;
-    // Optimistically flip the row so the icon reacts instantly. We deliberately do NOT
-    // call loadDefinitions() on success — it sets `loading`, flashing the "Loading…"
-    // block and re-rendering the whole list (the "refresh" blink). The 204 confirms the
-    // server persisted `paused`, so the optimistic value is authoritative; loadAggregate
-    // still refreshes the Links tab, whose inherited copies flip `enabled` with the rule.
-    // Mirrors toggleMarkerEnabled / applyEnabledLocal (which never hit a loading flag).
-    this.applyDefinitionPausedLocal(row.name, wantPaused);
+    // Show the row's spinner while the request is in flight; don't touch the icon until
+    // the server confirms (204) — the displayed state is always authoritative. We never
+    // call loadDefinitions() here: it sets `loading` and flashes the "Loading…" block /
+    // re-renders the whole list. The 204 confirms `paused`, so we set it locally on
+    // success; loadAggregate refreshes the Links tab's inherited copies.
     this.togglingDefinition.set(row.name);
     const req$ = wantPaused
       ? this.markerService.pauseDefinition(controller, project.project_id, row.name)
@@ -754,11 +761,11 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
     req$.pipe(takeUntil(this.destroy$)).subscribe({
       next: () => {
         this.togglingDefinition.set(null);
+        this.applyDefinitionPausedLocal(row.name, wantPaused);
         this.loadAggregate();
       },
       error: (err) => {
         this.togglingDefinition.set(null);
-        this.applyDefinitionPausedLocal(row.name, !wantPaused); // revert optimistic flip
         this.defError.set(err.error?.message || err.message || 'Failed to toggle definition');
         this.cdr.markForCheck();
       },
@@ -780,22 +787,26 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
     const controller = this.controller();
     const project = this.project();
     if (!controller || !project) return;
+    // Guard against double-fires while a toggle is already in flight.
+    if (this.isTogglingMarker(linkId, marker.name)) return;
 
     // `enabled` defaults to true when undefined; only an explicit `false` is "off".
     const nextEnabled = marker.enabled === false;
-    // Optimistically flip the local row so the icon reacts before the round-trip.
-    this.applyEnabledLocal(linkId, marker.name, nextEnabled);
-
+    // Show the row's spinner while in flight; flip the icon only after the server
+    // confirms, so the displayed state is always authoritative.
+    this.togglingMarker.set(`${linkId}/${marker.name}`);
     this.markerService
       .setEnabled(controller, project.project_id, linkId, marker.name, nextEnabled)
       .pipe(takeUntil(this.destroy$))
       .subscribe({
         next: () => {
+          this.togglingMarker.set(null);
+          this.applyEnabledLocal(linkId, marker.name, nextEnabled);
           this.refreshLink(linkId);
           this.loadAggregate();
         },
         error: (err) => {
-          this.applyEnabledLocal(linkId, marker.name, !nextEnabled); // revert optimistic flip
+          this.togglingMarker.set(null);
           this.toasterService.error(err.error?.message || err.message || 'Failed to toggle marker');
           this.cdr.markForCheck();
         },

--- a/src/app/components/project-map/marker-manager/marker-manager.component.ts
+++ b/src/app/components/project-map/marker-manager/marker-manager.component.ts
@@ -48,6 +48,7 @@ import { MarkerRegistryService } from '@services/marker-registry.service';
 import { ToasterService } from '@services/toaster.service';
 import { WindowBoundaryService, WindowStyle } from '@services/window-boundary.service';
 import { WindowManagementService } from '@services/window-management.service';
+import { MarkerFormComponent } from './marker-form.component';
 
 interface DefinitionRow {
   name: string;
@@ -110,6 +111,7 @@ function notGlobalName(control: UntypedFormControl): { notGlobalName: true } | n
     CdkTextareaAutosize,
     ResizableDirective,
     ResizeHandleDirective,
+    MarkerFormComponent,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
@@ -160,6 +162,8 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
   readonly addingToLink = signal<string | null>(null);
   /** Marker currently being edited: { linkId, name }. */
   readonly editingMarker = signal<{ linkId: string; name: string } | null>(null);
+  /** LinkIds whose marker list is collapsed in the aggregate Links view. */
+  readonly collapsedGroups = signal<Set<string>>(new Set());
   // ---- Node selector (first step in Links tab) ----
   /** Node options (id + display name). Built once from NodesDataSource. */
   readonly nodeOptions = signal<{ id: string; name: string }[]>([]);
@@ -211,8 +215,11 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
     bpf: new UntypedFormControl('', [Validators.required]),
     tag: new UntypedFormControl(null),
     color: new UntypedFormControl(null),
-    highlight_duration: new UntypedFormControl(800, [Validators.required, Validators.min(1)]),
-    direction: new UntypedFormControl(null),
+    highlight_duration: new UntypedFormControl(800, {
+      nonNullable: true,
+      validators: [Validators.required, Validators.min(1)],
+    }),
+    direction: new UntypedFormControl('both'),
   });
 
   readonly markerForm = new UntypedFormGroup({
@@ -220,8 +227,12 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
     bpf: new UntypedFormControl('', [Validators.required]),
     tag: new UntypedFormControl(null),
     color: new UntypedFormControl(null),
-    highlight_duration: new UntypedFormControl(800, [Validators.required, Validators.min(1)]),
-    direction: new UntypedFormControl(null),
+    highlight_duration: new UntypedFormControl(800, {
+      nonNullable: true,
+      validators: [Validators.required, Validators.min(1)],
+    }),
+    direction: new UntypedFormControl('both'),
+    capture_node_id: new UntypedFormControl(null),
   });
 
   readonly markerEditForm = new UntypedFormGroup({
@@ -229,8 +240,12 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
     bpf: new UntypedFormControl('', [Validators.required]),
     tag: new UntypedFormControl(null),
     color: new UntypedFormControl(null),
-    highlight_duration: new UntypedFormControl(800, [Validators.required, Validators.min(1)]),
-    direction: new UntypedFormControl(null),
+    highlight_duration: new UntypedFormControl(800, {
+      nonNullable: true,
+      validators: [Validators.required, Validators.min(1)],
+    }),
+    direction: new UntypedFormControl('both'),
+    capture_node_id: new UntypedFormControl({ value: null, disabled: true }),
   });
 
   private boundaryService = inject(WindowBoundaryService);
@@ -397,6 +412,22 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
     return `${src.name} ${sLabel} → ${dst.name} ${dLabel}`.replace(/\s+/g, ' ').trim();
   }
 
+  /** Endpoint nodes of a link — options for the per-link "Capture node" dropdown. */
+  linkEndpoints(linkId: string): { id: string; name: string }[] {
+    const link = this.linksDataSource.get(linkId);
+    const nodes = link?.nodes;
+    if (!nodes || nodes.length === 0) return [];
+    return nodes.map((n) => {
+      const node = this.nodesDataSource.get(n.node_id);
+      return { id: n.node_id, name: node?.name ?? n.node_id };
+    });
+  }
+
+  /** Resolve a node id to its display name (falls back to the raw id). */
+  nodeName(nodeId: string): string {
+    return this.nodesDataSource.get(nodeId)?.name ?? nodeId;
+  }
+
   // ---- definitions CRUD ----
 
   submitDefinition() {
@@ -416,7 +447,8 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
     if (v.color) body.color = v.color;
     const hd = this.asNumber(v.highlight_duration);
     if (hd !== null) body.highlight_duration = hd;
-    if (v.direction) body.direction = v.direction;
+    const dir = this.dirToBody(v.direction);
+    if (dir) body.direction = dir;
 
     const editing = this.editingDefinition();
     const done = () => {
@@ -453,7 +485,7 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
       tag: row.tag,
       color: row.color,
       highlight_duration: row.highlight_duration,
-      direction: row.direction,
+      direction: this.dirFromMarker(row.direction),
     });
     // Name is immutable on update; disable to communicate that.
     this.definitionForm.get('name')?.disable();
@@ -514,6 +546,23 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
     this.cdr.markForCheck();
   }
 
+  /**
+   * `displayWith` for the node autocomplete — maps the selected value (node id) back to
+   * its display name. Without this, mat-autocomplete writes the raw `[value]` (the UUID)
+   * into the input; on repeat selection of the same option the signal doesn't notify
+   * (equal value ⇒ no CD), so the `[value]` binding never overwrites it and the UUID sticks.
+   */
+  displayNode = (id: string | null): string => {
+    if (!id) return '';
+    return this.nodeOptions().find((o) => o.id === id)?.name ?? id;
+  };
+
+  /** `displayWith` for the link autocomplete — maps the selected link id to its display name. */
+  displayLink = (id: string | null): string => {
+    if (!id) return '';
+    return this.linkName(id);
+  };
+
   /** Clear autocomplete inputs and return to the aggregate view. */
   resetLinkSelect() {
     this.selectedNodeId.set(null);
@@ -524,8 +573,34 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
     this.cdr.markForCheck();
   }
 
+  /** Whether a link group's marker list is collapsed in the aggregate view. */
+  isGroupCollapsed(linkId: string): boolean {
+    return this.collapsedGroups().has(linkId);
+  }
+
+  /** Toggle a link group's collapsed state (click on its header). */
+  toggleGroup(linkId: string) {
+    const next = new Set(this.collapsedGroups());
+    if (next.has(linkId)) next.delete(linkId);
+    else next.add(linkId);
+    this.collapsedGroups.set(next);
+  }
+
+  /** Ensure a group is expanded — used when opening its add/edit form so the form isn't hidden. */
+  private expandGroup(linkId: string) {
+    if (this.collapsedGroups().has(linkId)) {
+      const next = new Set(this.collapsedGroups());
+      next.delete(linkId);
+      this.collapsedGroups.set(next);
+    }
+  }
+
   toggleAddMarker(linkId: string) {
-    this.addingToLink.set(this.addingToLink() === linkId ? null : linkId);
+    const opening = this.addingToLink() !== linkId;
+    this.addingToLink.set(opening ? linkId : null);
+    // Add and edit are mutually exclusive — opening the add form closes any open edit.
+    this.editingMarker.set(null);
+    if (opening) this.expandGroup(linkId);
     this.markerForm.reset();
     this.linkError.set(null);
     this.cdr.markForCheck();
@@ -548,7 +623,9 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
     if (v.color) body.color = v.color;
     const hd = this.asNumber(v.highlight_duration);
     if (hd !== null) body.highlight_duration = hd;
-    if (v.direction) body.direction = v.direction;
+    const dir = this.dirToBody(v.direction);
+    if (dir) body.direction = dir;
+    if (v.capture_node_id) body.capture_node_id = v.capture_node_id;
 
     this.markerService.create(controller, project.project_id, linkId, body).subscribe({
       next: () => {
@@ -586,6 +663,9 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
 
   startEditMarker(linkId: string, marker: GroupMarker) {
     this.editingMarker.set({ linkId, name: marker.name });
+    // Add and edit are mutually exclusive — opening an edit closes any open add form.
+    this.addingToLink.set(null);
+    this.expandGroup(linkId);
     this.linkError.set(null);
     this.markerEditForm.reset({
       name: marker.name,
@@ -593,9 +673,11 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
       tag: marker.tag ?? null,
       color: marker.color ?? null,
       highlight_duration: marker.highlight_duration ?? 800,
-      direction: marker.direction ?? null,
+      direction: this.dirFromMarker(marker.direction),
+      capture_node_id: marker.capture_node_id ?? null,
     });
     this.markerEditForm.get('name')?.disable();
+    this.markerEditForm.get('capture_node_id')?.disable();
     this.cdr.markForCheck();
   }
 
@@ -623,7 +705,8 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
     if (v.color) body.color = v.color;
     const hd = this.asNumber(v.highlight_duration);
     if (hd !== null) body.highlight_duration = hd;
-    if (v.direction) body.direction = v.direction;
+    const dir = this.dirToBody(v.direction);
+    if (dir) body.direction = dir;
 
     this.markerService.update(controller, project.project_id, linkId, editing.name, body).subscribe({
       next: () => {
@@ -662,6 +745,20 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
     if (v === null || v === undefined || v === '') return null;
     const n = Number(v);
     return isNaN(n) ? null : n;
+  }
+
+  /**
+   * Map a form direction value to the backend value. The form uses the `'both'` sentinel
+   * because mat-select clears its selection model on `null` — a null-valued option never
+   * displays in the trigger. `'both'` maps to absent/null (both directions) on the wire.
+   */
+  private dirToBody(d: unknown): 'tx' | 'rx' | null {
+    return d === 'tx' || d === 'rx' ? d : null;
+  }
+
+  /** Map a stored/backend direction back to the form value (`null`/`undefined` → `'both'`). */
+  private dirFromMarker(d: 'tx' | 'rx' | null | undefined): 'both' | 'tx' | 'rx' {
+    return d === 'tx' || d === 'rx' ? d : 'both';
   }
 
   // ---- window chrome (cloned from node-file-manager-inline) ----

--- a/src/app/handlers/project-web-service-handler.spec.ts
+++ b/src/app/handlers/project-web-service-handler.spec.ts
@@ -510,7 +510,7 @@ describe('ProjectWebServiceHandler', () => {
       handler.handleMessage(message);
 
       expect(mockLinksDataSource.get).toHaveBeenCalledWith('l-1');
-      expect(mockMarkerFlashService.flash).toHaveBeenCalledWith('l-1', 'red', null);
+      expect(mockMarkerFlashService.flash).toHaveBeenCalledWith('l-1', 'red', null, null, 'n-1');
     });
 
     it('should flash with null when marker has no color', () => {
@@ -523,7 +523,7 @@ describe('ProjectWebServiceHandler', () => {
 
       handler.handleMessage(message);
 
-      expect(mockMarkerFlashService.flash).toHaveBeenCalledWith('l-2', null, null);
+      expect(mockMarkerFlashService.flash).toHaveBeenCalledWith('l-2', null, null, null, 'n-1');
     });
 
     it('should pass the marker highlight_duration to flash', () => {
@@ -536,7 +536,50 @@ describe('ProjectWebServiceHandler', () => {
 
       handler.handleMessage(message);
 
-      expect(mockMarkerFlashService.flash).toHaveBeenCalledWith('l-3', null, 1200);
+      expect(mockMarkerFlashService.flash).toHaveBeenCalledWith('l-3', null, 1200, null, 'n-1');
+    });
+
+    it('should pass dir + node_id to flash for the direction arrow', () => {
+      const link = createMockLink('l-4');
+      link.markers = { 'marker-l4': { bpf: 'tcp' } } as any;
+      mockLinksDataSource.get = vi.fn().mockReturnValue(link);
+
+      const event = {
+        project_id: 'p-1',
+        node_id: 'n-4',
+        link_id: 'l-4',
+        filter: 'marker-l4',
+        tag: null,
+        ts: 1,
+        len: 64,
+        dir: 'rx',
+      };
+      const message: WebServiceMessage = { action: 'marker.match', event };
+
+      handler.handleMessage(message);
+
+      expect(mockMarkerFlashService.flash).toHaveBeenCalledWith('l-4', null, null, 'rx', 'n-4');
+    });
+
+    it('should pass null dir when the event omits it (legacy uBridge)', () => {
+      const link = createMockLink('l-5');
+      link.markers = { 'marker-l5': { bpf: 'tcp' } } as any;
+      mockLinksDataSource.get = vi.fn().mockReturnValue(link);
+
+      const event = {
+        project_id: 'p-1',
+        node_id: 'n-5',
+        link_id: 'l-5',
+        filter: 'marker-l5',
+        tag: null,
+        ts: 1,
+        len: 64,
+      };
+      const message: WebServiceMessage = { action: 'marker.match', event };
+
+      handler.handleMessage(message);
+
+      expect(mockMarkerFlashService.flash).toHaveBeenCalledWith('l-5', null, null, null, 'n-5');
     });
   });
 

--- a/src/app/handlers/project-web-service-handler.ts
+++ b/src/app/handlers/project-web-service-handler.ts
@@ -67,13 +67,16 @@ export class ProjectWebServiceHandler {
       const event = message.event as MarkerMatchEvent;
       // Resolve the marker's color + highlight_duration from link state (event carries
       // neither). `filter` is the marker name; null color ⇒ default theme color;
-      // null duration ⇒ UI default (see MarkerFlashService).
+      // null duration ⇒ UI default (see MarkerFlashService). `dir` + `node_id` orient
+      // the direction arrow; null/absent `dir` (old uBridge) ⇒ flash without arrow.
       const link = this.linksDataSource.get(event.link_id);
       const marker = link?.markers?.[event.filter];
       this.markerFlashService.flash(
         event.link_id,
         marker?.color ?? null,
-        marker?.highlight_duration ?? null
+        marker?.highlight_duration ?? null,
+        event.dir ?? null,
+        event.node_id
       );
     }
     if (message.action === 'drawing.created') {

--- a/src/app/models/marker.ts
+++ b/src/app/models/marker.ts
@@ -67,8 +67,8 @@ export interface MarkerDefinitionCreateBody {
   tag?: number | null;
   color?: string;
   highlight_duration?: number | null;
-  /** Optional direction filter (same semantics as {@link Marker.direction}). */
-  direction?: 'tx' | 'rx' | null;
+  /** Optional direction filter: `"tx"` | `"rx"` | `"both"` | null. */
+  direction?: 'tx' | 'rx' | 'both' | null;
 }
 
 /**

--- a/src/app/models/marker.ts
+++ b/src/app/models/marker.ts
@@ -20,6 +20,13 @@ export interface Marker {
    * receiving only), or `null`/absent (both directions — default).
    */
   direction?: 'tx' | 'rx' | null;
+  /**
+   * Link-layer encapsulation for capture/pcap decode (uBridge DLT value).
+   * Defaults to `"DLT_EN10MB"` (Ethernet). Set to a WAN value — `"DLT_C_HDLC"`,
+   * `"DLT_PPP_SERIAL"`, `"DLT_FRELAY"`, `"DLT_ATM_RFC1483"` — so the BPF match
+   * and pcap decode against a serial link's IOS encapsulation.
+   */
+  data_link_type?: string;
   /** Capture-side node chosen by the server. */
   capture_node_id?: string;
   capture_adapter?: number;
@@ -46,6 +53,13 @@ export interface MarkerDefinition {
   highlight_duration?: number | null;
   /** Optional direction filter (same semantics as {@link Marker.direction}). */
   direction?: 'tx' | 'rx' | null;
+  /**
+   * Link-layer encapsulation (uBridge DLT). Defaults to `"DLT_EN10MB"` (Ethernet
+   * only — serial links are skipped). A WAN value also covers serial links of that
+   * encapsulation while Ethernet links stay EN10MB, so one definition can serve a
+   * mixed topology. Updatable (the server re-fans-out).
+   */
+  data_link_type?: string;
   /** Links currently carrying an inherited copy (GET only). */
   link_ids?: string[];
   /**
@@ -69,6 +83,8 @@ export interface MarkerDefinitionCreateBody {
   highlight_duration?: number | null;
   /** Optional direction filter: `"tx"` | `"rx"` | `"both"` | null. */
   direction?: 'tx' | 'rx' | 'both' | null;
+  /** Link-layer encapsulation (uBridge DLT). Defaults to `"DLT_EN10MB"` (Ethernet). */
+  data_link_type?: string;
 }
 
 /**

--- a/src/app/models/marker.ts
+++ b/src/app/models/marker.ts
@@ -48,6 +48,13 @@ export interface MarkerDefinition {
   direction?: 'tx' | 'rx' | null;
   /** Links currently carrying an inherited copy (GET only). */
   link_ids?: string[];
+  /**
+   * Server-authoritative, persisted pause state: when true, every inherited copy this
+   * definition fanned out is disabled (signal + pcap off, traffic still forwards). Flipped
+   * by POST /marker-definitions/{name}/{pause|resume}; read back via GET /marker-definitions.
+   * Links inheriting a paused definition start disabled.
+   */
+  paused?: boolean;
 }
 
 /** Definitions keyed by name. */

--- a/src/app/models/marker.ts
+++ b/src/app/models/marker.ts
@@ -70,8 +70,8 @@ export type AggregateMarkerMap = { [key: string]: AggregateMarkerEntry };
 /**
  * Wire shape of the `marker.match` project WebSocket event.
  * The `filter` field IS the marker name (per backend contract).
- * `node_id` is the capture-side node; it is received but not highlighted
- * (per the feature's visualization decision — only the link flashes).
+ * `node_id` is the capture-side node (one of the link's two endpoints);
+ * it is not highlighted itself — it orients the direction arrow.
  */
 export interface MarkerMatchEvent {
   project_id: string;
@@ -81,4 +81,13 @@ export interface MarkerMatchEvent {
   tag?: number | null;
   ts: number;
   len: number;
+  /**
+   * Traffic direction relative to the capture node (`node_id`):
+   *  - `"tx"` → capture node is sending → flow is capture → peer
+   *  - `"rx"` → capture node is receiving → flow is peer → capture
+   *
+   * Absent or `null` for old uBridge builds that don't report direction;
+   * in that case the link flashes without an arrow (legacy behaviour).
+   */
+  dir?: 'tx' | 'rx' | null;
 }

--- a/src/app/models/marker.ts
+++ b/src/app/models/marker.ts
@@ -15,6 +15,11 @@ export interface Marker {
   highlight_duration?: number | null;
   /** Source definition name — present on inherited markers only (`null` for private). */
   inherited_from?: string | null;
+  /**
+   * Optional direction filter: `"tx"` (capture sending only), `"rx"` (capture
+   * receiving only), or `null`/absent (both directions — default).
+   */
+  direction?: 'tx' | 'rx' | null;
   /** Capture-side node chosen by the server. */
   capture_node_id?: string;
   capture_adapter?: number;
@@ -39,6 +44,8 @@ export interface MarkerDefinition {
   tag?: number | null;
   color?: string | null;
   highlight_duration?: number | null;
+  /** Optional direction filter (same semantics as {@link Marker.direction}). */
+  direction?: 'tx' | 'rx' | null;
   /** Links currently carrying an inherited copy (GET only). */
   link_ids?: string[];
 }
@@ -53,6 +60,8 @@ export interface MarkerDefinitionCreateBody {
   tag?: number | null;
   color?: string;
   highlight_duration?: number | null;
+  /** Optional direction filter (same semantics as {@link Marker.direction}). */
+  direction?: 'tx' | 'rx' | null;
 }
 
 /**

--- a/src/app/services/marker-flash.service.spec.ts
+++ b/src/app/services/marker-flash.service.spec.ts
@@ -3,15 +3,22 @@ import { describe, it, expect, beforeEach, beforeAll, afterAll, vi } from 'vites
 import { MarkerFlashService } from './marker-flash.service';
 
 /**
- * MarkerFlashService stores link state in the private `_flashing` signal (linkId → color)
- * and schedules a per-link续命 timer. We assert on that signal/timer behaviour directly;
- * the DOM side-effects (`.marker-pulse` + inline stroke) require an SVG and are exercised
- * manually instead.
+ * MarkerFlashService stores per-(linkId, dir) flash state in the `_flashing` signal
+ * and schedules independent per-slot续命 timers. We assert on the signal / timer
+ * behaviour directly; DOM side-effects require an SVG and are exercised manually.
  */
+
+/** Match the composite-key separator used in the service (null-byte). */
+const SEP = '\x00';
+const key = (linkId: string, dir: 'tx' | 'rx' | null = null) => `${linkId}${SEP}${dir ?? 'none'}`;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type StoredState = { color: string | null; dir: 'tx' | 'rx' | null; captureNodeId: string | null; _seq: number };
+
 describe('MarkerFlashService', () => {
   let service: MarkerFlashService;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const flashing = () => (service as any)._flashing() as ReadonlyMap<string, string | null>;
+  const flashing = () => (service as any)._flashing() as ReadonlyMap<string, StoredState>;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -21,13 +28,54 @@ describe('MarkerFlashService', () => {
 
   it('adds the link to the active set immediately on flash()', () => {
     service.flash('link-1', null);
-    expect(flashing().has('link-1')).toBe(true);
+    expect(flashing().has(key('link-1'))).toBe(true);
   });
 
   it('stores the latest color on repeat flash()', () => {
+    service.flash('link-1', 'red');
+    service.flash('link-1', 'blue');
+    expect(flashing().get(key('link-1'))?.color).toBe('blue');
+  });
+
+  it('stores dir + captureNodeId for the direction arrow', () => {
+    service.flash('link-1', null, null, 'tx', 'node-a');
+    const state = flashing().get(key('link-1', 'tx'));
+    expect(state?.dir).toBe('tx');
+    expect(state?.captureNodeId).toBe('node-a');
+  });
+
+  it('defaults dir + captureNodeId to null when omitted (legacy uBridge)', () => {
     service.flash('link-1', null);
-    service.flash('link-1', null);
-    expect(flashing().get('link-1')).toBeNull();
+    const state = flashing().get(key('link-1'));
+    expect(state?.dir).toBeNull();
+    expect(state?.captureNodeId).toBeNull();
+  });
+
+  /**
+   * Direction semantics (pure logic — the path is always drawn source→target).
+   * `dir` is relative to the capture node, so the arrow follows the path only for
+   * tx-from-source and rx-at-target; every other case points against the path.
+   */
+  describe('arrowPointsAlongPath (direction semantics)', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const arrowAlong = (dir: 'tx' | 'rx', capture: 'source' | 'target') =>
+      (MarkerFlashService as any).arrowPointsAlongPath(dir, capture === 'source', capture === 'target');
+
+    it('tx from the source end flows source→target (along the path)', () => {
+      expect(arrowAlong('tx', 'source')).toBe(true);
+    });
+
+    it('rx at the target end means peer(source)→capture(target) (along the path)', () => {
+      expect(arrowAlong('rx', 'target')).toBe(true);
+    });
+
+    it('tx from the target end flows target→source (against the path)', () => {
+      expect(arrowAlong('tx', 'target')).toBe(false);
+    });
+
+    it('rx at the source end means peer(target)→capture(source) (against the path)', () => {
+      expect(arrowAlong('rx', 'source')).toBe(false);
+    });
   });
 
   describe('with fake timers', () => {
@@ -37,19 +85,19 @@ describe('MarkerFlashService', () => {
     it('expires after the default 800ms', () => {
       service.flash('link-default', null);
       vi.advanceTimersByTime(799);
-      expect(flashing().has('link-default')).toBe(true);
+      expect(flashing().has(key('link-default'))).toBe(true);
       vi.advanceTimersByTime(2);
-      expect(flashing().has('link-default')).toBe(false);
+      expect(flashing().has(key('link-default'))).toBe(false);
     });
 
     it('honors a custom durationMs (1200ms)', () => {
       service.flash('link-custom', null, 1200);
       vi.advanceTimersByTime(800);
-      expect(flashing().has('link-custom')).toBe(true);
+      expect(flashing().has(key('link-custom'))).toBe(true);
       vi.advanceTimersByTime(399);
-      expect(flashing().has('link-custom')).toBe(true);
+      expect(flashing().has(key('link-custom'))).toBe(true);
       vi.advanceTimersByTime(2);
-      expect(flashing().has('link-custom')).toBe(false);
+      expect(flashing().has(key('link-custom'))).toBe(false);
     });
 
     it('续命: a repeat flash within the window resets the timer', () => {
@@ -57,9 +105,44 @@ describe('MarkerFlashService', () => {
       vi.advanceTimersByTime(500); // 300ms left on original
       service.flash('link-renew', null); // reset to a fresh 800ms
       vi.advanceTimersByTime(500); // original would have expired; reset still has 300ms
-      expect(flashing().has('link-renew')).toBe(true);
+      expect(flashing().has(key('link-renew'))).toBe(true);
       vi.advanceTimersByTime(300);
-      expect(flashing().has('link-renew')).toBe(false);
+      expect(flashing().has(key('link-renew'))).toBe(false);
+    });
+
+    it('方向变化不续命: tx and rx coexist with independent timers', () => {
+      // tx at t=0, rx at t=200
+      service.flash('link-1', null, null, 'tx', 'node-a');
+      vi.advanceTimersByTime(200);
+      service.flash('link-1', null, null, 'rx', 'node-b');
+
+      // Both active right after the rx call.
+      expect(flashing().has(key('link-1', 'tx'))).toBe(true);
+      expect(flashing().has(key('link-1', 'rx'))).toBe(true);
+
+      // tx timer (800ms, set at t=0) expires at t=800. Advance past it.
+      vi.advanceTimersByTime(601); // total 801ms elapsed
+      expect(flashing().has(key('link-1', 'tx'))).toBe(false);
+      expect(flashing().has(key('link-1', 'rx'))).toBe(true);
+
+      // rx timer (800ms, set at t=200) expires at t=1000.
+      vi.advanceTimersByTime(200); // total 1001ms elapsed
+      expect(flashing().has(key('link-1', 'rx'))).toBe(false);
+    });
+
+    it('续命 only for same direction, not across directions', () => {
+      service.flash('link-1', 'red', null, 'tx', 'node-a');
+      vi.advanceTimersByTime(700); // 100ms left on tx
+      // Different direction — should NOT reset tx timer.
+      service.flash('link-1', 'blue', null, 'rx', 'node-b');
+      // tx still has its original timer
+      vi.advanceTimersByTime(101); // tx expired, rx still active
+      expect(flashing().has(key('link-1', 'tx'))).toBe(false);
+      expect(flashing().has(key('link-1', 'rx'))).toBe(true);
+      // Same direction should续命
+      service.flash('link-1', null, null, 'rx', 'node-b');
+      vi.advanceTimersByTime(700); // rx should still be alive (timer reset at second rx call)
+      expect(flashing().has(key('link-1', 'rx'))).toBe(true);
     });
   });
 });

--- a/src/app/services/marker-flash.service.ts
+++ b/src/app/services/marker-flash.service.ts
@@ -1,39 +1,76 @@
 import { Injectable, signal, effect, EffectRef, DestroyRef, inject } from '@angular/core';
-import { select } from 'd3-selection';
+import { select, Selection } from 'd3-selection';
+
+/** Resolved visual state for one flashing link. */
+interface FlashState {
+  /** Marker color (hex) or null ⇒ default theme color. */
+  color: string | null;
+  /** Traffic direction relative to the capture node, or null ⇒ no arrow. */
+  dir: 'tx' | 'rx' | null;
+  /** Capture-side node id (the link endpoint `dir` is relative to). */
+  captureNodeId: string | null;
+  /** Monotonic counter so we can pick the most-recent entry when multiple
+   *  directions are active on the same link — excluded from sameFlash() diff. */
+  _seq: number;
+}
+
+/** Filled triangle pointing +x with its centroid at the origin; rotated to the flow. */
+const ARROW_PATH = 'M -4 -6 L 8 0 L -4 6 Z';
+/** Target spacing (px) between arrows along the path — drives how many are drawn. */
+const ARROW_SPACING = 55;
+const MIN_ARROW_COUNT = 3;
+const MAX_ARROW_COUNT = 8;
+/** Distance (in path length) either side of an arrow used to estimate the local tangent. */
+const ARROW_TANGENT_EPS = 6;
 
 /**
- * Flashes a link when its marker matches live traffic.
+ * Composite-key helpers.  Entries are keyed by `linkId` + direction so that
+ * tx and rx slots on the same link live independently (独立过期, 同方向续命).
+ * A null byte separates the two parts; linkIds are UUIDs so the separator is safe.
+ */
+const SEP = '\x00';
+const compKey = (linkId: string, dir: 'tx' | 'rx' | null) => `${linkId}${SEP}${dir ?? 'none'}`;
+const linkIdOf = (key: string) => key.split(SEP)[0];
+
+/** Module-level monotonic counter for ordering entries on the same link. */
+let _seq = 0;
+
+/**
+ * Flashes a link when its marker matches live traffic, and — when the match
+ * carries a direction (`dir`) — draws evenly-spaced arrows (鱼鳞) along the link
+ * pointing toward the traffic receiver.
  *
- * State is a signal of `linkId → color`. On each `flash(linkId, color, durationMs?)`:
- *   - the entry is (re)added to the map with the latest color
- *   - a per-link timer is (re)set for `durationMs ?? DEFAULT_FLASH_MS` (debounce-style续命)
+ * State is a signal of composite-key → FlashState.  On each `flash(...)`:
+ *   - the entry for that (linkId, dir) slot is (re)added
+ *   - a per-slot timer is (re)set (同方向续命, 不同方向独立过期)
  *
  * An `effect()` diffs the new map against the previous one and mutates ONLY the
- * changed link's DOM — add/keep → apply color + `.marker-pulse`; remove → clear.
- * So no matter how large the topology, a single flash touches exactly one path.
+ * changed link's DOM.  When a slot expires but another direction is still active
+ * on the same link, the DOM falls back to the other direction automatically.
  *
  * Color comes from the caller (resolved as `marker.color ?? null`). `null` means
- * "use the default theme color" (handled in CSS via the class, no inline color).
+ * "use the default theme color" (handled in CSS).
  * `durationMs` comes from the marker's `highlight_duration` (`null` ⇒ UI default).
+ * `dir` is `null`/absent for old uBridge builds → pulse without an arrow.
  */
 @Injectable()
 export class MarkerFlashService {
-  /** linkId → color (hex) or null (use default theme color). */
-  private readonly _flashing = signal<ReadonlyMap<string, string | null>>(new Map());
-  /** Per-link debounce timers (续命). */
+  /** composite-key → flash state. */
+  private readonly _flashing = signal<ReadonlyMap<string, FlashState>>(new Map());
+  /** Per-slot debounce timers (续命). */
   private readonly timers = new Map<string, ReturnType<typeof setTimeout>>();
   /** UI default highlight duration when a marker has no `highlight_duration`. */
   private readonly DEFAULT_FLASH_MS = 800;
   private readonly effectRef: EffectRef;
-  /** Previous snapshot for diffing. */
-  private prev = new Map<string, string | null>();
+  /** Previous snapshot for diffing (composite-key → state). */
+  private prev = new Map<string, FlashState>();
 
   constructor() {
     const destroyRef = inject(DestroyRef);
     this.effectRef = effect(() => this.applyDiff(this._flashing()));
     destroyRef.onDestroy(() => {
       this.effectRef.destroy();
-      for (const id of [...this.prev.keys()]) this.clearLink(id);
+      for (const key of [...this.prev.keys()]) this.clearLink(linkIdOf(key));
       this.prev.clear();
       for (const t of this.timers.values()) clearTimeout(t);
       this.timers.clear();
@@ -41,68 +78,209 @@ export class MarkerFlashService {
   }
 
   /**
-   * Flash a link. Repeated calls within the duration window keep it lit (timer续命);
-   * each call (re)sets the timer, so the latest `durationMs` wins.
+   * Flash a link. Repeated calls with the same direction within the duration
+   * window keep that direction lit (续命).  Calls with a *different* direction
+   * start an independent timer — the old direction stays active until its own
+   * timer expires (方向变化不续命).
+   *
    * @param color resolved marker color (hex), or null to use the default theme color.
    * @param durationMs how long to stay lit after the last match
    *   (`marker.highlight_duration`, or null for the UI default).
+   * @param dir traffic direction relative to `captureNodeId` (`"tx"` | `"rx"` | null).
+   *   Null/absent (old uBridge) ⇒ pulse without an arrow.
+   * @param captureNodeId the link endpoint `dir` is relative to (orients the arrow).
    */
-  flash(linkId: string, color: string | null, durationMs?: number | null) {
+  flash(
+    linkId: string,
+    color: string | null,
+    durationMs?: number | null,
+    dir: 'tx' | 'rx' | null = null,
+    captureNodeId: string | null = null
+  ) {
+    const key = compKey(linkId, dir);
+    const state: FlashState = { color, dir, captureNodeId, _seq: _seq++ };
     this._flashing.update((m) => {
       const next = new Map(m);
-      next.set(linkId, color);
+      next.set(key, state);
       return next;
     });
     const ms = durationMs && durationMs > 0 ? durationMs : this.DEFAULT_FLASH_MS;
-    clearTimeout(this.timers.get(linkId));
-    this.timers.set(linkId, setTimeout(() => this.expire(linkId), ms));
+    // Only cancel the same-direction timer (续命 for this slot only).
+    clearTimeout(this.timers.get(key));
+    this.timers.set(key, setTimeout(() => this.expire(key), ms));
   }
 
-  private expire(linkId: string) {
-    this.timers.delete(linkId);
+  private expire(key: string) {
+    this.timers.delete(key);
     this._flashing.update((m) => {
-      if (!m.has(linkId)) return m;
+      if (!m.has(key)) return m;
       const next = new Map(m);
-      next.delete(linkId);
+      next.delete(key);
       return next;
     });
   }
 
   /** Diff old vs new and touch only changed links. */
-  private applyDiff(curr: ReadonlyMap<string, string | null>) {
-    // Removed → clear.
-    for (const id of [...this.prev.keys()]) {
-      if (!curr.has(id)) {
-        this.clearLink(id);
-        this.prev.delete(id);
+  private applyDiff(curr: ReadonlyMap<string, FlashState>) {
+    // Removed → clear or fall back to another active direction on the same link.
+    for (const key of [...this.prev.keys()]) {
+      if (!curr.has(key)) {
+        const lid = linkIdOf(key);
+        this.prev.delete(key);
+        const best = this.bestEntryForLink(curr, lid);
+        if (best) {
+          this.setLink(lid, best.state);
+          this.prev.set(best.key, best.state);
+        } else {
+          this.clearLink(lid);
+        }
       }
     }
-    // Added or color changed → set.
-    for (const [id, color] of curr) {
-      if (this.prev.get(id) !== color) {
-        this.setLink(id, color);
-        this.prev.set(id, color);
+    // Added or changed → set.
+    for (const [key, state] of curr) {
+      const prevState = this.prev.get(key);
+      if (
+        !prevState ||
+        prevState.color !== state.color ||
+        prevState.dir !== state.dir ||
+        prevState.captureNodeId !== state.captureNodeId
+      ) {
+        this.setLink(linkIdOf(key), state);
+        this.prev.set(key, state);
       }
     }
   }
 
-  private setLink(id: string, color: string | null) {
-    const sel = this.selectLinkPath(id);
-    if (sel.empty()) return;
-    sel.classed('marker-pulse', true);
+  /** Among entries for the same linkId, pick the one with the highest _seq. */
+  private bestEntryForLink(
+    map: ReadonlyMap<string, FlashState>,
+    linkId: string
+  ): { key: string; state: FlashState } | null {
+    let result: { key: string; state: FlashState } | null = null;
+    for (const [k, s] of map) {
+      if (linkIdOf(k) === linkId && (!result || s._seq > result.state._seq)) {
+        result = { key: k, state: s };
+      }
+    }
+    return result;
+  }
+
+  private setLink(id: string, state: FlashState) {
+    const group = this.selectLinkGroup(id);
+    if (group.empty()) return;
+    const path = group.select<SVGPathElement>('path.ethernet_link, path.serial_link');
+    if (path.empty()) return;
+    path.classed('marker-pulse', true);
     // null → remove inline color so CSS default (var(--mat-sys-primary)) applies.
-    sel.style('stroke', color ?? null);
+    path.style('stroke', state.color ?? null);
+    const slot = state.dir === 'tx' ? 'tx' : state.dir === 'rx' ? 'rx' : null;
+    this.renderDirArrow(group, path, state, slot);
   }
 
   private clearLink(id: string) {
-    const sel = this.selectLinkPath(id);
-    if (sel.empty()) return;
-    sel.classed('marker-pulse', false).style('stroke', null);
+    const group = this.selectLinkGroup(id);
+    if (group.empty()) return;
+    group
+      .select('path.ethernet_link, path.serial_link')
+      .classed('marker-pulse', false)
+      .style('stroke', null);
+    // Remove ALL direction arrows (both tx and rx slots).
+    group.selectAll('g.marker-arrow-tx, g.marker-arrow-rx').remove();
   }
 
-  private selectLinkPath(id: string) {
-    return select('svg#map')
-      .select(`g.link[link_id="${id}"]`)
-      .select('path.ethernet_link, path.serial_link');
+  private selectLinkGroup(id: string) {
+    return select('svg#map').select<SVGGElement>(`g.link[link_id="${id}"]`);
+  }
+
+  /**
+   * Whether the arrow points along the path's source→target direction. The path
+   * is always drawn source→target, and `dir` is relative to the capture node, so
+   * the arrow follows the path only when the capture node sits at the sending end
+   * of a `tx` flow (capture→peer) or the receiving end of an `rx` flow (peer→capture).
+   * Pure — unit-tested directly (the geometry side can't run under jsdom).
+   */
+  private static arrowPointsAlongPath(
+    dir: 'tx' | 'rx',
+    captureIsSource: boolean,
+    captureIsTarget: boolean
+  ): boolean {
+    return (dir === 'tx' && captureIsSource) || (dir === 'rx' && captureIsTarget);
+  }
+
+  /**
+   * Draw evenly-spaced direction arrows along the link into a direction-specific
+   * container (`g.marker-arrow-tx` / `marker-arrow-rx`). Each slot is managed
+   * independently so tx and rx arrows can coexist without wiping each other out.
+   *
+   * The path is always drawn source→target, so we read `map-source`/`map-target`
+   * off the link group to learn which end the capture node is, then orient all
+   * arrows along or against the path. Skips when `dir` is null, or when the
+   * capture node can't be matched to an endpoint.
+   */
+  private renderDirArrow(
+    group: Selection<SVGGElement, any, any, any>,
+    path: Selection<SVGPathElement, any, any, any>,
+    state: FlashState,
+    slot: 'tx' | 'rx' | null
+  ) {
+    // Only remove OUR slot's container — leave the other direction's arrows alone.
+    const slotClass = slot ? `marker-arrow-${slot}` : 'marker-arrow';
+    group.select(`g.${slotClass}`).remove();
+    if (!slot) return; // legacy (no dir) → pulse only, no arrows.
+
+    const sourceId = group.attr('map-source');
+    const targetId = group.attr('map-target');
+    const captureIsSource = !!state.captureNodeId && state.captureNodeId === sourceId;
+    const captureIsTarget = !!state.captureNodeId && state.captureNodeId === targetId;
+    if (!captureIsSource && !captureIsTarget) return;
+
+    const node = path.node();
+    if (!node) return;
+    // jsdom (unit tests) doesn't implement path geometry — bail out quietly there.
+    let len: number;
+    try {
+      len = node.getTotalLength();
+    } catch {
+      return;
+    }
+    if (!len || !Number.isFinite(len)) return;
+
+    // Pre-compute the direction offset once for all arrows along this link.
+    const angleOffset = MarkerFlashService.arrowPointsAlongPath(state.dir, captureIsSource, captureIsTarget)
+      ? 0
+      : Math.PI;
+
+    // Place evenly-spaced arrows along the path. When both tx and rx are active
+    // simultaneously, stagger rx arrows by half a step so they don't overlap.
+    const count = Math.max(MIN_ARROW_COUNT, Math.min(MAX_ARROW_COUNT, Math.round(len / ARROW_SPACING)));
+    const container = group.append<SVGGElement>('g').attr('class', slotClass);
+    const step = len / (count + 1);
+
+    for (let i = 0; i < count; i++) {
+      let at = step * (i + 1);
+      if (slot === 'rx') at += step * 0.5;
+      const behind = this.pointAt(node, Math.max(0, at - ARROW_TANGENT_EPS));
+      const ahead = this.pointAt(node, Math.min(len, at + ARROW_TANGENT_EPS));
+      const pos = this.pointAt(node, at);
+      if (!behind || !ahead || !pos) continue;
+
+      const angle = Math.atan2(ahead.y - behind.y, ahead.x - behind.x) + angleOffset;
+      container
+        .append<SVGPathElement>('path')
+        .attr('d', ARROW_PATH)
+        .attr('transform', `translate(${pos.x},${pos.y}) rotate(${(angle * 180) / Math.PI})`)
+        // null → CSS default (var(--mat-sys-primary)); hex → match the pulse color.
+        .style('fill', state.color ?? null);
+    }
+  }
+
+  /** Safe getPointAtLength wrapper (jsdom throws / returns non-finite values). */
+  private pointAt(node: SVGPathElement, at: number): { x: number; y: number } | null {
+    try {
+      const p = node.getPointAtLength(at);
+      return p && Number.isFinite(p.x) && Number.isFinite(p.y) ? { x: p.x, y: p.y } : null;
+    } catch {
+      return null;
+    }
   }
 }

--- a/src/app/services/marker-flash.service.ts
+++ b/src/app/services/marker-flash.service.ts
@@ -98,16 +98,27 @@ export class MarkerFlashService {
     captureNodeId: string | null = null
   ) {
     const key = compKey(linkId, dir);
+    const ms = durationMs && durationMs > 0 ? durationMs : this.DEFAULT_FLASH_MS;
+    clearTimeout(this.timers.get(key));
+    this.timers.set(key, setTimeout(() => this.expire(key), ms));
+
+    // Same-state guard: under heavy traffic (e.g. ping -f),
+    // repeated matches with identical color / direction / capture node
+    // only extend the timer — no Map copy, no signal update, no effect.
+    // Without this, every match copies the Map and fires the full diff
+    // pipeline even though the DOM is unchanged; the churn leaks into
+    // GC pressure and browser memory climbs.
+    const existing = this._flashing().get(key);
+    if (existing && existing.color === color && existing.dir === dir && existing.captureNodeId === captureNodeId) {
+      return;
+    }
+
     const state: FlashState = { color, dir, captureNodeId, _seq: _seq++ };
     this._flashing.update((m) => {
       const next = new Map(m);
       next.set(key, state);
       return next;
     });
-    const ms = durationMs && durationMs > 0 ? durationMs : this.DEFAULT_FLASH_MS;
-    // Only cancel the same-direction timer (续命 for this slot only).
-    clearTimeout(this.timers.get(key));
-    this.timers.set(key, setTimeout(() => this.expire(key), ms));
   }
 
   private expire(key: string) {

--- a/src/app/services/marker.service.spec.ts
+++ b/src/app/services/marker.service.spec.ts
@@ -77,6 +77,38 @@ describe('MarkerService', () => {
     });
   });
 
+  describe('definition pause/resume + per-marker enable', () => {
+    it('pauseDefinition → POST /marker-definitions/{name}/pause with empty body', () => {
+      mockHttpController.post.mockReturnValue(of(undefined));
+      service.pauseDefinition(mockController, PROJECT_ID, NAME).subscribe();
+      expect(mockHttpController.post).toHaveBeenCalledWith(
+        mockController,
+        `/projects/${PROJECT_ID}/marker-definitions/${encodeURIComponent(NAME)}/pause`,
+        {}
+      );
+    });
+
+    it('resumeDefinition → POST /marker-definitions/{name}/resume with empty body', () => {
+      mockHttpController.post.mockReturnValue(of(undefined));
+      service.resumeDefinition(mockController, PROJECT_ID, NAME).subscribe();
+      expect(mockHttpController.post).toHaveBeenCalledWith(
+        mockController,
+        `/projects/${PROJECT_ID}/marker-definitions/${encodeURIComponent(NAME)}/resume`,
+        {}
+      );
+    });
+
+    it('setEnabled → PUT /links/{lid}/markers/{name} with {enabled}', () => {
+      mockHttpController.put.mockReturnValue(of({}));
+      service.setEnabled(mockController, PROJECT_ID, LINK_ID, NAME, false).subscribe();
+      expect(mockHttpController.put).toHaveBeenCalledWith(
+        mockController,
+        `/projects/${PROJECT_ID}/links/${LINK_ID}/markers/${encodeURIComponent(NAME)}`,
+        { enabled: false }
+      );
+    });
+  });
+
   describe('per-link markers (unchanged shape)', () => {
     it('list → GET /links/{lid}/markers', () => {
       mockHttpController.get.mockReturnValue(of({}));

--- a/src/app/services/marker.service.ts
+++ b/src/app/services/marker.service.ts
@@ -18,6 +18,14 @@ export interface MarkerWriteBody {
   enabled?: boolean;
   /** Optional direction filter: `"tx"` | `"rx"` | null (both directions, default). */
   direction?: 'tx' | 'rx' | null;
+  /**
+   * Capture-side (observer) node id — the endpoint `direction` is measured from.
+   * Only honored on **create**; immutable afterwards (server ignores it on update —
+   * changing it would invert stored direction semantics). Omit/null ⇒ server
+   * auto-selects one of the link's endpoints. Not valid on project-level definitions
+   * (inherited copies always auto-select).
+   */
+  capture_node_id?: string | null;
 }
 
 /**

--- a/src/app/services/marker.service.ts
+++ b/src/app/services/marker.service.ts
@@ -19,6 +19,11 @@ export interface MarkerWriteBody {
   /** Optional direction filter: `"tx"` | `"rx"` | `"both"` | null (both = no filter). */
   direction?: 'tx' | 'rx' | 'both' | null;
   /**
+   * Link-layer encapsulation (uBridge DLT). Defaults to `"DLT_EN10MB"`. Required for
+   * serial/WAN links. Create-only on per-link markers (immutable afterwards).
+   */
+  data_link_type?: string;
+  /**
    * Capture-side (observer) node id — the endpoint `direction` is measured from.
    * Only honored on **create**; immutable afterwards (server ignores it on update —
    * changing it would invert stored direction semantics). Omit/null ⇒ server

--- a/src/app/services/marker.service.ts
+++ b/src/app/services/marker.service.ts
@@ -16,6 +16,8 @@ export interface MarkerWriteBody {
   color?: string;
   highlight_duration?: number | null;
   enabled?: boolean;
+  /** Optional direction filter: `"tx"` | `"rx"` | null (both directions, default). */
+  direction?: 'tx' | 'rx' | null;
 }
 
 /**

--- a/src/app/services/marker.service.ts
+++ b/src/app/services/marker.service.ts
@@ -95,6 +95,27 @@ export class MarkerService {
     );
   }
 
+  /**
+   * Flip only a marker's `enabled` flag — the controller's fast path: signal detection +
+   * pcap recording stop/start instantly while traffic keeps forwarding (no NIO rebuild,
+   * no pcap flush). Use this for the per-row on/off switch; {@link update} still rebuilds
+   * for any other field change (BPF/tag/color/…). PUT `{ enabled }`, returns the link's
+   * markers.
+   */
+  setEnabled(
+    controller: Controller,
+    projectId: string,
+    linkId: string,
+    name: string,
+    enabled: boolean
+  ) {
+    return this.httpController.put<MarkerMap>(
+      controller,
+      `/projects/${projectId}/links/${linkId}/markers/${encodeURIComponent(name)}`,
+      { enabled }
+    );
+  }
+
   // ---- Project-level definitions (global rules, fanned out to all capable links) ----
 
   /** List all definitions + the `link_ids` each is currently bound to. */
@@ -137,6 +158,29 @@ export class MarkerService {
     return this.httpController.delete(
       controller,
       `/projects/${projectId}/marker-definitions/${encodeURIComponent(name)}`
+    );
+  }
+
+  /**
+   * Pause a definition: every inherited copy (`global-{name}`) it fanned out is toggled off
+   * via enable_packet_filter — instantly, with no NIO/pcap rebuild. The definition stores a
+   * persisted `paused` flag (read back via {@link listDefinitions}); links that later
+   * inherit a paused definition start disabled. 204, no body.
+   */
+  pauseDefinition(controller: Controller, projectId: string, name: string) {
+    return this.httpController.post<void>(
+      controller,
+      `/projects/${projectId}/marker-definitions/${encodeURIComponent(name)}/pause`,
+      {}
+    );
+  }
+
+  /** Resume a paused definition — re-enables every inherited copy. 204, no body. */
+  resumeDefinition(controller: Controller, projectId: string, name: string) {
+    return this.httpController.post<void>(
+      controller,
+      `/projects/${projectId}/marker-definitions/${encodeURIComponent(name)}/resume`,
+      {}
     );
   }
 

--- a/src/app/services/marker.service.ts
+++ b/src/app/services/marker.service.ts
@@ -16,8 +16,8 @@ export interface MarkerWriteBody {
   color?: string;
   highlight_duration?: number | null;
   enabled?: boolean;
-  /** Optional direction filter: `"tx"` | `"rx"` | null (both directions, default). */
-  direction?: 'tx' | 'rx' | null;
+  /** Optional direction filter: `"tx"` | `"rx"` | `"both"` | null (both = no filter). */
+  direction?: 'tx' | 'rx' | 'both' | null;
   /**
    * Capture-side (observer) node id — the endpoint `direction` is measured from.
    * Only honored on **create**; immutable afterwards (server ignores it on update —

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -311,6 +311,14 @@ body .cdk-overlay-container .cdk-overlay-pane .mat-mdc-menu-panel.template-menu 
   stroke-width: 5px;
 }
 
+/* Direction arrow drawn at a flashing link's midpoint when a `marker.match`
+   carries a `dir` (tx/rx). Inline fill (user-chosen hex) is set by
+   MarkerFlashService; when none is set, the default theme color below applies. */
+.marker-arrow-tx path,
+.marker-arrow-rx path {
+  fill: var(--mat-sys-primary);
+}
+
 /* =============================================
 // Curviness Anchor (Link Drag Handle)
 // ============================================= */


### PR DESCRIPTION
## Summary

This PR upgrades the **BPF traffic marker (Marker Manager)** from a basic create/delete list into a full management surface for the new marker capabilities introduced on the server and capture sides.

Depends on:
- https://github.com/GNS3/gns3-server/pull/2844 — server-side marker APIs (direction, capture node, enable, pause/resume, data_link_type)
- https://github.com/GNS3/ubridge/pull/116 — capture-side direction-aware packet matching + WAN encapsulation decode

## What's new

### Direction filter
- Per-link marker create/edit forms gain a **Direction** selector: `Both` / `Tx→` / `←Rx`.
- `marker.match` events now render a **direction arrow** on the link.
- Definitions are restricted to `Both` only (global rules are not direction-scoped).
- `direction=both` is sent on PUT so the filter is cleared rather than left stale.

### Capture node
- Per-link markers can specify a **capture node** — the link endpoint acting as the observer. Immutable after create.
- The form markup is centralized in a new shared `<app-marker-form>` component, reused for both create and edit.

### Serial / WAN encapsulation (data_link_type)
- Markers carry a `data_link_type` so they decode serial (WAN) links — Cisco HDLC / PPP / Frame Relay / ATM — not just Ethernet.
- A **Serial encapsulation** picker (WAN options only; Ethernet is the implicit default, never shown as a choice):
  - **per-link form**: shown only on serial links (`link.link_type === 'serial'`), seeded to Cisco HDLC, disabled in edit (create-only — recreate to switch).
  - **definition form**: blank = Ethernet-only (serial links are skipped); picking a WAN encapsulation makes the definition also cover serial links of that encapsulation while Ethernet links stay EN10MB, so one definition can serve a mixed topology.
- Options mirror the capture dialog's DLT table (Cisco PPP is `DLT_PPP_SERIAL`, not raw `DLT_PPP`).
- Editing a definition's encapsulation prompts a **confirmation** on Save, since it rebuilds every inherited copy and restarts capture on all affected links (uBridge itself is unaffected).

### Enable / Pause toggles
- **Per-marker** enable/disable toggle (toggles signal + capture together).
- **Per-definition** pause/resume — pausing a definition disables all of its inherited copies across every link; resuming re-enables them.

### Links tab redesign
- Markers are now **grouped by link** (collapsible), with a Node → Link cascading filter and an on-demand **+ Marker** button per group.
- Errors are **scoped to the originating link group** instead of all surfacing at the top of the panel.

### Polish & fixes
- Spinners on delete / submit / toggle buttons; removed the list-refresh blink when toggling a definition.
- Perf: skip the Map copy + signal/effect cycle when a flash does not change a link's state.
- `fix(selection)`: rubber-band selection now divides the rect by the zoom scale before hit-testing, fixing off-by-zoom selection at non-1× zoom.

## How to test
1. Open a project with at least one link carrying traffic.
2. Open the Marker Manager (Definitions + Links tabs).
3. Create a definition and a per-link marker; set Direction and a Capture node.
4. Verify the direction arrow flashes on matching traffic.
5. Pause a definition → confirm all inherited copies disable; resume → re-enable.
6. Toggle an individual marker on/off.
7. On a serial link, set a WAN encapsulation on a marker (and on a definition) → confirm serial traffic is monitored; Ethernet links show no encapsulation picker.
8. Edit a definition's encapsulation → confirm the rebuild confirmation appears on Save.
9. Trigger a form error → confirm it appears next to the relevant link group, not at the panel top.
10. Use rubber-band selection at 150% / 50% zoom → confirm the correct nodes are selected.
