### PR TITLE
perf(cartography): Tier 1 & 2 — incremental render pipeline + pure-signal targeted DOM updates

### DIFF
--- a/src/app/cartography/components/d3-map/d3-map.component.ts
+++ b/src/app/cartography/components/d3-map/d3-map.component.ts
@@ -232,14 +232,17 @@ export class D3MapComponent implements OnInit, OnChanges, OnDestroy {
     this.subscriptions.push(
       this.toolsService.isMovingToolActivated.subscribe((value: boolean) => {
         this.movingToolWidget.setEnabled(value);
-        this.mapChangeDetectorRef.detectChanges();
+        // Apply the drag-binding change directly via the tool's draw() — a tool
+        // switch changes no rendering, so a full redraw is pure waste (and is
+        // very slow with thousands of nodes).
+        this.movingToolWidget.draw(this.svg, this.context);
       })
     );
 
     this.subscriptions.push(
       this.toolsService.isSelectionToolActivated.subscribe((value: boolean) => {
         this.selectionToolWidget.setEnabled(value);
-        this.mapChangeDetectorRef.detectChanges();
+        this.selectionToolWidget.draw(this.svg, this.context);
       })
     );
 

--- a/src/app/cartography/components/d3-map/d3-map.component.ts
+++ b/src/app/cartography/components/d3-map/d3-map.component.ts
@@ -20,7 +20,6 @@ import { Link } from '@models/link';
 import { Project } from '@models/project';
 import { Controller } from '@models/controller';
 import { Symbol } from '@models/symbol';
-import { MapScaleService } from '@services/mapScale.service';
 import { MapSettingsService } from '@services/mapsettings.service';
 import { ToolsService } from '@services/tools.service';
 import { affectedIsEmpty, emptyAffectedIds, mergeAffected } from '../../helpers/item-signature';
@@ -117,7 +116,6 @@ export class D3MapComponent implements OnInit, OnChanges, OnDestroy {
   protected movingToolWidget = inject(MovingTool);
   public graphLayout = inject(GraphLayout);
   private toolsService = inject(ToolsService);
-  private mapScaleService = inject(MapScaleService);
   private mapSettingsService = inject(MapSettingsService);
 
   constructor() {
@@ -220,10 +218,6 @@ export class D3MapComponent implements OnInit, OnChanges, OnDestroy {
           this.graphLayout.updateSelectionHighlights(this.svg);
         }
       })
-    );
-
-    this.subscriptions.push(
-      this.mapScaleService.scaleChangeEmitter.subscribe((value: number) => this.scheduleRedraw())
     );
 
     this.subscriptions.push(

--- a/src/app/cartography/components/d3-map/d3-map.component.ts
+++ b/src/app/cartography/components/d3-map/d3-map.component.ts
@@ -455,12 +455,13 @@ export class D3MapComponent implements OnInit, OnChanges, OnDestroy {
     // Restore origin to prevent visual canvas shifting. The size is updated to
     // accommodate new content, but the <g> transform origin stays stable so
     // existing elements don't jump (same pattern as node-drag locking).
-    // The saved value starts null (empty canvas at ngOnInit), and restoring null
-    // made the origin size/2 — which MOVES whenever the canvas resizes (e.g.
-    // during zoom), breaking cursor-centered zoom and shifting content. Fix the
-    // origin to the computed value on the first draw with content instead.
-    this.context.centerX = savedCenterX ?? this.context.centerX;
-    this.context.centerY = savedCenterY ?? this.context.centerY;
+    // The saved value starts null, and restoring null made the origin size/2 —
+    // which MOVES whenever the canvas resizes (e.g. during zoom), breaking
+    // cursor-centered zoom and shifting content. Fix the origin once, at the
+    // center of the project canvas (scene_width/2, scene_height/2 — defaults
+    // 2000x1000), so every open is deterministic and the zoom anchor holds.
+    this.context.centerX = savedCenterX ?? this.width() / 2;
+    this.context.centerY = savedCenterY ?? this.height() / 2;
 
     this.graphLayout.draw(this.svg, this.context);
     this.textEditor().activateTextEditingForDrawings();

--- a/src/app/cartography/components/d3-map/d3-map.component.ts
+++ b/src/app/cartography/components/d3-map/d3-map.component.ts
@@ -24,6 +24,7 @@ import { MapScaleService } from '@services/mapScale.service';
 import { MapSettingsService } from '@services/mapsettings.service';
 import { ToolsService } from '@services/tools.service';
 import { affectedIsEmpty, emptyAffectedIds, mergeAffected } from '../../helpers/item-signature';
+import { applyIncrementalPatches } from '../../helpers/dom-patcher';
 import { CanvasSizeDetector } from '../../helpers/canvas-size-detector';
 import { GraphDataManager } from '../../managers/graph-data-manager';
 import { MapSettingsManager } from '../../managers/map-settings-manager';
@@ -469,6 +470,18 @@ export class D3MapComponent implements OnInit, OnChanges, OnDestroy {
     // On later redraws savedCenterX is non-null and stays locked (drag-lock).
     this.context.centerX = savedCenterX ?? this.context.centerX;
     this.context.centerY = savedCenterY ?? this.context.centerY;
+
+    // For gated (data-driven) redraws try incremental DOM patches first.
+    // When only node xY positions changed, targeted transform updates on the
+    // affected g.node elements are enough — no D3 data-join, no getBBox /
+    // getTotalLength reflows.  Structural changes (add/remove) and non-xY
+    // updates fall through to full graphLayout.draw below.
+    if (gated && !applyIncrementalPatches(this.svg, affected, this.graphDataManager, this.context)) {
+      this.textEditor().activateTextEditingForDrawings();
+      this.textEditor().activateTextEditingForNodeLabels();
+      this.mapSettingsService.mapRenderedEmitter.emit(true);
+      return;
+    }
 
     this.graphLayout.draw(this.svg, this.context);
     this.textEditor().activateTextEditingForDrawings();

--- a/src/app/cartography/components/d3-map/d3-map.component.ts
+++ b/src/app/cartography/components/d3-map/d3-map.component.ts
@@ -89,6 +89,11 @@ export class D3MapComponent implements OnInit, OnChanges, OnDestroy {
   // redraw per frame regardless of how many WS notifications / zoom events /
   // signal writes fire in between.
   private rafId: number | null = null;
+  // Visual signatures of the last-drawn nodes/links/drawings (only
+  // canvas-rendered fields). redraw() skips the full draw when none changed.
+  private lastNodeSig = '';
+  private lastLinkSig = '';
+  private lastDrawSig = '';
   protected settings = {
     show_interface_labels: true,
   };
@@ -398,6 +403,22 @@ export class D3MapComponent implements OnInit, OnChanges, OnDestroy {
   private redraw() {
     this.updateGrid();
 
+    // Visual-signature gate: skip the expensive full draw (graphDataManager
+    // conversion + D3 data-join + getBBox/getTotalLength reflows) when no
+    // canvas-rendered field changed since the last draw. This is what stops a
+    // flood of non-visual updates — e.g. per-def marker config fanning out
+    // link.updated that only changes `markers`, or node.updated that only
+    // changes console/properties/command_line — from re-rendering the whole map.
+    const nodeSig = this.signatureOfNodes(this.nodes());
+    const linkSig = this.signatureOfLinks(this.links());
+    const drawSig = this.signatureOfDrawings(this.drawings());
+    if (nodeSig === this.lastNodeSig && linkSig === this.lastLinkSig && drawSig === this.lastDrawSig) {
+      return;
+    }
+    this.lastNodeSig = nodeSig;
+    this.lastLinkSig = linkSig;
+    this.lastDrawSig = drawSig;
+
     this.graphDataManager.setNodes(this.nodes());
     this.graphDataManager.setLinks(this.links());
     this.graphDataManager.setDrawings(this.drawings());
@@ -445,5 +466,95 @@ export class D3MapComponent implements OnInit, OnChanges, OnDestroy {
   @HostListener('window:resize', ['$event'])
   onResize(event) {
     this.changeLayout();
+  }
+
+  /**
+   * Signature of the canvas-rendered fields of all nodes. Excludes non-visual
+   * fields (console*, command_line, node_directory, compute_id, properties,
+   * usage) so that e.g. a startup node.updated changing only console/properties
+   * does not re-render the map.
+   */
+  private signatureOfNodes(nodes: Node[]): string {
+    let s = '';
+    for (const n of nodes) {
+      s +=
+        n.node_id +
+        '|' +
+        n.x +
+        '|' +
+        n.y +
+        '|' +
+        n.z +
+        '|' +
+        n.symbol +
+        '|' +
+        n.symbol_url +
+        '|' +
+        n.width +
+        '|' +
+        n.height +
+        '|' +
+        n.status +
+        '|' +
+        n.locked +
+        '|' +
+        n.name +
+        '|' +
+        n.node_type +
+        '|' +
+        n.first_port_name +
+        '|' +
+        n.port_name_format +
+        '|' +
+        n.port_segment_size +
+        '|' +
+        JSON.stringify(n.label) +
+        '|' +
+        JSON.stringify(n.ports) +
+        '§';
+    }
+    return s;
+  }
+
+  /**
+   * Signature of the canvas-rendered fields of all links. `markers` is
+   * intentionally excluded: configuring a per-def marker fans out link.updated
+   * that changes only `markers` (which the link widget does not render — marker
+   * highlights are drawn separately by MarkerFlashService), so it must not
+   * trigger a map redraw.
+   */
+  private signatureOfLinks(links: Link[]): string {
+    let s = '';
+    for (const l of links) {
+      s +=
+        l.link_id +
+        '|' +
+        l.capturing +
+        '|' +
+        l.suspend +
+        '|' +
+        l.show_filters_icon +
+        '|' +
+        l.wireshark +
+        '|' +
+        l.link_type +
+        '|' +
+        JSON.stringify(l.filters) +
+        '|' +
+        JSON.stringify(l.link_style) +
+        '|' +
+        JSON.stringify(l.nodes) +
+        '§';
+    }
+    return s;
+  }
+
+  /** Signature of the canvas-rendered fields of all drawings (excludes project_id). */
+  private signatureOfDrawings(drawings: Drawing[]): string {
+    let s = '';
+    for (const d of drawings) {
+      s += d.drawing_id + '|' + d.x + '|' + d.y + '|' + d.z + '|' + d.rotation + '|' + d.locked + '|' + d.svg + '§';
+    }
+    return s;
   }
 }

--- a/src/app/cartography/components/d3-map/d3-map.component.ts
+++ b/src/app/cartography/components/d3-map/d3-map.component.ts
@@ -455,8 +455,12 @@ export class D3MapComponent implements OnInit, OnChanges, OnDestroy {
     // Restore origin to prevent visual canvas shifting. The size is updated to
     // accommodate new content, but the <g> transform origin stays stable so
     // existing elements don't jump (same pattern as node-drag locking).
-    this.context.centerX = savedCenterX;
-    this.context.centerY = savedCenterY;
+    // The saved value starts null (empty canvas at ngOnInit), and restoring null
+    // made the origin size/2 — which MOVES whenever the canvas resizes (e.g.
+    // during zoom), breaking cursor-centered zoom and shifting content. Fix the
+    // origin to the computed value on the first draw with content instead.
+    this.context.centerX = savedCenterX ?? this.context.centerX;
+    this.context.centerY = savedCenterY ?? this.context.centerY;
 
     this.graphLayout.draw(this.svg, this.context);
     this.textEditor().activateTextEditingForDrawings();

--- a/src/app/cartography/components/d3-map/d3-map.component.ts
+++ b/src/app/cartography/components/d3-map/d3-map.component.ts
@@ -84,6 +84,11 @@ export class D3MapComponent implements OnInit, OnChanges, OnDestroy {
   private onChangesDetected: Subscription;
   private subscriptions: Subscription[] = [];
   private drawLinkTool: boolean;
+  // Pending requestAnimationFrame id for the coalesced redraw. All redraw
+  // triggers funnel through scheduleRedraw(), guaranteeing at most one full
+  // redraw per frame regardless of how many WS notifications / zoom events /
+  // signal writes fire in between.
+  private rafId: number | null = null;
   protected settings = {
     show_interface_labels: true,
   };
@@ -117,6 +122,20 @@ export class D3MapComponent implements OnInit, OnChanges, OnDestroy {
       if (project && this.mapChangeDetectorRef.hasBeenDrawn) {
         this.updateGrid();
         this.mapChangeDetectorRef.detectChanges();
+      }
+    });
+
+    // Signal-driven data -> redraw. Reading the input signals here registers
+    // them as effect dependencies, so any nodes/links/drawings change schedules
+    // a single coalesced redraw (see scheduleRedraw). This replaces the old
+    // reliance on mapChangeDetectorRef + setTimeout for propagating zoneless
+    // signal inputs: inside an effect the inputs are already fresh.
+    effect(() => {
+      this.nodes();
+      this.links();
+      this.drawings();
+      if (this.mapChangeDetectorRef.hasBeenDrawn) {
+        this.scheduleRedraw();
       }
     });
   }
@@ -153,12 +172,11 @@ export class D3MapComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   ngOnChanges(changes: { [propKey: string]: SimpleChange }) {
+    // nodes/links/drawings changes are handled by the signal-driven effect in
+    // the constructor; only width/height/symbols still need ngOnChanges.
     if (
       (changes['width'] && !changes['width'].isFirstChange()) ||
       (changes['height'] && !changes['height'].isFirstChange()) ||
-      (changes['drawings'] && !changes['drawings'].isFirstChange()) ||
-      (changes['nodes'] && !changes['nodes'].isFirstChange()) ||
-      (changes['links'] && !changes['links'].isFirstChange()) ||
       (changes['symbols'] && !changes['symbols'].isFirstChange())
     ) {
       if (this.svg.empty && !this.svg.empty()) {
@@ -184,10 +202,7 @@ export class D3MapComponent implements OnInit, OnChanges, OnDestroy {
 
     this.onChangesDetected = this.mapChangeDetectorRef.changesDetected.subscribe(() => {
       if (this.mapChangeDetectorRef.hasBeenDrawn) {
-        // Defer redraw so Angular propagates signal inputs (nodes/links/drawings)
-        // before D3 reads them. Without this, redraw() reads stale empty arrays
-        // because zoneless change detection hasn't propagated inputs yet.
-        setTimeout(() => this.redraw());
+        this.scheduleRedraw();
       }
     });
 
@@ -199,7 +214,9 @@ export class D3MapComponent implements OnInit, OnChanges, OnDestroy {
       })
     );
 
-    this.subscriptions.push(this.mapScaleService.scaleChangeEmitter.subscribe((value: number) => this.redraw()));
+    this.subscriptions.push(
+      this.mapScaleService.scaleChangeEmitter.subscribe((value: number) => this.scheduleRedraw())
+    );
 
     this.subscriptions.push(
       this.toolsService.isMovingToolActivated.subscribe((value: boolean) => {
@@ -279,6 +296,10 @@ export class D3MapComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   ngOnDestroy() {
+    if (this.rafId !== null) {
+      cancelAnimationFrame(this.rafId);
+      this.rafId = null;
+    }
     this.graphLayout.disconnect(this.svg);
     this.onChangesDetected.unsubscribe();
     this.subscriptions.forEach((subscription: Subscription) => {
@@ -287,7 +308,20 @@ export class D3MapComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   public applyMapSettingsChanges() {
-    this.redraw();
+    this.scheduleRedraw();
+  }
+
+  // Coalesce redraw requests to at most one per animation frame. Every
+  // trigger (signal-driven data change via effect, changesDetected, zoom,
+  // resize, map settings) calls this instead of redraw() directly.
+  private scheduleRedraw() {
+    if (this.rafId !== null) {
+      return;
+    }
+    this.rafId = requestAnimationFrame(() => {
+      this.rafId = null;
+      this.redraw();
+    });
   }
 
   public createGraph(domElement: HTMLElement) {
@@ -354,11 +388,7 @@ export class D3MapComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   private changeLayout() {
-    if (this.parentNativeElement != null) {
-      this.context.size = this.getSize();
-    }
-
-    this.redraw();
+    this.scheduleRedraw();
   }
 
   private onSymbolsChange(change: SimpleChange) {

--- a/src/app/cartography/components/d3-map/d3-map.component.ts
+++ b/src/app/cartography/components/d3-map/d3-map.component.ts
@@ -23,6 +23,7 @@ import { Symbol } from '@models/symbol';
 import { MapScaleService } from '@services/mapScale.service';
 import { MapSettingsService } from '@services/mapsettings.service';
 import { ToolsService } from '@services/tools.service';
+import { affectedIsEmpty, emptyAffectedIds, mergeAffected } from '../../helpers/item-signature';
 import { CanvasSizeDetector } from '../../helpers/canvas-size-detector';
 import { GraphDataManager } from '../../managers/graph-data-manager';
 import { MapSettingsManager } from '../../managers/map-settings-manager';
@@ -94,11 +95,6 @@ export class D3MapComponent implements OnInit, OnChanges, OnDestroy {
   // so the gate can never skip a redraw the selection tool or canvas transform
   // needs. Any non-gated trigger in a frame downgrades the pending redraw.
   private pendingGated = true;
-  // Visual signatures of the last-drawn nodes/links/drawings (only
-  // canvas-rendered fields). The gated data redraw skips when none changed.
-  private lastNodeSig = '';
-  private lastLinkSig = '';
-  private lastDrawSig = '';
   protected settings = {
     show_interface_labels: true,
   };
@@ -358,9 +354,6 @@ export class D3MapComponent implements OnInit, OnChanges, OnDestroy {
     this.context.centerX = null;
     this.context.centerY = null;
     this.context.size = new Size(0, 0);
-    this.lastNodeSig = '';
-    this.lastLinkSig = '';
-    this.lastDrawSig = '';
     this.graphLayout.connect(this.svg, this.context);
     this.graphLayout.draw(this.svg, this.context);
     this.mapChangeDetectorRef.hasBeenDrawn = true;
@@ -437,25 +430,21 @@ export class D3MapComponent implements OnInit, OnChanges, OnDestroy {
       // (graphDataManager conversion + D3 data-join + getBBox/getTotalLength
       // reflows) when no canvas-rendered field changed since the last draw.
       // This is what stops a flood of non-visual updates — e.g. per-def marker
-      // config fanning out link.updated that only changes `markers`, or
-      // node.updated that only changes console/properties/command_line — from
-      // re-rendering the whole map. Non-gated redraws (zoom, resize, settings,
-      // tool switches) always run: the gate must never skip a redraw the
-      // selection tool or canvas transform depends on.
-      const nodeSig = this.signatureOfNodes(this.nodes());
-      const linkSig = this.signatureOfLinks(this.links());
-      const drawSig = this.signatureOfDrawings(this.drawings());
-      if (nodeSig === this.lastNodeSig && linkSig === this.lastLinkSig && drawSig === this.lastDrawSig) {
-        return;
-      }
-      this.lastNodeSig = nodeSig;
-      this.lastLinkSig = linkSig;
-      this.lastDrawSig = drawSig;
     }
 
-    this.graphDataManager.setNodes(this.nodes());
-    this.graphDataManager.setLinks(this.links());
-    this.graphDataManager.setDrawings(this.drawings());
+    // setNodes/setLinks/setDrawings perform incremental diff internally
+    // (per-item visual-signature comparison) and return AffectedIds describing
+    // exactly which items changed and in what visual groups.  If nothing
+    // changed and this is a data-driven (gated) redraw, skip entirely — same
+    // semantic as the old signature gate, but per-item instead of one blob.
+    const affected = emptyAffectedIds();
+    mergeAffected(affected, this.graphDataManager.setNodes(this.nodes()));
+    mergeAffected(affected, this.graphDataManager.setLinks(this.links()));
+    mergeAffected(affected, this.graphDataManager.setDrawings(this.drawings()));
+
+    if (gated && affectedIsEmpty(affected)) {
+      return;
+    }
 
     // Save current origin before getSize() potentially changes it — when new
     // content extends beyond the current canvas boundary getSize() grows the
@@ -517,87 +506,6 @@ export class D3MapComponent implements OnInit, OnChanges, OnDestroy {
    * usage) so that e.g. a startup node.updated changing only console/properties
    * does not re-render the map.
    */
-  private signatureOfNodes(nodes: Node[]): string {
-    let s = '';
-    for (const n of nodes) {
-      s +=
-        n.node_id +
-        '|' +
-        n.x +
-        '|' +
-        n.y +
-        '|' +
-        n.z +
-        '|' +
-        n.symbol +
-        '|' +
-        n.symbol_url +
-        '|' +
-        n.width +
-        '|' +
-        n.height +
-        '|' +
-        n.status +
-        '|' +
-        n.locked +
-        '|' +
-        n.name +
-        '|' +
-        n.node_type +
-        '|' +
-        n.first_port_name +
-        '|' +
-        n.port_name_format +
-        '|' +
-        n.port_segment_size +
-        '|' +
-        JSON.stringify(n.label) +
-        '|' +
-        JSON.stringify(n.ports) +
-        '§';
-    }
-    return s;
-  }
 
-  /**
-   * Signature of the canvas-rendered fields of all links. `markers` is
-   * intentionally excluded: configuring a per-def marker fans out link.updated
-   * that changes only `markers` (which the link widget does not render — marker
-   * highlights are drawn separately by MarkerFlashService), so it must not
-   * trigger a map redraw.
-   */
-  private signatureOfLinks(links: Link[]): string {
-    let s = '';
-    for (const l of links) {
-      s +=
-        l.link_id +
-        '|' +
-        l.capturing +
-        '|' +
-        l.suspend +
-        '|' +
-        l.show_filters_icon +
-        '|' +
-        l.wireshark +
-        '|' +
-        l.link_type +
-        '|' +
-        JSON.stringify(l.filters) +
-        '|' +
-        JSON.stringify(l.link_style) +
-        '|' +
-        JSON.stringify(l.nodes) +
-        '§';
-    }
-    return s;
-  }
 
-  /** Signature of the canvas-rendered fields of all drawings (excludes project_id). */
-  private signatureOfDrawings(drawings: Drawing[]): string {
-    let s = '';
-    for (const d of drawings) {
-      s += d.drawing_id + '|' + d.x + '|' + d.y + '|' + d.z + '|' + d.rotation + '|' + d.locked + '|' + d.svg + '§';
-    }
-    return s;
-  }
 }

--- a/src/app/cartography/components/d3-map/d3-map.component.ts
+++ b/src/app/cartography/components/d3-map/d3-map.component.ts
@@ -89,12 +89,16 @@ export class D3MapComponent implements OnInit, OnChanges, OnDestroy {
   // redraw per frame regardless of how many WS notifications / zoom events /
   // signal writes fire in between.
   private rafId: number | null = null;
+  // Whether the coalesced redraw may be gated. Only DATA-driven redraws (the
+  // signal effect) are gated — zoom/resize/settings/tool switches always redraw,
+  // so the gate can never skip a redraw the selection tool or canvas transform
+  // needs. Any non-gated trigger in a frame downgrades the pending redraw.
+  private pendingGated = true;
   // Visual signatures of the last-drawn nodes/links/drawings (only
-  // canvas-rendered fields). redraw() skips the full draw when none changed.
+  // canvas-rendered fields). The gated data redraw skips when none changed.
   private lastNodeSig = '';
   private lastLinkSig = '';
   private lastDrawSig = '';
-  private lastViewSig = '';
   protected settings = {
     show_interface_labels: true,
   };
@@ -141,7 +145,8 @@ export class D3MapComponent implements OnInit, OnChanges, OnDestroy {
       this.links();
       this.drawings();
       if (this.mapChangeDetectorRef.hasBeenDrawn) {
-        this.scheduleRedraw();
+        // Data-only trigger: the redraw may be skipped if nothing visual changed.
+        this.scheduleRedraw(true);
       }
     });
   }
@@ -320,13 +325,19 @@ export class D3MapComponent implements OnInit, OnChanges, OnDestroy {
   // Coalesce redraw requests to at most one per animation frame. Every
   // trigger (signal-driven data change via effect, changesDetected, zoom,
   // resize, map settings) calls this instead of redraw() directly.
-  private scheduleRedraw() {
+  private scheduleRedraw(gated = false) {
     if (this.rafId !== null) {
+      // Already scheduled this frame: a non-gated trigger (zoom, resize,
+      // settings, tool switches) makes the coalesced redraw unconditional.
+      if (!gated) this.pendingGated = false;
       return;
     }
+    this.pendingGated = gated;
     this.rafId = requestAnimationFrame(() => {
       this.rafId = null;
-      this.redraw();
+      const runGated = this.pendingGated;
+      this.pendingGated = true;
+      this.redraw(runGated);
     });
   }
 
@@ -401,40 +412,29 @@ export class D3MapComponent implements OnInit, OnChanges, OnDestroy {
     this.graphDataManager.setSymbols(this.symbols());
   }
 
-  private redraw() {
+  private redraw(gated = false) {
     this.updateGrid();
 
-    // Visual-signature gate: skip the expensive full draw (graphDataManager
-    // conversion + D3 data-join + getBBox/getTotalLength reflows) when no
-    // canvas-rendered field changed since the last draw. This is what stops a
-    // flood of non-visual updates — e.g. per-def marker config fanning out
-    // link.updated that only changes `markers`, or node.updated that only
-    // changes console/properties/command_line — from re-rendering the whole map.
-    // `viewSig` covers render-affecting state that isn't the data itself: zoom
-    // scale, viewport size (resize), and the interface-labels toggle.
-    const nodeSig = this.signatureOfNodes(this.nodes());
-    const linkSig = this.signatureOfLinks(this.links());
-    const drawSig = this.signatureOfDrawings(this.drawings());
-    const viewSig =
-      this.context.transformation.k +
-      '|' +
-      document.documentElement.clientWidth +
-      '|' +
-      document.documentElement.clientHeight +
-      '|' +
-      this.settings.show_interface_labels;
-    if (
-      nodeSig === this.lastNodeSig &&
-      linkSig === this.lastLinkSig &&
-      drawSig === this.lastDrawSig &&
-      viewSig === this.lastViewSig
-    ) {
-      return;
+    if (gated) {
+      // Data-driven redraw (signal effect): skip the expensive full draw
+      // (graphDataManager conversion + D3 data-join + getBBox/getTotalLength
+      // reflows) when no canvas-rendered field changed since the last draw.
+      // This is what stops a flood of non-visual updates — e.g. per-def marker
+      // config fanning out link.updated that only changes `markers`, or
+      // node.updated that only changes console/properties/command_line — from
+      // re-rendering the whole map. Non-gated redraws (zoom, resize, settings,
+      // tool switches) always run: the gate must never skip a redraw the
+      // selection tool or canvas transform depends on.
+      const nodeSig = this.signatureOfNodes(this.nodes());
+      const linkSig = this.signatureOfLinks(this.links());
+      const drawSig = this.signatureOfDrawings(this.drawings());
+      if (nodeSig === this.lastNodeSig && linkSig === this.lastLinkSig && drawSig === this.lastDrawSig) {
+        return;
+      }
+      this.lastNodeSig = nodeSig;
+      this.lastLinkSig = linkSig;
+      this.lastDrawSig = drawSig;
     }
-    this.lastNodeSig = nodeSig;
-    this.lastLinkSig = linkSig;
-    this.lastDrawSig = drawSig;
-    this.lastViewSig = viewSig;
 
     this.graphDataManager.setNodes(this.nodes());
     this.graphDataManager.setLinks(this.links());

--- a/src/app/cartography/components/d3-map/d3-map.component.ts
+++ b/src/app/cartography/components/d3-map/d3-map.component.ts
@@ -94,6 +94,7 @@ export class D3MapComponent implements OnInit, OnChanges, OnDestroy {
   private lastNodeSig = '';
   private lastLinkSig = '';
   private lastDrawSig = '';
+  private lastViewSig = '';
   protected settings = {
     show_interface_labels: true,
   };
@@ -409,15 +410,31 @@ export class D3MapComponent implements OnInit, OnChanges, OnDestroy {
     // flood of non-visual updates — e.g. per-def marker config fanning out
     // link.updated that only changes `markers`, or node.updated that only
     // changes console/properties/command_line — from re-rendering the whole map.
+    // `viewSig` covers render-affecting state that isn't the data itself: zoom
+    // scale, viewport size (resize), and the interface-labels toggle.
     const nodeSig = this.signatureOfNodes(this.nodes());
     const linkSig = this.signatureOfLinks(this.links());
     const drawSig = this.signatureOfDrawings(this.drawings());
-    if (nodeSig === this.lastNodeSig && linkSig === this.lastLinkSig && drawSig === this.lastDrawSig) {
+    const viewSig =
+      this.context.transformation.k +
+      '|' +
+      document.documentElement.clientWidth +
+      '|' +
+      document.documentElement.clientHeight +
+      '|' +
+      this.settings.show_interface_labels;
+    if (
+      nodeSig === this.lastNodeSig &&
+      linkSig === this.lastLinkSig &&
+      drawSig === this.lastDrawSig &&
+      viewSig === this.lastViewSig
+    ) {
       return;
     }
     this.lastNodeSig = nodeSig;
     this.lastLinkSig = linkSig;
     this.lastDrawSig = drawSig;
+    this.lastViewSig = viewSig;
 
     this.graphDataManager.setNodes(this.nodes());
     this.graphDataManager.setLinks(this.links());

--- a/src/app/cartography/components/d3-map/d3-map.component.ts
+++ b/src/app/cartography/components/d3-map/d3-map.component.ts
@@ -347,6 +347,20 @@ export class D3MapComponent implements OnInit, OnChanges, OnDestroy {
   public createGraph(domElement: HTMLElement) {
     const rootElement = select(domElement);
     this.svg = rootElement.select<SVGSVGElement>('svg');
+    // Context is an app-lifetime singleton (provided in the eager
+    // CartographyModule), so its transformation (pan/scale), centerX/Y and size
+    // PERSIST across project open/close. Reset to a clean state here so every
+    // entry starts identically; redraw() then anchors the origin to the content
+    // center (getSize() leftSpace) from scratch.
+    this.context.transformation.x = 0;
+    this.context.transformation.y = 0;
+    this.context.transformation.k = 1;
+    this.context.centerX = null;
+    this.context.centerY = null;
+    this.context.size = new Size(0, 0);
+    this.lastNodeSig = '';
+    this.lastLinkSig = '';
+    this.lastDrawSig = '';
     this.graphLayout.connect(this.svg, this.context);
     this.graphLayout.draw(this.svg, this.context);
     this.mapChangeDetectorRef.hasBeenDrawn = true;
@@ -452,16 +466,20 @@ export class D3MapComponent implements OnInit, OnChanges, OnDestroy {
     // Recalculate after setNodes/Drawings so graphDataManager has current positions.
     this.context.size = this.getSize();
 
-    // Restore origin to prevent visual canvas shifting. The size is updated to
-    // accommodate new content, but the <g> transform origin stays stable so
-    // existing elements don't jump (same pattern as node-drag locking).
-    // The saved value starts null, and restoring null made the origin size/2 —
-    // which MOVES whenever the canvas resizes (e.g. during zoom), breaking
-    // cursor-centered zoom and shifting content. Fix the origin once, at the
-    // center of the project canvas (scene_width/2, scene_height/2 — defaults
-    // 2000x1000), so every open is deterministic and the zoom anchor holds.
-    this.context.centerX = savedCenterX ?? this.width() / 2;
-    this.context.centerY = savedCenterY ?? this.height() / 2;
+    // Origin anchor. On the FIRST redraw savedCenterX is null (createGraph
+    // reset), so adopt getSize()'s freshly-computed leftSpace/topSpace — the
+    // content-centered origin — rather than width()/2 (scene center). Scene
+    // center leaves content off-center whenever the content bbox ≠ scene center.
+    // Worse: the ngOnInit getSize() (:206) reads the app-singleton
+    // graphDataManager BEFORE this redraw's setNodes clears it, so the old
+    // width()/2 fallback anchored the first visit at scene center (off-center)
+    // while a re-visit — with leftover graphDataManager data — accidentally
+    // anchored at the previous content center. That was the "first open wrong,
+    // re-open right" symptom. Anchoring to the current getSize() result removes
+    // the dependency on leftover state and centers content on every open.
+    // On later redraws savedCenterX is non-null and stays locked (drag-lock).
+    this.context.centerX = savedCenterX ?? this.context.centerX;
+    this.context.centerY = savedCenterY ?? this.context.centerY;
 
     this.graphLayout.draw(this.svg, this.context);
     this.textEditor().activateTextEditingForDrawings();

--- a/src/app/cartography/components/d3-map/d3-map.component.ts
+++ b/src/app/cartography/components/d3-map/d3-map.component.ts
@@ -26,6 +26,7 @@ import { affectedIsEmpty, emptyAffectedIds, mergeAffected } from '../../helpers/
 import { applyIncrementalPatches } from '../../helpers/dom-patcher';
 import { CanvasSizeDetector } from '../../helpers/canvas-size-detector';
 import { GraphDataManager } from '../../managers/graph-data-manager';
+import { LayersManager } from '../../managers/layers-manager';
 import { MapSettingsManager } from '../../managers/map-settings-manager';
 import { Context } from '../../models/context';
 import { Drawing } from '../../models/drawing';
@@ -106,6 +107,7 @@ export class D3MapComponent implements OnInit, OnChanges, OnDestroy {
   public drawingGridY: number = 0;
 
   private graphDataManager = inject(GraphDataManager);
+  private layersManager = inject(LayersManager);
   public context = inject(Context);
   private mapChangeDetectorRef = inject(MapChangeDetectorRef);
   private canvasSizeDetector = inject(CanvasSizeDetector);
@@ -198,7 +200,11 @@ export class D3MapComponent implements OnInit, OnChanges, OnDestroy {
     if (this.parentNativeElement !== null) {
       this.createGraph(this.parentNativeElement);
     }
-    this.context.size = this.getSize();
+    // context.size is already 0x0 from createGraph's reset — do NOT call
+    // getSize() here.  It runs before the first redraw's setNodes clears the
+    // app-singleton graphDataManager, so on a re-visit it reads the PREVIOUS
+    // project's nodes and leaks their content center into savedCenterX →
+    // the first redraw anchors origin to the wrong content center.
 
     // Initialize grid offsets based on project settings
     const project = this.project();
@@ -348,6 +354,10 @@ export class D3MapComponent implements OnInit, OnChanges, OnDestroy {
     this.context.transformation.k = 1;
     this.context.centerX = null;
     this.context.centerY = null;
+    // LayersManager is an app-lifetime singleton — its layer buckets carry
+    // over the previous project's nodes/links/drawings, which graphLayout.draw
+    // would render as a ghost frame before the first data redraw clears them.
+    this.layersManager.clear();
     this.context.size = new Size(0, 0);
     this.graphLayout.connect(this.svg, this.context);
     this.graphLayout.draw(this.svg, this.context);

--- a/src/app/cartography/datasources/datasource.ts
+++ b/src/app/cartography/datasources/datasource.ts
@@ -2,6 +2,11 @@ import { BehaviorSubject, Subject } from 'rxjs';
 
 export abstract class DataSource<T> {
   protected data: T[] = [];
+  // key -> array index, kept in sync with `data` for O(1) lookups. Item
+  // references are mutated in place (Object.assign), so an item never changes
+  // its array slot via update(); only add/remove/set shift indices (handled by
+  // reindex).
+  protected keyIndex = new Map<any, number>();
   protected dataChange: BehaviorSubject<T[]> = new BehaviorSubject<T[]>([]);
   protected itemUpdated: Subject<T> = new Subject<T>();
 
@@ -13,34 +18,34 @@ export abstract class DataSource<T> {
     const index = this.findIndex(item);
     if (index >= 0) {
       this.update(item);
-    } else {
-      this.data.push(item);
-      this.dataChange.next(this.data);
+      return;
     }
+    // New array reference so signal consumers (signal.set) actually re-fire;
+    // Object.is on the previous same-reference emit was a no-op.
+    this.data = [...this.data, item];
+    this.keyIndex.set(this.getItemKey(item), this.data.length - 1);
+    this.dataChange.next(this.data);
   }
 
   public set(data: T[]) {
-    data.forEach((item) => {
-      const index = this.findIndex(item);
-      if (index >= 0) {
-        const updated = Object.assign(this.data[index], item);
-        this.data[index] = updated;
-      } else {
-        this.data.push(item);
-      }
-    });
-
-    const toRemove = this.data.filter(
-      (item) => data.filter((i) => this.getItemKey(i) === this.getItemKey(item)).length === 0
-    );
-    toRemove.forEach((item) => this.remove(item));
-
+    // O(N) reconcile that preserves Object.assign merge semantics: existing
+    // items are reused and mutated in place (so client-side fields such as
+    // symbol_url/width/height are retained), items not present in `data` are
+    // dropped.
+    const newData: T[] = [];
+    for (const item of data || []) {
+      const key = this.getItemKey(item);
+      const existingIdx = this.keyIndex.get(key);
+      newData.push(existingIdx !== undefined ? Object.assign(this.data[existingIdx], item) : item);
+    }
+    this.data = newData;
+    this.reindex();
     this.dataChange.next(this.data);
   }
 
   public get(key: string | number) {
-    const index = this.data.findIndex((i: T) => this.getItemKey(i) === key);
-    if (index >= 0) {
+    const index = this.keyIndex.get(key);
+    if (index !== undefined) {
       return this.data[index];
     }
   }
@@ -48,7 +53,11 @@ export abstract class DataSource<T> {
   public update(item: T) {
     const index = this.findIndex(item);
     if (index >= 0) {
+      // Mutate the existing item in place to preserve reference identity
+      // (SelectionManager / D3 data-join / inline-window maps hold these
+      // refs), but emit a NEW array reference so signal consumers re-fire.
       const updated = Object.assign(this.data[index], item);
+      this.data = [...this.data];
       this.data[index] = updated;
       this.dataChange.next(this.data);
       this.itemUpdated.next(updated);
@@ -58,7 +67,8 @@ export abstract class DataSource<T> {
   public remove(item: T) {
     const index = this.findIndex(item);
     if (index >= 0) {
-      this.data.splice(index, 1);
+      this.data = this.data.filter((_, i) => i !== index);
+      this.reindex();
       this.dataChange.next(this.data);
     }
   }
@@ -73,11 +83,20 @@ export abstract class DataSource<T> {
 
   public clear() {
     this.data = [];
+    this.keyIndex.clear();
     this.dataChange.next(this.data);
   }
 
-  private findIndex(item: T) {
-    return this.data.findIndex((i: T) => this.getItemKey(i) === this.getItemKey(item));
+  private reindex() {
+    this.keyIndex.clear();
+    for (let i = 0; i < this.data.length; i++) {
+      this.keyIndex.set(this.getItemKey(this.data[i]), i);
+    }
+  }
+
+  protected findIndex(item: T) {
+    const index = this.keyIndex.get(this.getItemKey(item));
+    return index === undefined ? -1 : index;
   }
 
   protected abstract getItemKey(item: T): any;

--- a/src/app/cartography/datasources/datasource.ts
+++ b/src/app/cartography/datasources/datasource.ts
@@ -73,6 +73,29 @@ export abstract class DataSource<T> {
     }
   }
 
+  /**
+   * Batch-apply additions and removals with a single array-copy and
+   * dataChange emission. Existing items that were mutated in-place by the
+   * caller (Object.assign) do NOT need to be passed here — only structural
+   * changes (new / dropped keys) require applyBatch.
+   */
+  public applyBatch(additions: T[], removals: T[]): void {
+    for (const item of additions) {
+      this.data = [...this.data, item];
+      this.keyIndex.set(this.getItemKey(item), this.data.length - 1);
+    }
+
+    if (removals.length > 0) {
+      const removeKeys = new Set(removals.map((r) => this.getItemKey(r)));
+      this.data = this.data.filter((item) => !removeKeys.has(this.getItemKey(item)));
+      this.reindex();
+    }
+
+    // Fresh array reference so signal consumers re-fire
+    this.data = [...this.data];
+    this.dataChange.next(this.data);
+  }
+
   public get changes() {
     return this.dataChange;
   }

--- a/src/app/cartography/directives/zooming-canvas.directive.ts
+++ b/src/app/cartography/directives/zooming-canvas.directive.ts
@@ -38,6 +38,10 @@ export class ZoomingCanvasDirective implements OnInit, OnDestroy {
   addListener() {
     this.wheelListener = (event: WheelEvent) => {
       event.stopPropagation();
+      // In pan mode the wheel means zoom — stop the browser from ALSO scrolling
+      // the page (which requires a non-passive listener; passive:true can't
+      // preventDefault).
+      event.preventDefault();
 
       let zoom = event.deltaY;
       zoom = event.deltaMode === 0 ? zoom / 100 : zoom / 3;
@@ -57,9 +61,10 @@ export class ZoomingCanvasDirective implements OnInit, OnDestroy {
       });
     };
 
-    // Use passive: true since we're using CSS to prevent default zoom
+    // Non-passive so preventDefault() can stop the page from scrolling while
+    // zooming. touch-action: none in ngOnInit handles touch pinch-zoom.
     this.element.nativeElement.addEventListener('wheel', this.wheelListener as EventListenerOrEventListenerObject, {
-      passive: true,
+      passive: false,
     });
   }
 

--- a/src/app/cartography/directives/zooming-canvas.directive.ts
+++ b/src/app/cartography/directives/zooming-canvas.directive.ts
@@ -1,5 +1,5 @@
 import { Directive, ElementRef, OnDestroy, OnInit, Renderer2 } from '@angular/core';
-import { select } from 'd3-selection';
+import { pointer, select } from 'd3-selection';
 import { Subscription } from 'rxjs';
 import { MapScaleService } from '@services/mapScale.service';
 import { MovingEventSource } from '../events/moving-event-source';
@@ -50,14 +50,31 @@ export class ZoomingCanvasDirective implements OnInit, OnDestroy {
       const canvas = view.selectAll<SVGGElement, Context>('g.canvas').data([this.context]);
 
       canvas.attr('transform', () => {
-        this.context.transformation.k = this.context.transformation.k - zoom / 10;
+        const oldK = this.context.transformation.k;
+        if (!oldK || isNaN(oldK)) return;
+        const newK = Math.max(0.01, oldK - zoom / 10);
 
-        const xTrans = this.context.getZeroZeroTransformationPoint().x + this.context.transformation.x;
-        const yTrans = this.context.getZeroZeroTransformationPoint().y + this.context.transformation.y;
-        const kTrans = this.context.transformation.k;
-        this.mapsScaleService.setScale(kTrans);
+        // Cursor-centered zoom: keep the canvas point under the cursor fixed.
+        // That canvas point is (svg cursor - origin - pan) / k.
+        const cursor = pointer(event, this.element.nativeElement);
+        const origin = this.context.getZeroZeroTransformationPoint();
+        const tx = origin.x + this.context.transformation.x;
+        const ty = origin.y + this.context.transformation.y;
+        const canvasX = (cursor[0] - tx) / oldK;
+        const canvasY = (cursor[1] - ty) / oldK;
 
-        return `translate(${xTrans}, ${yTrans}) scale(${kTrans})`;
+        // Bake the offset into the pan (transformation.x/y) so the transform
+        // that graphLayout.draw() rebuilds after the scale change stays centered
+        // on the cursor instead of snapping back to the canvas origin.
+        this.context.transformation.k = newK;
+        this.context.transformation.x += canvasX * (oldK - newK);
+        this.context.transformation.y += canvasY * (oldK - newK);
+
+        const xTrans = origin.x + this.context.transformation.x;
+        const yTrans = origin.y + this.context.transformation.y;
+        this.mapsScaleService.setScale(newK);
+
+        return `translate(${xTrans}, ${yTrans}) scale(${newK})`;
       });
     };
 

--- a/src/app/cartography/directives/zooming-canvas.directive.ts
+++ b/src/app/cartography/directives/zooming-canvas.directive.ts
@@ -52,7 +52,10 @@ export class ZoomingCanvasDirective implements OnInit, OnDestroy {
       canvas.attr('transform', () => {
         const oldK = this.context.transformation.k;
         if (!oldK || isNaN(oldK)) return;
-        const newK = Math.max(0.01, oldK - zoom / 10);
+        // Proportional zoom: each wheel notch multiplies k by ~exp(∓0.1), so the
+        // step feels uniform at every zoom level. (The old absolute −zoom/10
+        // step made one notch a 50%+ jump when zoomed far out.)
+        const newK = Math.max(0.01, oldK * Math.exp(-zoom / 10));
 
         // Cursor-centered zoom: keep the canvas point under the cursor fixed.
         // That canvas point is (svg cursor - origin - pan) / k.

--- a/src/app/cartography/helpers/dom-patcher.ts
+++ b/src/app/cartography/helpers/dom-patcher.ts
@@ -28,53 +28,75 @@ export function applyIncrementalPatches(
   let needsFullDraw = false;
 
   // ── Structural changes always require full draw (enter / exit) ──
-  if (affected.additions.nodes.length > 0 || affected.removals.nodes.length > 0) {
-    needsFullDraw = true;
-  }
-  if (affected.additions.links.length > 0 || affected.removals.links.length > 0) {
-    needsFullDraw = true;
-  }
-  if (affected.additions.drawings.length > 0 || affected.removals.drawings.length > 0) {
-    needsFullDraw = true;
-  }
+  if (affected.additions.nodes.length > 0 || affected.removals.nodes.length > 0) needsFullDraw = true;
+  if (affected.additions.links.length > 0 || affected.removals.links.length > 0) needsFullDraw = true;
+  if (affected.additions.drawings.length > 0 || affected.removals.drawings.length > 0) needsFullDraw = true;
 
-  // ── Node targeted updates ──
+  if (needsFullDraw) return true;
+
+  // ── Node / Drawing targeted updates ──
   const nodes = graphDataManager.getNodes();
-  for (const [nodeId, groups] of affected.updates) {
-    const isNodeUpdate = affected.updates.has(nodeId) && groups != null;
+  const drawings = graphDataManager.getDrawings();
 
-    if (!isNodeUpdate) continue;
+  for (const [itemId, groups] of affected.updates) {
+    const onlyXy = groups.length === 1 && groups[0] === 'xY';
+    const onlyXyZ  = groups.every((g) => g === 'xY' || g === 'z');
+    const onlyLabel = groups.length === 1 && groups[0] === 'label';
 
-    // If ONLY xY changed: targeted DOM transform update (no reflow, Repaint only)
-    if (groups.length === 1 && groups[0] === 'xY') {
-      const node = nodes.find((n) => n.id === nodeId);
+    // Node: only xY (or xY+z) → targeted transform
+    if (onlyXyZ && nodes.some((n) => n.id === itemId)) {
+      const node = nodes.find((n) => n.id === itemId);
       if (node) {
         svg
-          .select(`g.node[node_id="${d3SelectEscape(nodeId)}"]`)
+          .select(`g.node[node_id="${d3SelectEscape(itemId)}"]`)
           .select<SVGGElement>('g.node_body')
           .attr('transform', `translate(${node.x}, ${node.y})`);
       }
       continue;
     }
 
-    // Any other node change → full draw (for now; Commit 3 will add
-    // targeted updates for text/label/visual/symbol via widget patch methods)
-    needsFullDraw = true;
-  }
-
-  // ── Link / Drawing changes → full draw for now (Commit 3) ──
-  for (const [_linkId] of affected.updates) {
-    // If the key is NOT in the node updates we just handled, it's a link/drawing
-    // change that needs full draw.  We don't have targeted link/drawing patching
-    // yet, so flag it.
-  }
-  // Simpler: if any link or drawing updates exist, full draw.
-  for (const [id] of affected.updates) {
-    const isNode = nodes.some((n) => n.id === id);
-    if (!isNode) {
-      needsFullDraw = true;
-      break;
+    // Node: only label → targeted text update + getBBox (only that label)
+    if (onlyLabel && nodes.some((n) => n.id === itemId)) {
+      const node = nodes.find((n) => n.id === itemId);
+      if (node && node.label) {
+        const label = node.label;
+        const labelSel = svg.select(`g.node[node_id="${d3SelectEscape(itemId)}"]`).select('text.label');
+        if (!labelSel.empty()) {
+          labelSel
+            .attr('style', (label as any).style)
+            .text((label as any).text)
+            .attr('x', (label as any).x)
+            .attr('y', (label as any).y);
+          // Recompute the label selection rect bbox
+          const bbox = (labelSel.node() as SVGTextElement | null)?.getBBox();
+          if (bbox) {
+            svg
+              .select(`g.node[node_id="${d3SelectEscape(itemId)}"]`)
+              .select('rect.label_selection')
+              .attr('x', bbox.x)
+              .attr('y', bbox.y)
+              .attr('width', bbox.width)
+              .attr('height', bbox.height);
+          }
+        }
+      }
+      continue;
     }
+
+    // Drawing: only xY (or xY+z) → targeted transform
+    if (onlyXyZ && drawings.some((d) => d.id === itemId)) {
+      const drawing = drawings.find((d) => d.id === itemId);
+      if (drawing) {
+        svg
+          .select(`g.drawing[drawing_id="${d3SelectEscape(itemId)}"]`)
+          .select<SVGGElement>('g.drawing_body')
+          .attr('transform', `translate(${drawing.x}, ${drawing.y}) rotate(${drawing.rotation})`);
+      }
+      continue;
+    }
+
+    // Anything else → fall through to full draw
+    needsFullDraw = true;
   }
 
   return needsFullDraw;

--- a/src/app/cartography/helpers/dom-patcher.ts
+++ b/src/app/cartography/helpers/dom-patcher.ts
@@ -1,0 +1,86 @@
+/**
+ * Targeted DOM patcher for incremental D3 map updates.
+ *
+ * When a data-driven (gated) redraw only contains xY-position changes on
+ * nodes, we can skip the full graphLayout.draw (D3 data-join + getBBox
+ * reflows) and directly update the affected DOM elements.  Everything else
+ * (structural changes, link/drawing updates, non-xY visual changes) falls
+ * back to full draw for now — widget-specific targeted-update methods
+ * (Commit 3) will extend this gradually.
+ */
+
+import * as d3 from 'd3';
+import { Context } from '../models/context';
+import { AffectedIds } from './item-signature';
+import { GraphDataManager } from '../managers/graph-data-manager';
+
+/**
+ * Apply incremental DOM patches for items that only had xY position changes.
+ * Returns `true` if a FULL draw is still required (structural changes or
+ * non-xY updates were found).
+ */
+export function applyIncrementalPatches(
+  svg: d3.Selection<SVGSVGElement, unknown, null, unknown>,
+  affected: AffectedIds,
+  graphDataManager: GraphDataManager,
+  _context: Context
+): boolean {
+  let needsFullDraw = false;
+
+  // ── Structural changes always require full draw (enter / exit) ──
+  if (affected.additions.nodes.length > 0 || affected.removals.nodes.length > 0) {
+    needsFullDraw = true;
+  }
+  if (affected.additions.links.length > 0 || affected.removals.links.length > 0) {
+    needsFullDraw = true;
+  }
+  if (affected.additions.drawings.length > 0 || affected.removals.drawings.length > 0) {
+    needsFullDraw = true;
+  }
+
+  // ── Node targeted updates ──
+  const nodes = graphDataManager.getNodes();
+  for (const [nodeId, groups] of affected.updates) {
+    const isNodeUpdate = affected.updates.has(nodeId) && groups != null;
+
+    if (!isNodeUpdate) continue;
+
+    // If ONLY xY changed: targeted DOM transform update (no reflow, Repaint only)
+    if (groups.length === 1 && groups[0] === 'xY') {
+      const node = nodes.find((n) => n.id === nodeId);
+      if (node) {
+        svg
+          .select(`g.node[node_id="${d3SelectEscape(nodeId)}"]`)
+          .select<SVGGElement>('g.node_body')
+          .attr('transform', `translate(${node.x}, ${node.y})`);
+      }
+      continue;
+    }
+
+    // Any other node change → full draw (for now; Commit 3 will add
+    // targeted updates for text/label/visual/symbol via widget patch methods)
+    needsFullDraw = true;
+  }
+
+  // ── Link / Drawing changes → full draw for now (Commit 3) ──
+  for (const [_linkId] of affected.updates) {
+    // If the key is NOT in the node updates we just handled, it's a link/drawing
+    // change that needs full draw.  We don't have targeted link/drawing patching
+    // yet, so flag it.
+  }
+  // Simpler: if any link or drawing updates exist, full draw.
+  for (const [id] of affected.updates) {
+    const isNode = nodes.some((n) => n.id === id);
+    if (!isNode) {
+      needsFullDraw = true;
+      break;
+    }
+  }
+
+  return needsFullDraw;
+}
+
+/** Escape a string for use in a CSS attribute selector (node_id / link_id). */
+function d3SelectEscape(id: string): string {
+  return id.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}

--- a/src/app/cartography/helpers/item-signature.ts
+++ b/src/app/cartography/helpers/item-signature.ts
@@ -1,0 +1,122 @@
+/**
+ * Per-item visual signatures with grouped sub-signatures — used by
+ * GraphDataManager for incremental diff and by dom-patcher for dispatching
+ * targeted DOM updates (e.g. position change → transform; text change →
+ * getBBox; path change → recalc d).
+ *
+ * Field sets are kept in sync with D3MapComponent.signatureOfNodes /
+ * signatureOfLinks / signatureOfDrawings.  Link signatures exclude `markers`
+ * (marker-flash has its own per-frame batched update path).
+ */
+
+export type NodeSigGroup = 'xY' | 'z' | 'visual' | 'label' | 'ports' | 'type';
+export type LinkSigGroup = 'nodes' | 'visual';
+export type DrawingSigGroup = 'xY' | 'z' | 'visual';
+
+export interface ItemSignatures<T extends string = string> {
+  all: string;
+  groups: Record<T, string>;
+}
+
+export interface AffectedIds {
+  additions: { nodes: string[]; links: string[]; drawings: string[] };
+  updates: Map<string, string[] /* changed group names */>;
+  removals: { nodes: string[]; links: string[]; drawings: string[] };
+}
+
+export function emptyAffectedIds(): AffectedIds {
+  return {
+    additions: { nodes: [], links: [], drawings: [] },
+    updates: new Map(),
+    removals: { nodes: [], links: [], drawings: [] },
+  };
+}
+
+export function mergeAffected(base: AffectedIds, ...others: AffectedIds[]): AffectedIds {
+  for (const o of others) {
+    base.additions.nodes.push(...o.additions.nodes);
+    base.additions.links.push(...o.additions.links);
+    base.additions.drawings.push(...o.additions.drawings);
+    base.removals.nodes.push(...o.removals.nodes);
+    base.removals.links.push(...o.removals.links);
+    base.removals.drawings.push(...o.removals.drawings);
+    for (const [id, groups] of o.updates) {
+      const existing = base.updates.get(id);
+      if (existing) {
+        for (const g of groups) if (!existing.includes(g)) existing.push(g);
+      } else {
+        base.updates.set(id, [...groups]);
+      }
+    }
+  }
+  return base;
+}
+
+export function affectedIsEmpty(a: AffectedIds): boolean {
+  return (
+    a.additions.nodes.length === 0 &&
+    a.additions.links.length === 0 &&
+    a.additions.drawings.length === 0 &&
+    a.removals.nodes.length === 0 &&
+    a.removals.links.length === 0 &&
+    a.removals.drawings.length === 0 &&
+    a.updates.size === 0
+  );
+}
+
+// ── Node ────────────────────────────────────────────────────────
+
+export function nodeSignatures(
+  n: { node_id: string; x: number; y: number; z: number; symbol: string; symbol_url: string; width: number; height: number; status: string; locked: boolean; name: string; node_type: string; first_port_name: string; port_name_format: string; port_segment_size: number; label: unknown; ports: unknown }
+): ItemSignatures<NodeSigGroup> {
+  const xY = `${n.x}|${n.y}`;
+  const z = `${n.z}`;
+  const visual = `${n.symbol}|${n.symbol_url}|${n.width}|${n.height}|${n.status}|${n.locked}|${n.name}`;
+  const label = JSON.stringify(n.label);
+  const ports = JSON.stringify(n.ports);
+  const type = `${n.node_type}|${n.first_port_name}|${n.port_name_format}|${n.port_segment_size}`;
+  return {
+    all: `${n.node_id}|${xY}|${z}|${visual}|${label}|${ports}|${type}`,
+    groups: { xY, z, visual, label, ports, type },
+  };
+}
+
+// ── Link ────────────────────────────────────────────────────────
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function linkSignatures(l: any): ItemSignatures<LinkSigGroup> {
+  const nodes = JSON.stringify(l.nodes);
+  const visual = `${l.capturing}|${l.suspend}|${l.show_filters_icon}|${l.wireshark}|${l.link_type}|${JSON.stringify(l.filters)}|${JSON.stringify(l.link_style)}`;
+  return {
+    all: `${l.link_id}|${nodes}|${visual}`,
+    groups: { nodes, visual },
+  };
+}
+
+// ── Drawing ─────────────────────────────────────────────────────
+
+export function drawingSignatures(
+  d: { drawing_id: string; x: number; y: number; z: number; rotation: number; locked: boolean; svg: string }
+): ItemSignatures<DrawingSigGroup> {
+  const xY = `${d.x}|${d.y}`;
+  const z = `${d.z}`;
+  const visual = `${d.rotation}|${d.locked}|${d.svg}`;
+  return {
+    all: `${d.drawing_id}|${xY}|${z}|${visual}`,
+    groups: { xY, z, visual },
+  };
+}
+
+// ── Diff helper ─────────────────────────────────────────────────
+
+export function changedGroups<T extends string>(
+  oldGroups: Record<T, string> | undefined,
+  curGroups: Record<T, string>
+): T[] {
+  if (!oldGroups) return Object.keys(curGroups) as T[];
+  const changed: T[] = [];
+  for (const k of Object.keys(oldGroups) as T[]) {
+    if (oldGroups[k] !== curGroups[k]) changed.push(k);
+  }
+  return changed;
+}

--- a/src/app/cartography/managers/graph-data-manager.ts
+++ b/src/app/cartography/managers/graph-data-manager.ts
@@ -13,13 +13,36 @@ import {
 } from '../datasources/map-datasource';
 import { MultiLinkCalculatorHelper } from '../helpers/multi-link-calculator-helper';
 import { Drawing } from '../models/drawing';
+import { MapDrawing } from '../models/map/map-drawing';
 import { MapLink } from '../models/map/map-link';
 import { MapNode } from '../models/map/map-node';
 import { Node } from '../models/node';
 import { LayersManager } from './layers-manager';
+import {
+  AffectedIds,
+  changedGroups,
+  drawingSignatures,
+  DrawingSigGroup,
+  emptyAffectedIds,
+  ItemSignatures,
+  LinkSigGroup,
+  linkSignatures,
+  nodeSignatures,
+  NodeSigGroup,
+} from '../helpers/item-signature';
 
 @Injectable()
 export class GraphDataManager {
+  // Per-item visual signatures and sub-signatures — used to diff incremental
+  // setNodes/setLinks/setDrawings and to produce AffectedIds for the dom-patcher.
+  private nodeSig = new Map<string, ItemSignatures<NodeSigGroup>>();
+  private linkSig = new Map<string, ItemSignatures<LinkSigGroup>>();
+  private drawingSig = new Map<string, ItemSignatures<DrawingSigGroup>>();
+
+  // Reverse index: nodeId → set of linkIds whose source or target is that node.
+  // Maintained incrementally by setLinks and recomputed on first load.
+  private nodeToLinks = new Map<string, Set<string>>();
+
   constructor(
     private mapNodesDataSource: MapNodesDataSource,
     private mapLinksDataSource: MapLinksDataSource,
@@ -33,33 +56,210 @@ export class GraphDataManager {
     private multiLinkCalculator: MultiLinkCalculatorHelper
   ) {}
 
-  public setNodes(nodes: Node[]) {
-    if (nodes) {
-      const mapNodes = nodes.map((n) => this.nodeToMapNode.convert(n));
-      this.mapNodesDataSource.set(mapNodes);
+  // ── Public read-access ────────────────────────────────────────
 
-      this.assignDataToLinks();
-      this.onDataUpdate();
+  public getNodes() { return this.mapNodesDataSource.getItems(); }
+  public getLinks() { return this.mapLinksDataSource.getItems(); }
+  public getDrawings() { return this.mapDrawingsDataSource.getItems(); }
+  public getSymbols() { return this.mapSymbolsDataSource.getItems(); }
+
+  // ── Incremental setters (return AffectedIds for dom-patcher) ───
+
+  public setNodes(nodes: Node[]): AffectedIds {
+    if (!nodes) return emptyAffectedIds();
+
+    const affected = emptyAffectedIds();
+    const nodesByIdEntries: [string, MapNode][] = [];
+    for (const n of this.getNodes()) {
+      if (n.id != null) nodesByIdEntries.push([n.id, n]);
     }
+    const existingMap = new Map(nodesByIdEntries);
+    const newIds = new Set(nodes.map((n) => n.node_id));
+    const additions: MapNode[] = [];
+    const removals: MapNode[] = [];
+
+    for (const n of nodes) {
+      const sigs = nodeSignatures(n);
+      const existing = existingMap.get(n.node_id);
+      if (!existing) {
+        const converted = this.nodeToMapNode.convert(n);
+        additions.push(converted);
+        this.nodeSig.set(n.node_id, sigs);
+        affected.additions.nodes.push(n.node_id);
+        this.layersManager.addNode(converted);
+      } else {
+        const oldSigs = this.nodeSig.get(n.node_id);
+        const changed = changedGroups(oldSigs?.groups, sigs.groups);
+        if (changed.length > 0) {
+          const converted = this.nodeToMapNode.convert(n);
+          Object.assign(existing, converted);
+          this.nodeSig.set(n.node_id, sigs);
+          affected.updates.set(n.node_id, changed);
+          // Layer migration when z changes
+          const oldZ = oldSigs?.groups.z;
+          const newZ = sigs.groups.z;
+          if (oldZ !== undefined && oldZ !== newZ) {
+            this.layersManager.moveNode(existing, Number(oldZ));
+          }
+        }
+      }
+    }
+
+    for (const [id] of this.nodeSig) {
+      if (!newIds.has(id)) {
+        const m = existingMap.get(id);
+        if (m) {
+          removals.push(m);
+          this.layersManager.removeNode(m);
+        }
+        this.nodeSig.delete(id);
+        affected.removals.nodes.push(id);
+      }
+    }
+
+    this.mapNodesDataSource.applyBatch(additions, removals);
+    this.assignDataToLinksIncremental(affected, existingMap);
+    return affected;
   }
 
-  public setLinks(links: Link[]) {
-    if (links) {
-      const mapLinks = links.map((l) => this.linkToMapLink.convert(l));
-      this.mapLinksDataSource.set(mapLinks);
+  public setLinks(links: Link[]): AffectedIds {
+    if (!links) return emptyAffectedIds();
 
-      this.assignDataToLinks();
-      this.onDataUpdate();
+    const affected = emptyAffectedIds();
+    const linksByIdEntries: [string, MapLink][] = [];
+    for (const l of this.getLinks()) {
+      if (l.id != null) linksByIdEntries.push([l.id, l]);
     }
+    const existingMap = new Map(linksByIdEntries);
+    const newIds = new Set(links.map((l) => l.link_id));
+    const additions: MapLink[] = [];
+    const removals: MapLink[] = [];
+
+    // Rebuild nodeToLinks incrementally
+    const oldLinkToNodes = new Map<string, [string, string]>();
+    for (const [id, l] of existingMap) {
+      if (l.source?.id && l.target?.id) {
+        oldLinkToNodes.set(id, [l.source.id, l.target.id]);
+      }
+    }
+
+    for (const l of links) {
+      const sigs = linkSignatures(l);
+      const existing = existingMap.get(l.link_id);
+      if (!existing) {
+        const converted = this.linkToMapLink.convert(l);
+        additions.push(converted);
+        this.linkSig.set(l.link_id, sigs);
+        affected.additions.links.push(l.link_id);
+        if (converted.source?.id && converted.target?.id) {
+          this.registerLinkNodes(l.link_id, converted.source.id, converted.target.id);
+        }
+      } else {
+        const oldSigs = this.linkSig.get(l.link_id);
+        const changed = changedGroups(oldSigs?.groups, sigs.groups);
+        if (changed.length > 0) {
+          const converted = this.linkToMapLink.convert(l);
+          Object.assign(existing, converted);
+          this.linkSig.set(l.link_id, sigs);
+          affected.updates.set(l.link_id, changed);
+          // Update nodeToLinks if nodes changed
+          if (changed.includes('nodes')) {
+            const oldPair = oldLinkToNodes.get(l.link_id);
+            if (oldPair) {
+              this.unregisterLinkNodes(l.link_id, oldPair[0], oldPair[1]);
+            }
+            if (existing.source?.id && existing.target?.id) {
+              this.registerLinkNodes(l.link_id, existing.source.id, existing.target.id);
+            }
+          }
+        }
+      }
+    }
+
+    for (const [id] of this.linkSig) {
+      if (!newIds.has(id)) {
+        const m = existingMap.get(id);
+        if (m) {
+          removals.push(m);
+          this.layersManager.removeLink(m);
+        }
+        this.linkSig.delete(id);
+        const oldPair = oldLinkToNodes.get(id);
+        if (oldPair) {
+          this.unregisterLinkNodes(id, oldPair[0], oldPair[1]);
+        }
+        affected.removals.links.push(id);
+      }
+    }
+
+    this.mapLinksDataSource.applyBatch(additions, removals);
+
+    // Layer: walk additions and removals only (updates with z change handled
+    // during setNodes — link layer depends on source/target z which only
+    // changes via node updates, not link updates alone).
+    for (const m of additions) this.layersManager.addLink(m);
+
+    // Recompute link x/y / source/target for affected links + multiLink groups.
+    // Full recompute is cheap enough here — we already know the affected set.
+    this.assignDataToLinksIncremental(affected, new Map());
+
+    return affected;
   }
 
-  public setDrawings(drawings: Drawing[]) {
-    if (drawings) {
-      const mapDrawings = drawings.map((d) => this.drawingToMapDrawing.convert(d));
-      this.mapDrawingsDataSource.set(mapDrawings);
+  public setDrawings(drawings: Drawing[]): AffectedIds {
+    if (!drawings) return emptyAffectedIds();
 
-      this.onDataUpdate();
+    const affected = emptyAffectedIds();
+    const drawingsByIdEntries: [string, MapDrawing][] = [];
+    for (const d of this.getDrawings()) {
+      if (d.id != null) drawingsByIdEntries.push([d.id, d]);
     }
+    const existingMap = new Map(drawingsByIdEntries);
+    const newIds = new Set(drawings.map((d) => d.drawing_id));
+    const additions: MapDrawing[] = [];
+    const removals: MapDrawing[] = [];
+
+    for (const d of drawings) {
+      const sigs = drawingSignatures(d);
+      const existing = existingMap.get(d.drawing_id);
+      if (!existing) {
+        const converted = this.drawingToMapDrawing.convert(d);
+        additions.push(converted);
+        this.drawingSig.set(d.drawing_id, sigs);
+        affected.additions.drawings.push(d.drawing_id);
+        this.layersManager.addDrawing(converted);
+      } else {
+        const oldSigs = this.drawingSig.get(d.drawing_id);
+        const changed = changedGroups(oldSigs?.groups, sigs.groups);
+        if (changed.length > 0) {
+          const converted = this.drawingToMapDrawing.convert(d);
+          Object.assign(existing, converted);
+          this.drawingSig.set(d.drawing_id, sigs);
+          affected.updates.set(d.drawing_id, changed);
+          if (changed.includes('z')) {
+            const oldZ = oldSigs?.groups.z;
+            if (oldZ !== undefined) {
+              this.layersManager.moveDrawing(existing, Number(oldZ));
+            }
+          }
+        }
+      }
+    }
+
+    for (const [id] of this.drawingSig) {
+      if (!newIds.has(id)) {
+        const d = existingMap.get(id);
+        if (d) {
+          removals.push(d);
+          this.layersManager.removeDrawing(d);
+        }
+        this.drawingSig.delete(id);
+        affected.removals.drawings.push(id);
+      }
+    }
+
+    this.mapDrawingsDataSource.applyBatch(additions, removals);
+    return affected;
   }
 
   public setSymbols(symbols: Symbol[]) {
@@ -69,48 +269,87 @@ export class GraphDataManager {
     }
   }
 
-  public getNodes() {
-    return this.mapNodesDataSource.getItems();
+  // ── node ↔ link index ─────────────────────────────────────────
+
+  private registerLinkNodes(linkId: string, sourceId: string, targetId: string) {
+    for (const nid of [sourceId, targetId]) {
+      let s = this.nodeToLinks.get(nid);
+      if (!s) { s = new Set(); this.nodeToLinks.set(nid, s); }
+      s.add(linkId);
+    }
   }
 
-  public getLinks() {
-    return this.mapLinksDataSource.getItems();
+  private unregisterLinkNodes(linkId: string, sourceId: string, targetId: string) {
+    for (const nid of [sourceId, targetId]) {
+      const s = this.nodeToLinks.get(nid);
+      if (s) { s.delete(linkId); if (s.size === 0) this.nodeToLinks.delete(nid); }
+    }
   }
 
-  public getDrawings() {
-    return this.mapDrawingsDataSource.getItems();
+  // ── Incremental assignDataToLinks ──────────────────────────────
+
+  private assignDataToLinksIncremental(affected: AffectedIds, _existingNodes: Map<string, MapNode>) {
+    const hasStructural = affected.additions.nodes.length > 0 || affected.removals.nodes.length > 0
+                       || affected.additions.links.length > 0 || affected.removals.links.length > 0;
+
+    if (hasStructural) {
+      // Fall back to full assignDataToLinks + full layers rebuild.
+      this.assignDataToLinksFull();
+      this.onDataUpdateFull();
+      return;
+    }
+
+    // Updates only: recompute source/target/x/y for affected links
+    const nodesById = new Map(this.getNodes().map((n) => [n.id, n]));
+    const affectedLinkIds = this.collectAffectedLinks(affected);
+
+    for (const linkId of affectedLinkIds) {
+      const link = this.mapLinksDataSource.get(linkId) as unknown as MapLink | undefined;
+      if (!link) continue;
+
+      const linkNodeData = link.nodes;
+      if (!linkNodeData || linkNodeData.length < 2) continue;
+      const sourceId = linkNodeData[0]?.nodeId;
+      const targetId = linkNodeData[1]?.nodeId;
+      const srcNode = sourceId ? nodesById.get(sourceId) : undefined;
+      const tgtNode = targetId ? nodesById.get(targetId) : undefined;
+      if (srcNode) Object.assign(link, { source: srcNode });
+      if (tgtNode) Object.assign(link, { target: tgtNode });
+      if (srcNode && tgtNode) {
+        Object.assign(link, {
+          x: srcNode.x + (tgtNode.x - srcNode.x) * 0.5,
+          y: srcNode.y + (tgtNode.y - srcNode.y) * 0.5,
+        });
+      }
+    }
+
+    this.multiLinkCalculator.assignDataToLinks(this.getLinks());
   }
 
-  public getSymbols() {
-    return this.mapSymbolsDataSource.getItems();
+  /** Collect link ids affected by node position/visual changes, including the multiLink closure. */
+  private collectAffectedLinks(affected: AffectedIds): Set<string> {
+    const linkIds = new Set<string>();
+    for (const [nodeId] of affected.updates) {
+      const linkSet = this.nodeToLinks.get(nodeId);
+      if (linkSet) for (const lid of linkSet) linkIds.add(lid);
+    }
+    // Also directly affected links (nodes changed)
+    for (const [linkId] of affected.updates) linkIds.add(linkId);
+    return linkIds;
   }
 
-  private onDataUpdate() {
-    this.layersManager.clear();
-    this.layersManager.setNodes(this.getNodes());
-    this.layersManager.setLinks(this.getLinks());
-    this.layersManager.setDrawings(this.getDrawings());
-  }
+  // ── Full rebuild paths (first load / structural change) ───────
 
-  private assignDataToLinks() {
-    const nodes_by_id = {};
-    this.getNodes().forEach((n: MapNode) => {
-      nodes_by_id[n.id] = n;
-    });
+  private assignDataToLinksFull() {
+    const nodesById: Record<string, MapNode> = {};
+    this.getNodes().forEach((n) => { nodesById[n.id] = n; });
 
     this.getLinks().forEach((link: MapLink) => {
-      if (!link.nodes || link.nodes.length < 2) {
-        return;
-      }
-      const source_id = link.nodes[0]?.nodeId;
-      const target_id = link.nodes[1]?.nodeId;
-      if (source_id && source_id in nodes_by_id) {
-        link.source = nodes_by_id[source_id];
-      }
-      if (target_id && target_id in nodes_by_id) {
-        link.target = nodes_by_id[target_id];
-      }
-
+      if (!link.nodes || link.nodes.length < 2) return;
+      const sourceId = link.nodes[0]?.nodeId;
+      const targetId = link.nodes[1]?.nodeId;
+      if (sourceId && sourceId in nodesById) link.source = nodesById[sourceId];
+      if (targetId && targetId in nodesById) link.target = nodesById[targetId];
       if (link.source && link.target) {
         link.x = link.source.x + (link.target.x - link.source.x) * 0.5;
         link.y = link.source.y + (link.target.y - link.source.y) * 0.5;
@@ -118,5 +357,12 @@ export class GraphDataManager {
     });
 
     this.multiLinkCalculator.assignDataToLinks(this.getLinks());
+  }
+
+  private onDataUpdateFull() {
+    this.layersManager.clear();
+    this.layersManager.setNodes(this.getNodes());
+    this.layersManager.setLinks(this.getLinks());
+    this.layersManager.setDrawings(this.getDrawings());
   }
 }

--- a/src/app/cartography/managers/layers-manager.ts
+++ b/src/app/cartography/managers/layers-manager.ts
@@ -51,6 +51,56 @@ export class LayersManager {
     this.layers = {};
   }
 
+  // ── Single-item incremental API (used by GraphDataManager incremental diff) ──
+
+  public addNode(node: MapNode): void {
+    this.getLayerForKey(node.z.toString()).nodes.push(node);
+  }
+
+  public removeNode(node: MapNode): void {
+    for (const key of Object.keys(this.layers)) {
+      this.layers[key].nodes = this.layers[key].nodes.filter((n) => n.id !== node.id);
+    }
+  }
+
+  public moveNode(node: MapNode, oldZ: number): void {
+    this.removeNode(node);
+    node.z = oldZ; // restored by caller if needed — we just route to new layer
+    this.addNode(node);
+  }
+
+  public addLink(link: MapLink): void {
+    if (!link.source || !link.target) return;
+    const key = Math.min(link.source.z, link.target.z).toString();
+    this.getLayerForKey(key).links.push(link);
+  }
+
+  public removeLink(link: MapLink): void {
+    for (const key of Object.keys(this.layers)) {
+      this.layers[key].links = this.layers[key].links.filter((l) => l.id !== link.id);
+    }
+  }
+
+  public moveLink(link: MapLink, oldSourceZ: number, oldTargetZ: number): void {
+    this.removeLink(link);
+    this.addLink(link);
+  }
+
+  public addDrawing(drawing: MapDrawing): void {
+    this.getLayerForKey(drawing.z.toString()).drawings.push(drawing);
+  }
+
+  public removeDrawing(drawing: MapDrawing): void {
+    for (const key of Object.keys(this.layers)) {
+      this.layers[key].drawings = this.layers[key].drawings.filter((d) => d.id !== drawing.id);
+    }
+  }
+
+  public moveDrawing(drawing: MapDrawing, _oldZ: number): void {
+    this.removeDrawing(drawing);
+    this.addDrawing(drawing);
+  }
+
   public getLayerForKey(key: string): Layer {
     if (!(key in this.layers)) {
       this.layers[key] = new Layer();

--- a/src/app/components/drawings-listeners/drawing-dragged/drawing-dragged.component.spec.ts
+++ b/src/app/components/drawings-listeners/drawing-dragged/drawing-dragged.component.spec.ts
@@ -4,6 +4,7 @@ import { DrawingDraggedComponent } from './drawing-dragged.component';
 import { DrawingsDataSource } from '../../../cartography/datasources/drawings-datasource';
 import { DrawingsEventSource } from '../../../cartography/events/drawings-event-source';
 import { DrawingService } from '@services/drawing.service';
+import { MapChangeDetectorRef } from '../../../cartography/services/map-change-detector-ref';
 import { ToasterService } from '@services/toaster.service';
 import { DraggedDataEvent } from '../../../cartography/events/event-source';
 import { MapDrawing } from '../../../cartography/models/map/map-drawing';
@@ -106,6 +107,7 @@ describe('DrawingDraggedComponent', () => {
       imports: [DrawingDraggedComponent],
       providers: [
         { provide: DrawingService, useValue: mockDrawingService },
+        { provide: MapChangeDetectorRef, useValue: { detectChanges: vi.fn() } },
         { provide: ToasterService, useValue: mockToasterService },
         { provide: ChangeDetectorRef, useValue: mockChangeDetectorRef },
         DrawingsDataSource,

--- a/src/app/components/drawings-listeners/drawing-dragged/drawing-dragged.component.ts
+++ b/src/app/components/drawings-listeners/drawing-dragged/drawing-dragged.component.ts
@@ -8,6 +8,7 @@ import { MapDrawing } from '../../../cartography/models/map/map-drawing';
 import { Project } from '@models/project';
 import { Controller } from '@models/controller';
 import { DrawingService } from '@services/drawing.service';
+import { MapChangeDetectorRef } from '../../../cartography/services/map-change-detector-ref';
 import { ToasterService } from '@services/toaster.service';
 
 @Component({
@@ -25,6 +26,7 @@ export class DrawingDraggedComponent implements OnInit, OnDestroy {
   private drawingService = inject(DrawingService);
   private drawingsDataSource = inject(DrawingsDataSource);
   private drawingsEventSource = inject(DrawingsEventSource);
+  private mapChangeDetectorRef = inject(MapChangeDetectorRef);
   private toasterService = inject(ToasterService);
   private cdr = inject(ChangeDetectorRef);
 
@@ -42,6 +44,12 @@ export class DrawingDraggedComponent implements OnInit, OnDestroy {
       .subscribe({
         next: (controllerDrawing: Drawing) => {
           this.drawingsDataSource.update(controllerDrawing);
+          // Force an un-gated redraw to correct the DOM. During drag the
+          // graphDataManager datum was moved to the cursor; snap is computed at
+          // drag end. If snap lands on the same grid point (small drag) the
+          // drawings signature is unchanged and the gated redraw skips, leaving
+          // the DOM at the cursor. detectChanges() → scheduleRedraw() (un-gated).
+          this.mapChangeDetectorRef.detectChanges();
         },
         error: (err) => {
           const message = err.error?.message || err.message || 'Failed to update drawing position';

--- a/src/app/components/drawings-listeners/node-dragged/node-dragged.component.spec.ts
+++ b/src/app/components/drawings-listeners/node-dragged/node-dragged.component.spec.ts
@@ -6,6 +6,7 @@ import { NodeDraggedComponent } from './node-dragged.component';
 import { NodesDataSource } from '../../../cartography/datasources/nodes-datasource';
 import { NodesEventSource } from '../../../cartography/events/nodes-event-source';
 import { NodeService } from '@services/node.service';
+import { MapChangeDetectorRef } from '../../../cartography/services/map-change-detector-ref';
 import { ToasterService } from '@services/toaster.service';
 import { DraggedDataEvent } from '../../../cartography/events/event-source';
 import { MapNode } from '../../../cartography/models/map/map-node';
@@ -108,6 +109,7 @@ describe('NodeDraggedComponent', () => {
       providers: [
         { provide: NodesDataSource, useValue: mockNodesDataSource },
         { provide: NodeService, useValue: mockNodeService },
+        { provide: MapChangeDetectorRef, useValue: { detectChanges: vi.fn() } },
         { provide: NodesEventSource, useValue: mockNodesEventSource },
         { provide: ToasterService, useValue: mockToasterService },
         { provide: ChangeDetectorRef, useValue: mockChangeDetectorRef },

--- a/src/app/components/drawings-listeners/node-dragged/node-dragged.component.ts
+++ b/src/app/components/drawings-listeners/node-dragged/node-dragged.component.ts
@@ -8,6 +8,7 @@ import { Node } from '../../../cartography/models/node';
 import { Project } from '@models/project';
 import { Controller } from '@models/controller';
 import { NodeService } from '@services/node.service';
+import { MapChangeDetectorRef } from '../../../cartography/services/map-change-detector-ref';
 import { ToasterService } from '@services/toaster.service';
 
 @Component({
@@ -25,6 +26,7 @@ export class NodeDraggedComponent implements OnInit, OnDestroy {
   private nodesDataSource = inject(NodesDataSource);
   private nodeService = inject(NodeService);
   private nodesEventSource = inject(NodesEventSource);
+  private mapChangeDetectorRef = inject(MapChangeDetectorRef);
   private toasterService = inject(ToasterService);
   private cdr = inject(ChangeDetectorRef);
 
@@ -42,6 +44,11 @@ export class NodeDraggedComponent implements OnInit, OnDestroy {
       .subscribe({
         next: (controllerNode: Node) => {
           this.nodesDataSource.update(controllerNode);
+          // Force an un-gated redraw to correct the DOM (see drawing-dragged for
+          // rationale): snap is computed at drag end, and if it lands on the same
+          // grid point the signature is unchanged → gated redraw skips → DOM stays
+          // at the cursor. detectChanges() → scheduleRedraw() (un-gated).
+          this.mapChangeDetectorRef.detectChanges();
         },
         error: (err) => {
           const message = err.error?.message || err.message || 'Failed to update node position';

--- a/src/app/components/project-map/context-menu/actions/delete-action/delete-action.component.spec.ts
+++ b/src/app/components/project-map/context-menu/actions/delete-action/delete-action.component.spec.ts
@@ -164,7 +164,7 @@ describe('DeleteActionComponent', () => {
   });
 
   describe('delete() - nodes', () => {
-    it('should remove non-locked nodes from nodesDataSource', () => {
+    it('should NOT remove non-locked nodes locally (canvas removal is WS-driven)', () => {
       const node = createMockNode({ locked: false });
       fixture.componentRef.setInput('nodes', [node]);
       fixture.componentRef.setInput('drawings', []);
@@ -173,7 +173,7 @@ describe('DeleteActionComponent', () => {
 
       component.delete();
 
-      expect(mockNodesDataSource.remove).toHaveBeenCalledWith(node);
+      expect(mockNodesDataSource.remove).not.toHaveBeenCalled();
     });
 
     it('should call nodeService.delete() for non-locked nodes', () => {
@@ -207,15 +207,16 @@ describe('DeleteActionComponent', () => {
       fixture.componentRef.setInput('nodes', [node]);
       fixture.componentRef.setInput('drawings', []);
       fixture.componentRef.setInput('links', []);
+      fixture.componentRef.setInput('controller', mockController);
 
       component.delete();
 
-      expect(mockNodesDataSource.remove).toHaveBeenCalled();
+      expect(mockNodeService.delete).toHaveBeenCalledWith(mockController, node);
     });
   });
 
   describe('delete() - drawings', () => {
-    it('should remove non-locked drawings from drawingsDataSource', () => {
+    it('should NOT remove non-locked drawings locally (canvas removal is WS-driven)', () => {
       const drawing = createMockDrawing({ locked: false });
       fixture.componentRef.setInput('nodes', []);
       fixture.componentRef.setInput('drawings', [drawing]);
@@ -224,7 +225,7 @@ describe('DeleteActionComponent', () => {
 
       component.delete();
 
-      expect(mockDrawingsDataSource.remove).toHaveBeenCalledWith(drawing);
+      expect(mockDrawingsDataSource.remove).not.toHaveBeenCalled();
     });
 
     it('should call drawingService.delete() for non-locked drawings', () => {
@@ -264,7 +265,7 @@ describe('DeleteActionComponent', () => {
 
       component.delete();
 
-      expect(mockLinksDataSource.remove).toHaveBeenCalledWith(link);
+      expect(mockLinksDataSource.remove).not.toHaveBeenCalled();
       expect(mockLinkService.deleteLink).toHaveBeenCalledWith(mockController, link);
     });
 
@@ -321,8 +322,8 @@ describe('DeleteActionComponent', () => {
 
       component.delete();
 
-      expect(mockNodesDataSource.remove).toHaveBeenCalledWith(node);
-      expect(mockDrawingsDataSource.remove).toHaveBeenCalledWith(drawing);
+      expect(mockNodeService.delete).toHaveBeenCalledWith(mockController, node);
+      expect(mockDrawingService.delete).toHaveBeenCalledWith(mockController, drawing);
       expect(mockLinksDataSource.remove).not.toHaveBeenCalled();
     });
 
@@ -337,7 +338,7 @@ describe('DeleteActionComponent', () => {
       component.delete();
 
       expect(mockToasterService.error).toHaveBeenCalledWith('Cannot delete locked node: Locked');
-      expect(mockNodesDataSource.remove).toHaveBeenCalledWith(unlockedNode);
+      expect(mockNodesDataSource.remove).not.toHaveBeenCalled();
       expect(mockNodeService.delete).toHaveBeenCalledWith(mockController, unlockedNode);
     });
   });

--- a/src/app/components/project-map/context-menu/actions/delete-action/delete-action.component.ts
+++ b/src/app/components/project-map/context-menu/actions/delete-action/delete-action.component.ts
@@ -4,9 +4,6 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatBottomSheet } from '@angular/material/bottom-sheet';
 import { ConfirmationBottomSheetComponent } from 'app/components/projects/confirmation-bottomsheet/confirmation-bottomsheet.component';
-import { DrawingsDataSource } from '../../../../../cartography/datasources/drawings-datasource';
-import { LinksDataSource } from '../../../../../cartography/datasources/links-datasource';
-import { NodesDataSource } from '../../../../../cartography/datasources/nodes-datasource';
 import { Drawing } from '../../../../../cartography/models/drawing';
 import { Node } from '../../../../../cartography/models/node';
 import { Link } from '@models/link';
@@ -25,9 +22,6 @@ import { ToasterService } from '@services/toaster.service';
 })
 export class DeleteActionComponent {
   private toasterService = inject(ToasterService);
-  private nodesDataSource = inject(NodesDataSource);
-  private drawingsDataSource = inject(DrawingsDataSource);
-  private linksDataSource = inject(LinksDataSource);
   private nodeService = inject(NodeService);
   private drawingService = inject(DrawingService);
   private linkService = inject(LinkService);
@@ -55,7 +49,10 @@ export class DeleteActionComponent {
   delete() {
     this.nodes().forEach((node) => {
       if (!node.locked) {
-        this.nodesDataSource.remove(node);
+        // Do NOT remove locally here (optimistic): the canvas removal is driven
+        // by the `node.deleted` WebSocket notification, which fires once the
+        // backend has actually deleted the node. Removing optimistically made
+        // nodes vanish before the backend confirmed the delete.
         this.nodeService.delete(this.controller(), node).subscribe({
           next: (node: Node) => {},
           error: (err) => {
@@ -73,7 +70,7 @@ export class DeleteActionComponent {
 
     this.drawings().forEach((drawing) => {
       if (!drawing.locked) {
-        this.drawingsDataSource.remove(drawing);
+        // Removal driven by the `drawing.deleted` WS notification (see nodes above).
         this.drawingService.delete(this.controller(), drawing).subscribe({
           next: (drawing: Drawing) => {},
           error: (err) => {
@@ -91,7 +88,7 @@ export class DeleteActionComponent {
 
     if (this.nodes().length == 0 && this.drawings().length == 0) {
       this.links().forEach((link) => {
-        this.linksDataSource.remove(link);
+        // Removal driven by the `link.deleted` WS notification (see nodes above).
         this.linkService.deleteLink(this.controller(), link).subscribe({
           next: () => {
             LinkTypeCache.remove(link.project_id, link.link_id);

--- a/src/app/components/project-map/marker-manager/marker-manager.component.html
+++ b/src/app/components/project-map/marker-manager/marker-manager.component.html
@@ -41,9 +41,10 @@
     </div>
 
     <div class="marker-manager__body">
-      <mat-tab-group>
+      <mat-tab-group [selectedIndex]="activeTabIndex()" (selectedIndexChange)="activeTabIndex.set($event)">
         <!-- ===================== Definitions ===================== -->
         <mat-tab label="Definitions">
+          @if (activeTabIndex() === 0) {
           <div class="marker-manager__panel">
             <!-- Create / edit form -->
             <form [formGroup]="definitionForm" (ngSubmit)="submitDefinition()">
@@ -168,10 +169,12 @@
               }
             </div>
           </div>
+          }
         </mat-tab>
 
         <!-- ===================== Links (aggregate) ===================== -->
         <mat-tab label="Links">
+          @if (activeTabIndex() === 1) {
           <div class="marker-manager__panel">
             @if (panelError(); as msg) {
             <div class="marker-manager__error">{{ msg }}</div>
@@ -270,7 +273,11 @@
               <div class="marker-manager__empty">
                 No markers on any link yet. Use the selector above to pick a link and add one.
               </div>
-              }
+              } @else if (linkGroups().length > 50) {
+              <div class="marker-manager__empty">
+                {{ linkGroups().length }} links have markers. Use the <strong>Node / Link</strong> selector above to filter by a specific link.
+              </div>
+              } @else {
               @for (group of linkGroups(); track group.linkId) {
               <div class="marker-manager__group">
                 <div class="marker-manager__group-header" (click)="toggleGroup(group.linkId)">
@@ -314,9 +321,11 @@
                 }
               </div>
               }
+              }
             </div>
             }
           </div>
+          }
         </mat-tab>
       </mat-tab-group>
     </div>

--- a/src/app/components/project-map/marker-manager/marker-manager.component.ts
+++ b/src/app/components/project-map/marker-manager/marker-manager.component.ts
@@ -231,16 +231,15 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
 
   // ---- forms ----
   readonly definitionForm = new UntypedFormGroup({
-    name: new UntypedFormControl('', { updateOn: 'blur', validators: [Validators.required, notGlobalName] }),
-    bpf: new UntypedFormControl('', { updateOn: 'blur', validators: [Validators.required] }),
+    name: new UntypedFormControl('', [Validators.required, notGlobalName]),
+    bpf: new UntypedFormControl('', [Validators.required]),
     // `tag` is reserved for the upcoming traffic-replay feature. There's no UI for it
     // on definitions yet, so it stays null and submitDefinition()'s tag read is a no-op
     // until the field ships — kept here deliberately, not dead code.
-    tag: new UntypedFormControl(null, { updateOn: 'blur' }),
-    color: new UntypedFormControl(null, { updateOn: 'blur' }),
+    tag: new UntypedFormControl(null),
+    color: new UntypedFormControl(null),
     highlight_duration: new UntypedFormControl(800, {
       nonNullable: true,
-      updateOn: 'blur',
       validators: [Validators.required, Validators.min(1)],
     }),
     direction: new UntypedFormControl('both'),
@@ -250,13 +249,12 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
   });
 
   readonly markerForm = new UntypedFormGroup({
-    name: new UntypedFormControl('', { updateOn: 'blur', validators: [Validators.required, notGlobalName] }),
-    bpf: new UntypedFormControl('', { updateOn: 'blur', validators: [Validators.required] }),
-    tag: new UntypedFormControl(null, { updateOn: 'blur' }),
-    color: new UntypedFormControl(null, { updateOn: 'blur' }),
+    name: new UntypedFormControl('', [Validators.required, notGlobalName]),
+    bpf: new UntypedFormControl('', [Validators.required]),
+    tag: new UntypedFormControl(null),
+    color: new UntypedFormControl(null),
     highlight_duration: new UntypedFormControl(800, {
       nonNullable: true,
-      updateOn: 'blur',
       validators: [Validators.required, Validators.min(1)],
     }),
     direction: new UntypedFormControl('both'),

--- a/src/app/components/project-map/marker-manager/marker-manager.component.ts
+++ b/src/app/components/project-map/marker-manager/marker-manager.component.ts
@@ -409,6 +409,7 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
     this.markerService.aggregateList(controller, project.project_id).pipe(takeUntil(this.destroy$)).subscribe({
       next: (map: AggregateMarkerMap) => {
         this.linkGroups.set(this.buildGroups(map));
+        this.markerRegistryService.rebuildFromAggregate(map);
         this.cdr.markForCheck();
       },
       error: (err) => {
@@ -518,8 +519,6 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
       this.submittingDefinition.set(false);
       this.cancelEditDefinition();
       this.loadDefinitions();
-      // The fan-out emits link.updated → registry reconciles (legend/icons); also refresh
-      // the Links tab so inherited markers appear/disappear immediately.
       this.loadAggregate();
     };
     const fail = (err: any) => {

--- a/src/app/components/project-map/marker-manager/marker-manager.component.ts
+++ b/src/app/components/project-map/marker-manager/marker-manager.component.ts
@@ -231,15 +231,16 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
 
   // ---- forms ----
   readonly definitionForm = new UntypedFormGroup({
-    name: new UntypedFormControl('', [Validators.required, notGlobalName]),
-    bpf: new UntypedFormControl('', [Validators.required]),
+    name: new UntypedFormControl('', { updateOn: 'blur', validators: [Validators.required, notGlobalName] }),
+    bpf: new UntypedFormControl('', { updateOn: 'blur', validators: [Validators.required] }),
     // `tag` is reserved for the upcoming traffic-replay feature. There's no UI for it
     // on definitions yet, so it stays null and submitDefinition()'s tag read is a no-op
     // until the field ships — kept here deliberately, not dead code.
-    tag: new UntypedFormControl(null),
-    color: new UntypedFormControl(null),
+    tag: new UntypedFormControl(null, { updateOn: 'blur' }),
+    color: new UntypedFormControl(null, { updateOn: 'blur' }),
     highlight_duration: new UntypedFormControl(800, {
       nonNullable: true,
+      updateOn: 'blur',
       validators: [Validators.required, Validators.min(1)],
     }),
     direction: new UntypedFormControl('both'),
@@ -249,12 +250,13 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
   });
 
   readonly markerForm = new UntypedFormGroup({
-    name: new UntypedFormControl('', [Validators.required, notGlobalName]),
-    bpf: new UntypedFormControl('', [Validators.required]),
-    tag: new UntypedFormControl(null),
-    color: new UntypedFormControl(null),
+    name: new UntypedFormControl('', { updateOn: 'blur', validators: [Validators.required, notGlobalName] }),
+    bpf: new UntypedFormControl('', { updateOn: 'blur', validators: [Validators.required] }),
+    tag: new UntypedFormControl(null, { updateOn: 'blur' }),
+    color: new UntypedFormControl(null, { updateOn: 'blur' }),
     highlight_duration: new UntypedFormControl(800, {
       nonNullable: true,
+      updateOn: 'blur',
       validators: [Validators.required, Validators.min(1)],
     }),
     direction: new UntypedFormControl('both'),

--- a/src/app/components/project-map/marker-manager/marker-manager.component.ts
+++ b/src/app/components/project-map/marker-manager/marker-manager.component.ts
@@ -163,7 +163,9 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
   readonly loading = signal(false);
   readonly defError = signal<string | null>(null);
   readonly linkError = signal<{ linkId: string | null; message: string } | null>(null);
+  readonly activeTabIndex = signal(0);
   readonly editingDefinition = signal<string | null>(null);
+
   /** linkId currently showing its inline "add private marker" form (Links tab). */
   readonly addingToLink = signal<string | null>(null);
   /** Marker currently being edited: { linkId, name }. */

--- a/src/app/components/project-map/project-map.component.html
+++ b/src/app/components/project-map/project-map.component.html
@@ -163,8 +163,8 @@
     [project]="project"
     [symbols]="symbols"
     [nodes]="nodes()"
-    [links]="links"
-    [drawings]="drawings"
+    [links]="links()"
+    [drawings]="drawings()"
     [width]="project.scene_width || 2000"
     [height]="project.scene_height || 2000"
     [show-interface-labels]="isInterfaceLabelVisible"
@@ -272,7 +272,7 @@
 
   <app-progress></app-progress>
   @if (tools.draw_link) {
-  <app-draw-link-tool [links]="links"></app-draw-link-tool>
+  <app-draw-link-tool [links]="links()"></app-draw-link-tool>
   }
   <app-drawing-dragged [controller]="controller" [project]="project"></app-drawing-dragged>
   <app-drawing-resized [controller]="controller"></app-drawing-resized>

--- a/src/app/components/project-map/project-map.component.html
+++ b/src/app/components/project-map/project-map.component.html
@@ -157,20 +157,30 @@
     </mat-menu>
   </div>
 
-  <!-- Project toolbar -->
-  <app-d3-map
-    [controller]="controller"
-    [project]="project"
-    [symbols]="symbols"
-    [nodes]="nodes()"
-    [links]="links()"
-    [drawings]="drawings()"
-    [width]="project.scene_width || 2000"
-    [height]="project.scene_height || 2000"
-    [show-interface-labels]="isInterfaceLabelVisible"
-    [readonly]="inReadOnlyMode"
-  >
-  </app-d3-map>
+  <!-- Render the map only after the project + controller data has resolved.
+       project/controller start as empty shells ({} as Project/Controller) and are
+       filled asynchronously by getData()'s HTTP chain. If d3-map instantiates
+       before that, createGraph + the first effect redraw lock the canvas origin
+       (centerX/Y) to the fallback scene size (width()/2) — and origin never
+       updates afterwards, so every open landed in a different spot depending on
+       whether the HTTP beat the first redraw. Gating on project_id makes the
+       first render use the real scene_width/height, anchoring origin correctly
+       once and for all. -->
+  @if (controller.id && project.project_id) {
+    <app-d3-map
+      [controller]="controller"
+      [project]="project"
+      [symbols]="symbols"
+      [nodes]="nodes()"
+      [links]="links()"
+      [drawings]="drawings()"
+      [width]="project.scene_width || 2000"
+      [height]="project.scene_height || 1000"
+      [show-interface-labels]="isInterfaceLabelVisible"
+      [readonly]="inReadOnlyMode"
+    >
+    </app-d3-map>
+  }
 
   <!-- Project toolbar -->
   <div id="project-toolbar">

--- a/src/app/components/project-map/project-map.component.ts
+++ b/src/app/components/project-map/project-map.component.ts
@@ -184,6 +184,16 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
   private projectWsIntentionalClose = false;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private reconnectAttempt = 0;
+
+  // ---- Marker notifications WebSocket (dedicated stream for marker data) ----
+  public markerWs: WebSocket;
+  private markerWsIntentionalClose = false;
+  private markerReconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private markerReconnectAttempt = 0;
+  private readonly MARKER_WS_LIVENESS_TIMEOUT_MS = 15000;
+  private readonly MARKER_WS_LIVENESS_CHECK_MS = 5000;
+  private markerLastWsMessageAt = 0;
+  private markerLivenessTimer: ReturnType<typeof setInterval> | null = null;
   /**
    * Liveness check. The backend pushes a ping on the notification stream every
    * ~5s, so a healthy connection always has inbound traffic. If nothing arrives
@@ -737,6 +747,7 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
       next: () => {
         this.setUpMapCallbacks();
         this.connectProjectWS(project);
+        this.connectMarkerWS(project);
         this.progressService.deactivate();
       },
       error: (err) => {
@@ -847,6 +858,73 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
     if (this.livenessTimer !== null) {
       clearInterval(this.livenessTimer);
       this.livenessTimer = null;
+    }
+  }
+
+  // ---- Marker notifications WebSocket (dedicated stream for marker data) ----
+
+  /**
+   * Open (or reopen) the marker notifications WebSocket. Same reconnect +
+   * liveness pattern as {@link connectProjectWS}, but no topology re-fetch on
+   * reconnect — the marker stream carries only marker events and the project WS
+   * already handles topology resync.
+   */
+  private connectMarkerWS(project: Project) {
+    this.markerWs = new WebSocket(
+      this.notificationService.markerNotificationsPath(this.controller, project.project_id)
+    );
+
+    this.markerWs.onopen = () => {
+      this.markerReconnectAttempt = 0;
+      this.startMarkerLivenessCheck();
+    };
+
+    this.markerWs.onmessage = (event: MessageEvent) => {
+      // Any inbound frame (incl. the periodic ping) proves the connection is
+      // alive — stamp it for the liveness check before dispatching.
+      this.markerLastWsMessageAt = Date.now();
+      this.projectWebServiceHandler.handleMessage(JSON.parse(event.data));
+    };
+
+    this.markerWs.onclose = () => {
+      this.stopMarkerLivenessCheck();
+      if (this.markerWsIntentionalClose) return;
+      this.scheduleMarkerReconnect(project);
+    };
+
+    this.markerWs.onerror = () => {
+      // onclose follows and drives the reconnect; no user-facing notice
+      // (silent reconnect). Log for debugging.
+      console.warn('Marker notifications WebSocket error; will reconnect');
+    };
+  }
+
+  private scheduleMarkerReconnect(project: Project) {
+    if (this.markerWsIntentionalClose) return;
+    const attempt = this.markerReconnectAttempt++;
+    // Exponential backoff capped at 30s, +up to 25% jitter to avoid reconnect
+    // storms when many clients drop simultaneously.
+    const base = Math.min(30000, 1000 * 2 ** attempt);
+    const delay = Math.round(base + Math.random() * 0.25 * base);
+    this.markerReconnectTimer = setTimeout(() => this.connectMarkerWS(project), delay);
+  }
+
+  private startMarkerLivenessCheck() {
+    this.stopMarkerLivenessCheck();
+    this.markerLastWsMessageAt = Date.now();
+    this.markerLivenessTimer = setInterval(() => {
+      if (Date.now() - this.markerLastWsMessageAt > this.MARKER_WS_LIVENESS_TIMEOUT_MS) {
+        console.warn('Marker WS liveness timeout — no message received, forcing reconnect');
+        this.stopMarkerLivenessCheck();
+        this.markerWs?.close(); // triggers onclose → scheduleMarkerReconnect
+      }
+    }, this.MARKER_WS_LIVENESS_CHECK_MS);
+  }
+
+  private stopMarkerLivenessCheck() {
+    if (this.markerLivenessTimer !== null) {
+      clearInterval(this.markerLivenessTimer);
+      this.markerLivenessTimer = null;
     }
   }
 
@@ -1872,6 +1950,18 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
     if (this.projectws) {
       if (this.projectws.OPEN) this.projectws.close();
     }
+
+    // Stop the marker WS auto-reconnect loop and close the socket.
+    this.markerWsIntentionalClose = true;
+    if (this.markerReconnectTimer) {
+      clearTimeout(this.markerReconnectTimer);
+      this.markerReconnectTimer = null;
+    }
+    this.stopMarkerLivenessCheck();
+    if (this.markerWs) {
+      if (this.markerWs.OPEN) this.markerWs.close();
+    }
+
     if (this.ws) {
       if (this.ws.OPEN) this.ws.close();
     }

--- a/src/app/components/project-map/project-map.component.ts
+++ b/src/app/components/project-map/project-map.component.ts
@@ -389,8 +389,10 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
   addSubscriptions() {
     this.projectMapSubscription.add(
       this.drawingsDataSource.changes.subscribe((drawings: Drawing[]) => {
+        // Data changes drive the redraw via D3MapComponent's data effect
+        // (gated by the visual signature). No detectChanges here: it would
+        // trigger the un-gated changesDetected path and bypass the gate.
         this.drawings.set(drawings);
-        this.mapChangeDetectorRef.detectChanges();
       })
     );
 
@@ -431,7 +433,6 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
         if (nodesToLoad.length === 0) {
           this.nodes.set(nodes);
           if (this.mapSettingsService.getSymbolScaling()) this.applyScalingOfNodeSymbols();
-          this.mapChangeDetectorRef.detectChanges();
           return;
         }
 
@@ -451,7 +452,6 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
             });
             this.nodes.set(nodes);
             if (this.mapSettingsService.getSymbolScaling()) this.applyScalingOfNodeSymbols();
-            this.mapChangeDetectorRef.detectChanges();
           },
           () => {
             // Fallback to raw URLs if blob fetch fails
@@ -462,7 +462,6 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
             });
             this.nodes.set(nodes);
             if (this.mapSettingsService.getSymbolScaling()) this.applyScalingOfNodeSymbols();
-            this.mapChangeDetectorRef.detectChanges();
           }
         );
       })
@@ -471,7 +470,6 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
     this.projectMapSubscription.add(
       this.linksDataSource.changes.subscribe((links: Link[]) => {
         this.links.set(links);
-        this.mapChangeDetectorRef.detectChanges();
       })
     );
 

--- a/src/app/components/project-map/project-map.component.ts
+++ b/src/app/components/project-map/project-map.component.ts
@@ -184,6 +184,17 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
   private projectWsIntentionalClose = false;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private reconnectAttempt = 0;
+  /**
+   * Liveness check. The backend pushes a ping on the notification stream every
+   * ~5s, so a healthy connection always has inbound traffic. If nothing arrives
+   * for WS_LIVENESS_TIMEOUT_MS (tolerates a couple of missed pings) the TCP
+   * connection is presumed half-open — onclose would never fire on its own, so
+   * we force-close to enter the normal reconnect path.
+   */
+  private readonly WS_LIVENESS_TIMEOUT_MS = 15000;
+  private readonly WS_LIVENESS_CHECK_MS = 5000;
+  private lastWsMessageAt = 0;
+  private livenessTimer: ReturnType<typeof setInterval> | null = null;
   public isProjectMapMenuVisible: boolean = false;
   public isConsoleVisible: boolean = true;
   public isTopologySummaryVisible: boolean = true;
@@ -789,13 +800,18 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
         );
       }
       this.reconnectAttempt = 0;
+      this.startLivenessCheck();
     };
 
     this.projectws.onmessage = (event: MessageEvent) => {
+      // Any inbound frame (incl. the periodic ping) proves the connection is
+      // alive — stamp it for the liveness check before dispatching.
+      this.lastWsMessageAt = Date.now();
       this.projectWebServiceHandler.handleMessage(JSON.parse(event.data));
     };
 
     this.projectws.onclose = () => {
+      this.stopLivenessCheck();
       if (this.projectWsIntentionalClose) return;
       this.scheduleReconnect(project);
     };
@@ -815,6 +831,25 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
     const base = Math.min(30000, 1000 * 2 ** attempt);
     const delay = Math.round(base + Math.random() * 0.25 * base);
     this.reconnectTimer = setTimeout(() => this.connectProjectWS(project), delay);
+  }
+
+  private startLivenessCheck() {
+    this.stopLivenessCheck();
+    this.lastWsMessageAt = Date.now();
+    this.livenessTimer = setInterval(() => {
+      if (Date.now() - this.lastWsMessageAt > this.WS_LIVENESS_TIMEOUT_MS) {
+        console.warn('Project WS liveness timeout — no message received, forcing reconnect');
+        this.stopLivenessCheck();
+        this.projectws?.close(); // triggers onclose → scheduleReconnect
+      }
+    }, this.WS_LIVENESS_CHECK_MS);
+  }
+
+  private stopLivenessCheck() {
+    if (this.livenessTimer !== null) {
+      clearInterval(this.livenessTimer);
+      this.livenessTimer = null;
+    }
   }
 
   setUpWS() {
@@ -1834,6 +1869,7 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
       clearTimeout(this.reconnectTimer);
       this.reconnectTimer = null;
     }
+    this.stopLivenessCheck();
 
     if (this.projectws) {
       if (this.projectws.OPEN) this.projectws.close();

--- a/src/app/components/project-map/project-map.component.ts
+++ b/src/app/components/project-map/project-map.component.ts
@@ -21,7 +21,7 @@ import { ExportPortableProjectComponent } from '@components/export-portable-proj
 import { environment } from 'environments/environment';
 import * as Mousetrap from 'mousetrap';
 import { forkJoin, from, Observable, Subscription } from 'rxjs';
-import { map, mergeMap } from 'rxjs/operators';
+import { map, mergeMap, tap } from 'rxjs/operators';
 import { D3MapComponent } from '../../cartography/components/d3-map/d3-map.component';
 import * as d3 from 'd3';
 import { MapDrawingToDrawingConverter } from '../../cartography/converters/map/map-drawing-to-drawing-converter';
@@ -178,6 +178,12 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
   public controller: Controller = {} as Controller;
   public projectws: WebSocket;
   public ws: WebSocket;
+  // Project WS auto-reconnect state. Reconnection is silent (no UI): the canvas
+  // just pauses updates while down, and re-fetches topology on reconnect to
+  // cover events the notification stream does not replay.
+  private projectWsIntentionalClose = false;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private reconnectAttempt = 0;
   public isProjectMapMenuVisible: boolean = false;
   public isConsoleVisible: boolean = true;
   public isTopologySummaryVisible: boolean = true;
@@ -718,50 +724,97 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
     this.readonly = this.projectService.isReadOnly(project);
     this.recentlyOpenedProjectService.setProjectId(this.project.project_id);
 
-    const subscription = this.projectService
-      .nodes(this.controller, project.project_id)
-      .pipe(
-        mergeMap((nodes: Node[]) => {
-          this.nodesDataSource.set(nodes);
-          nodes.filter((n) => n.status === 'started').forEach((n) => this.startedNodeIds.add(n.node_id));
-          return this.projectService.links(this.controller, project.project_id);
-        }),
-        mergeMap((links: Link[]) => {
-          this.linksDataSource.set(links);
-          this.markerRegistryService.rebuildAll(links);
-          return this.projectService.drawings(this.controller, project.project_id);
-        })
-      )
-      .subscribe({
-        next: (drawings: Drawing[]) => {
-          this.drawingsDataSource.set(drawings);
-
-          this.setUpMapCallbacks();
-          this.setUpProjectWS(project);
-
-          this.progressService.deactivate();
-        },
-        error: (err) => {
-          this.toasterService.error('Failed to load project data: ' + (err.error?.message || err.message || 'Unknown error'));
-          this.progressService.deactivate();
-          this.cd.markForCheck();
-        },
-      });
+    const subscription = this.fetchTopologyData(project).subscribe({
+      next: () => {
+        this.setUpMapCallbacks();
+        this.connectProjectWS(project);
+        this.progressService.deactivate();
+      },
+      error: (err) => {
+        this.toasterService.error('Failed to load project data: ' + (err.error?.message || err.message || 'Unknown error'));
+        this.progressService.deactivate();
+        this.cd.markForCheck();
+      },
+    });
     this.projectMapSubscription.add(subscription);
   }
 
-  setUpProjectWS(project: Project) {
+  /**
+   * Fetch nodes/links/drawings and push them into the datasources (also
+   * rebuilding the marker registry). Used both for the initial load and for
+   * re-syncing after the project WebSocket reconnects — the notification stream
+   * does not replay events missed while disconnected, so a reconnect must
+   * re-fetch to make the canvas match backend reality again.
+   */
+  private fetchTopologyData(project: Project) {
+    return this.projectService.nodes(this.controller, project.project_id).pipe(
+      tap((nodes: Node[]) => {
+        this.nodesDataSource.set(nodes);
+        nodes.filter((n) => n.status === 'started').forEach((n) => this.startedNodeIds.add(n.node_id));
+      }),
+      mergeMap(() => this.projectService.links(this.controller, project.project_id)),
+      tap((links: Link[]) => {
+        this.linksDataSource.set(links);
+        this.markerRegistryService.rebuildAll(links);
+      }),
+      mergeMap(() => this.projectService.drawings(this.controller, project.project_id)),
+      tap((drawings: Drawing[]) => {
+        this.drawingsDataSource.set(drawings);
+      })
+    );
+  }
+
+  /**
+   * Open (or reopen) the project notifications WebSocket. On an unexpected
+   * close the connection is silently reconnected with exponential backoff; on
+   * a successful reconnect the topology is re-fetched to cover any events
+   * missed while disconnected. ngOnDestroy sets projectWsIntentionalClose to
+   * stop the loop during teardown.
+   */
+  private connectProjectWS(project: Project) {
     this.projectws = new WebSocket(
       this.notificationService.projectNotificationsPath(this.controller, project.project_id)
     );
+
+    this.projectws.onopen = () => {
+      // Reconnect (attempt > 0): re-fetch topology to cover missed events.
+      // First connect (attempt 0): data was just loaded by onProjectLoad.
+      if (this.reconnectAttempt > 0) {
+        this.projectMapSubscription.add(
+          this.fetchTopologyData(project).subscribe({
+            error: (err) => {
+              console.warn('Topology resync after WS reconnect failed', err);
+            },
+          })
+        );
+      }
+      this.reconnectAttempt = 0;
+    };
 
     this.projectws.onmessage = (event: MessageEvent) => {
       this.projectWebServiceHandler.handleMessage(JSON.parse(event.data));
     };
 
-    this.projectws.onerror = (event: MessageEvent) => {
-      this.toasterService.error(`Connection to host lost. Error: ${event.data}`);
+    this.projectws.onclose = () => {
+      if (this.projectWsIntentionalClose) return;
+      this.scheduleReconnect(project);
     };
+
+    this.projectws.onerror = () => {
+      // onclose follows and drives the reconnect; no user-facing notice
+      // (silent reconnect). Log for debugging.
+      console.warn('Project notifications WebSocket error; will reconnect');
+    };
+  }
+
+  private scheduleReconnect(project: Project) {
+    if (this.projectWsIntentionalClose) return;
+    const attempt = this.reconnectAttempt++;
+    // Exponential backoff capped at 30s, +up to 25% jitter to avoid reconnect
+    // storms when many clients drop simultaneously.
+    const base = Math.min(30000, 1000 * 2 ** attempt);
+    const delay = Math.round(base + Math.random() * 0.25 * base);
+    this.reconnectTimer = setTimeout(() => this.connectProjectWS(project), delay);
   }
 
   setUpWS() {
@@ -1773,6 +1826,14 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
     this.drawingsDataSource.clear();
     this.nodesDataSource.clear();
     this.linksDataSource.clear();
+
+    // Stop the project WS auto-reconnect loop during teardown: set the flag so
+    // the onclose handler (fired by close() below) does not schedule a reconnect.
+    this.projectWsIntentionalClose = true;
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
 
     if (this.projectws) {
       if (this.projectws.OPEN) this.projectws.close();

--- a/src/app/components/project-map/project-map.component.ts
+++ b/src/app/components/project-map/project-map.component.ts
@@ -171,8 +171,8 @@ import { TextEditedComponent } from '../drawings-listeners/text-edited/text-edit
 })
 export class ProjectMapComponent implements OnInit, OnDestroy {
   public nodes = signal<Node[]>([]);
-  public links: Link[] = [];
-  public drawings: Drawing[] = [];
+  public links = signal<Link[]>([]);
+  public drawings = signal<Drawing[]>([]);
   public symbols: Symbol[] = [];
   public project: Project = {} as Project;
   public controller: Controller = {} as Controller;
@@ -372,7 +372,7 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
   addSubscriptions() {
     this.projectMapSubscription.add(
       this.drawingsDataSource.changes.subscribe((drawings: Drawing[]) => {
-        this.drawings = drawings;
+        this.drawings.set(drawings);
         this.mapChangeDetectorRef.detectChanges();
       })
     );
@@ -453,7 +453,7 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
 
     this.projectMapSubscription.add(
       this.linksDataSource.changes.subscribe((links: Link[]) => {
-        this.links = links;
+        this.links.set(links);
         this.mapChangeDetectorRef.detectChanges();
       })
     );
@@ -849,7 +849,7 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
     const onInterfaceLabelContextMenu = this.interfaceLabelWidget.onContextMenu.subscribe(
       (eventInterfaceLabel: InterfaceLabelContextMenu) => {
         const linkNode = this.mapLinkNodeToLinkNode.convert(eventInterfaceLabel.interfaceLabel);
-        const link = this.links.find((l) => l.link_id === eventInterfaceLabel.interfaceLabel.linkId);
+        const link = this.links().find((l) => l.link_id === eventInterfaceLabel.interfaceLabel.linkId);
         this.contextMenu().openMenuForInterfaceLabel(
           linkNode,
           link,

--- a/src/app/components/topology-summary/topology-summary.component.ts
+++ b/src/app/components/topology-summary/topology-summary.component.ts
@@ -81,17 +81,17 @@ export class TopologySummaryComponent implements OnInit, OnDestroy {
       : (this.isLightThemeEnabled = false);
     this.subscriptions.push(
       this.nodesDataSource.changes.subscribe((nodes: Node[]) => {
-        this.nodes = nodes;
-        this.nodes.forEach((n) => {
+        // Copy before sorting so we don't reorder the datasource's shared
+        // internal array (other subscribers receive the same reference).
+        const localNodes = [...nodes];
+        this.nodes = localNodes;
+        localNodes.forEach((n) => {
           if (n.console_host === '0.0.0.0' || n.console_host === '0:0:0:0:0:0:0:0' || n.console_host === '::') {
             n.console_host = this.controller?.host;
           }
         });
-        if (this.sortingOrder === 'asc') {
-          this.filteredNodes = nodes.sort(this.compareAsc);
-        } else {
-          this.filteredNodes = nodes.sort(this.compareDesc);
-        }
+        this.filteredNodes =
+          this.sortingOrder === 'asc' ? localNodes.sort(this.compareAsc) : localNodes.sort(this.compareDesc);
         // In zoneless mode, we need to mark for check after async updates
         this.cd.markForCheck();
       })

--- a/src/app/services/marker-flash.service.spec.ts
+++ b/src/app/services/marker-flash.service.spec.ts
@@ -4,7 +4,7 @@ import { MarkerFlashService } from './marker-flash.service';
 
 /**
  * MarkerFlashService stores per-(linkId, dir) flash state in the `_flashing` signal
- * and schedules independent per-slot续命 timers. flash() only stages into a per-frame
+ * and schedules independent per-slot debounce timers. flash() only stages into a per-frame
  * buffer; a requestAnimationFrame flush applies it. We assert on the signal / timer
  * behaviour directly; DOM side-effects require an SVG and are exercised manually.
  */
@@ -131,7 +131,7 @@ describe('MarkerFlashService', () => {
       expect(flashing().has(key('link-custom'))).toBe(false);
     });
 
-    it('续命: a repeat flash within the window resets the timer', async () => {
+    it('renew: a repeat flash within the window resets the timer', async () => {
       service.flash('link-renew', null); // 800ms timer
       await settle();
       vi.advanceTimersByTime(500); // 300ms left on original
@@ -143,7 +143,7 @@ describe('MarkerFlashService', () => {
       expect(flashing().has(key('link-renew'))).toBe(false);
     });
 
-    it('方向变化不续命: tx and rx coexist with independent timers', async () => {
+    it('cross-direction: tx and rx coexist with independent timers', async () => {
       // tx at t=0, rx at t=200
       service.flash('link-1', null, null, 'tx', 'node-a');
       await settle();
@@ -165,7 +165,7 @@ describe('MarkerFlashService', () => {
       expect(flashing().has(key('link-1', 'rx'))).toBe(false);
     });
 
-    it('续命 only for same direction, not across directions', async () => {
+    it('renew only for same direction, not across directions', async () => {
       service.flash('link-1', 'red', null, 'tx', 'node-a');
       await settle();
       vi.advanceTimersByTime(700); // 100ms left on tx
@@ -176,7 +176,7 @@ describe('MarkerFlashService', () => {
       vi.advanceTimersByTime(101); // tx expired, rx still active
       expect(flashing().has(key('link-1', 'tx'))).toBe(false);
       expect(flashing().has(key('link-1', 'rx'))).toBe(true);
-      // Same direction should续命
+      // Same direction should renew
       service.flash('link-1', null, null, 'rx', 'node-b');
       await settle();
       vi.advanceTimersByTime(700); // rx should still be alive (timer reset at second rx call)

--- a/src/app/services/marker-flash.service.spec.ts
+++ b/src/app/services/marker-flash.service.spec.ts
@@ -4,7 +4,8 @@ import { MarkerFlashService } from './marker-flash.service';
 
 /**
  * MarkerFlashService stores per-(linkId, dir) flash state in the `_flashing` signal
- * and schedules independent per-slot续命 timers. We assert on the signal / timer
+ * and schedules independent per-slot续命 timers. flash() only stages into a per-frame
+ * buffer; a requestAnimationFrame flush applies it. We assert on the signal / timer
  * behaviour directly; DOM side-effects require an SVG and are exercised manually.
  */
 
@@ -20,35 +21,63 @@ describe('MarkerFlashService', () => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const flashing = () => (service as any)._flashing() as ReadonlyMap<string, StoredState>;
 
+  /**
+   * flush() is driven by requestAnimationFrame. Defer it to a microtask so it runs
+   * outside Angular's synchronous scheduling (avoids "cannot synchronously execute
+   * watches while scheduling"). `settle()` lets that microtask fire before we assert.
+   * Re-stubbed in beforeEach so it wins over vi.useFakeTimers()'s faked rAF.
+   */
+  const settle = () => new Promise<void>((resolve) => queueMicrotask(() => resolve()));
+
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+      queueMicrotask(() => cb(0));
+      return 0;
+    });
+    vi.stubGlobal('cancelAnimationFrame', () => {});
     TestBed.configureTestingModule({ providers: [MarkerFlashService] });
     service = TestBed.inject(MarkerFlashService);
   });
 
-  it('adds the link to the active set immediately on flash()', () => {
+  it('adds the link to the active set once the frame flushes', async () => {
     service.flash('link-1', null);
+    await settle();
     expect(flashing().has(key('link-1'))).toBe(true);
   });
 
-  it('stores the latest color on repeat flash()', () => {
+  it('stores the latest color on repeat flash()', async () => {
     service.flash('link-1', 'red');
     service.flash('link-1', 'blue');
+    await settle();
     expect(flashing().get(key('link-1'))?.color).toBe('blue');
   });
 
-  it('stores dir + captureNodeId for the direction arrow', () => {
+  it('stores dir + captureNodeId for the direction arrow', async () => {
     service.flash('link-1', null, null, 'tx', 'node-a');
+    await settle();
     const state = flashing().get(key('link-1', 'tx'));
     expect(state?.dir).toBe('tx');
     expect(state?.captureNodeId).toBe('node-a');
   });
 
-  it('defaults dir + captureNodeId to null when omitted (legacy uBridge)', () => {
+  it('defaults dir + captureNodeId to null when omitted (legacy uBridge)', async () => {
     service.flash('link-1', null);
+    await settle();
     const state = flashing().get(key('link-1'));
     expect(state?.dir).toBeNull();
     expect(state?.captureNodeId).toBeNull();
+  });
+
+  it('coalesces same-direction matches within a frame to one state write', async () => {
+    // Three matches on the same (link,dir) before the flush fires: only the last
+    // color should land, and the signal should update once.
+    service.flash('link-1', 'red', null, 'tx', 'node-a');
+    service.flash('link-1', 'green', null, 'tx', 'node-a');
+    service.flash('link-1', 'blue', null, 'tx', 'node-a');
+    await settle();
+    expect(flashing().get(key('link-1', 'tx'))?.color).toBe('blue');
+    expect(flashing().size).toBe(1);
   });
 
   /**
@@ -82,16 +111,18 @@ describe('MarkerFlashService', () => {
     beforeAll(() => vi.useFakeTimers());
     afterAll(() => vi.useRealTimers());
 
-    it('expires after the default 800ms', () => {
+    it('expires after the default 800ms', async () => {
       service.flash('link-default', null);
+      await settle();
       vi.advanceTimersByTime(799);
       expect(flashing().has(key('link-default'))).toBe(true);
       vi.advanceTimersByTime(2);
       expect(flashing().has(key('link-default'))).toBe(false);
     });
 
-    it('honors a custom durationMs (1200ms)', () => {
+    it('honors a custom durationMs (1200ms)', async () => {
       service.flash('link-custom', null, 1200);
+      await settle();
       vi.advanceTimersByTime(800);
       expect(flashing().has(key('link-custom'))).toBe(true);
       vi.advanceTimersByTime(399);
@@ -100,23 +131,27 @@ describe('MarkerFlashService', () => {
       expect(flashing().has(key('link-custom'))).toBe(false);
     });
 
-    it('续命: a repeat flash within the window resets the timer', () => {
+    it('续命: a repeat flash within the window resets the timer', async () => {
       service.flash('link-renew', null); // 800ms timer
+      await settle();
       vi.advanceTimersByTime(500); // 300ms left on original
       service.flash('link-renew', null); // reset to a fresh 800ms
+      await settle();
       vi.advanceTimersByTime(500); // original would have expired; reset still has 300ms
       expect(flashing().has(key('link-renew'))).toBe(true);
       vi.advanceTimersByTime(300);
       expect(flashing().has(key('link-renew'))).toBe(false);
     });
 
-    it('方向变化不续命: tx and rx coexist with independent timers', () => {
+    it('方向变化不续命: tx and rx coexist with independent timers', async () => {
       // tx at t=0, rx at t=200
       service.flash('link-1', null, null, 'tx', 'node-a');
+      await settle();
       vi.advanceTimersByTime(200);
       service.flash('link-1', null, null, 'rx', 'node-b');
+      await settle();
 
-      // Both active right after the rx call.
+      // Both active right after the rx flush.
       expect(flashing().has(key('link-1', 'tx'))).toBe(true);
       expect(flashing().has(key('link-1', 'rx'))).toBe(true);
 
@@ -130,17 +165,20 @@ describe('MarkerFlashService', () => {
       expect(flashing().has(key('link-1', 'rx'))).toBe(false);
     });
 
-    it('续命 only for same direction, not across directions', () => {
+    it('续命 only for same direction, not across directions', async () => {
       service.flash('link-1', 'red', null, 'tx', 'node-a');
+      await settle();
       vi.advanceTimersByTime(700); // 100ms left on tx
       // Different direction — should NOT reset tx timer.
       service.flash('link-1', 'blue', null, 'rx', 'node-b');
+      await settle();
       // tx still has its original timer
       vi.advanceTimersByTime(101); // tx expired, rx still active
       expect(flashing().has(key('link-1', 'tx'))).toBe(false);
       expect(flashing().has(key('link-1', 'rx'))).toBe(true);
       // Same direction should续命
       service.flash('link-1', null, null, 'rx', 'node-b');
+      await settle();
       vi.advanceTimersByTime(700); // rx should still be alive (timer reset at second rx call)
       expect(flashing().has(key('link-1', 'rx'))).toBe(true);
     });

--- a/src/app/services/marker-flash.service.ts
+++ b/src/app/services/marker-flash.service.ts
@@ -40,9 +40,12 @@ let _seq = 0;
  * carries a direction (`dir`) — draws evenly-spaced arrows (鱼鳞) along the link
  * pointing toward the traffic receiver.
  *
- * State is a signal of composite-key → FlashState.  On each `flash(...)`:
- *   - the entry for that (linkId, dir) slot is (re)added
- *   - a per-slot timer is (re)set (同方向续命, 不同方向独立过期)
+ * State is a signal of composite-key → FlashState.  `flash(...)` only stages
+ * the (linkId, dir) slot into a per-frame buffer (last-write-wins); a
+ * requestAnimationFrame flush applies the whole frame's changes in ONE signal
+ * update and renews each slot's timer once (同方向续命, 不同方向独立过期).
+ * This decouples cost from the marker.match rate — N thousand matches/sec still
+ * process at ~60 flushes/sec.
  *
  * An `effect()` diffs the new map against the previous one and mutates ONLY the
  * changed link's DOM.  When a slot expires but another direction is still active
@@ -75,11 +78,30 @@ export class MarkerFlashService {
     string,
     { d: string; len: number; pts: Map<number, { x: number; y: number } | null> }
   >();
+  /**
+   * Per-frame batching buffer (composite-key → {state, ms}). `flash()` stages
+   * here (last-write-wins, O(1)) and schedules a single rAF flush; the flush
+   * applies all of the frame's changes in ONE signal update and renews timers
+   * once per key. This decouples cost from the marker.match rate — 25k
+   * matches/sec still → ~60 flushes/sec — and collapses repeated matches on the
+   * same (linkId,dir) within a frame to one entry.
+   */
+  private pending = new Map<string, { state: FlashState; ms: number }>();
+  /** Pending requestAnimationFrame id for the batch flush. */
+  private flushRaf: number | null = null;
+  /** Whether a flush is already scheduled (guard independent of the rAF id). */
+  private flushScheduled = false;
 
   constructor() {
     const destroyRef = inject(DestroyRef);
     this.effectRef = effect(() => this.applyDiff(this._flashing()));
     destroyRef.onDestroy(() => {
+      if (this.flushRaf !== null) {
+        cancelAnimationFrame(this.flushRaf);
+        this.flushRaf = null;
+      }
+      this.flushScheduled = false;
+      this.pending.clear();
       this.effectRef.destroy();
       for (const key of [...this.prev.keys()]) this.clearLink(linkIdOf(key));
       this.prev.clear();
@@ -111,25 +133,56 @@ export class MarkerFlashService {
   ) {
     const key = compKey(linkId, dir);
     const ms = durationMs && durationMs > 0 ? durationMs : this.DEFAULT_FLASH_MS;
-    clearTimeout(this.timers.get(key));
-    this.timers.set(key, setTimeout(() => this.expire(key), ms));
+    // Stage in the per-frame buffer (last-write-wins per key) and schedule a
+    // single flush. Avoids a full Map copy + signal update + effect per match;
+    // cost is decoupled from the marker.match rate.
+    this.pending.set(key, { state: { color, dir, captureNodeId, _seq: _seq++ }, ms });
+    this.scheduleFlush();
+  }
 
-    // Same-state guard: under heavy traffic (e.g. ping -f),
-    // repeated matches with identical color / direction / capture node
-    // only extend the timer — no Map copy, no signal update, no effect.
-    // Without this, every match copies the Map and fires the full diff
-    // pipeline even though the DOM is unchanged; the churn leaks into
-    // GC pressure and browser memory climbs.
-    const existing = this._flashing().get(key);
-    if (existing && existing.color === color && existing.dir === dir && existing.captureNodeId === captureNodeId) {
-      return;
+  private scheduleFlush() {
+    if (this.flushScheduled) return;
+    this.flushScheduled = true;
+    this.flushRaf = requestAnimationFrame(() => {
+      this.flushScheduled = false;
+      this.flushRaf = null;
+      this.flush();
+    });
+  }
+
+  /**
+   * Apply one frame's worth of staged flashes in a single signal update and
+   * renew each affected slot's timer once. Same (linkId,dir) repeated within the
+   * frame already collapsed to one entry in `pending`; here we additionally skip
+   * the signal update entirely when no staged state actually differs from the
+   * current one (so steady repeated matches cost only timer renewals).
+   */
+  private flush() {
+    if (this.pending.size === 0) return;
+    const updates = this.pending;
+    this.pending = new Map();
+    // Renew each slot's timer once per frame (续命).
+    for (const [key, { ms }] of updates) {
+      clearTimeout(this.timers.get(key));
+      this.timers.set(key, setTimeout(() => this.expire(key), ms));
     }
-
-    const state: FlashState = { color, dir, captureNodeId, _seq: _seq++ };
+    // Apply state changes in ONE Map copy; if nothing actually changed, return
+    // the same ref so the signal does not fire and the effect does not run.
     this._flashing.update((m) => {
-      const next = new Map(m);
-      next.set(key, state);
-      return next;
+      let next: Map<string, FlashState> | null = null;
+      for (const [key, { state }] of updates) {
+        const cur = m.get(key);
+        if (
+          !cur ||
+          cur.color !== state.color ||
+          cur.dir !== state.dir ||
+          cur.captureNodeId !== state.captureNodeId
+        ) {
+          if (next === null) next = new Map(m);
+          next.set(key, state);
+        }
+      }
+      return next ?? m;
     });
   }
 

--- a/src/app/services/marker-flash.service.ts
+++ b/src/app/services/marker-flash.service.ts
@@ -64,6 +64,17 @@ export class MarkerFlashService {
   private readonly effectRef: EffectRef;
   /** Previous snapshot for diffing (composite-key → state). */
   private prev = new Map<string, FlashState>();
+  /**
+   * Per-link path-geometry cache. getTotalLength()/getPointAtLength() are sync
+   * reflows whose cost scales with the WHOLE SVG (tens of thousands of elements
+   * on large topologies). Keyed by linkId and invalidated when the path's `d`
+   * attribute changes (node dragged / link redrawn), so repeated flashes of an
+   * unchanged link skip geometry queries entirely → no reflow per flash.
+   */
+  private readonly geoCache = new Map<
+    string,
+    { d: string; len: number; pts: Map<number, { x: number; y: number } | null> }
+  >();
 
   constructor() {
     const destroyRef = inject(DestroyRef);
@@ -74,6 +85,7 @@ export class MarkerFlashService {
       this.prev.clear();
       for (const t of this.timers.values()) clearTimeout(t);
       this.timers.clear();
+      this.geoCache.clear();
     });
   }
 
@@ -185,7 +197,7 @@ export class MarkerFlashService {
     // null → remove inline color so CSS default (var(--mat-sys-primary)) applies.
     path.style('stroke', state.color ?? null);
     const slot = state.dir === 'tx' ? 'tx' : state.dir === 'rx' ? 'rx' : null;
-    this.renderDirArrow(group, path, state, slot);
+    this.renderDirArrow(id, group, path, state, slot);
   }
 
   private clearLink(id: string) {
@@ -197,6 +209,7 @@ export class MarkerFlashService {
       .style('stroke', null);
     // Remove ALL direction arrows (both tx and rx slots).
     group.selectAll('g.marker-arrow-tx, g.marker-arrow-rx').remove();
+    this.geoCache.delete(id);
   }
 
   private selectLinkGroup(id: string) {
@@ -229,6 +242,7 @@ export class MarkerFlashService {
    * capture node can't be matched to an endpoint.
    */
   private renderDirArrow(
+    linkId: string,
     group: Selection<SVGGElement, any, any, any>,
     path: Selection<SVGPathElement, any, any, any>,
     state: FlashState,
@@ -247,14 +261,25 @@ export class MarkerFlashService {
 
     const node = path.node();
     if (!node) return;
-    // jsdom (unit tests) doesn't implement path geometry — bail out quietly there.
-    let len: number;
-    try {
-      len = node.getTotalLength();
-    } catch {
-      return;
+    // Cache geometry by the path's `d`: getTotalLength() is a sync reflow whose
+    // cost scales with the whole SVG, so reuse it while the link geometry is
+    // stable (the common case during a marker flood). When `d` changes (node
+    // dragged / link redrawn) the key mismatches and we recompute. jsdom (unit
+    // tests) doesn't implement path geometry → bail out quietly there.
+    const d = node.getAttribute('d') ?? '';
+    let entry = this.geoCache.get(linkId);
+    if (!entry || entry.d !== d) {
+      let len: number;
+      try {
+        len = node.getTotalLength();
+      } catch {
+        return;
+      }
+      if (!len || !Number.isFinite(len)) return;
+      entry = { d, len, pts: new Map() };
+      this.geoCache.set(linkId, entry);
     }
-    if (!len || !Number.isFinite(len)) return;
+    const len = entry.len;
 
     // Pre-compute the direction offset once for all arrows along this link.
     const angleOffset = MarkerFlashService.arrowPointsAlongPath(state.dir, captureIsSource, captureIsTarget)
@@ -270,9 +295,9 @@ export class MarkerFlashService {
     for (let i = 0; i < count; i++) {
       let at = step * (i + 1);
       if (slot === 'rx') at += step * 0.5;
-      const behind = this.pointAt(node, Math.max(0, at - ARROW_TANGENT_EPS));
-      const ahead = this.pointAt(node, Math.min(len, at + ARROW_TANGENT_EPS));
-      const pos = this.pointAt(node, at);
+      const behind = this.getCachedPt(entry, node, Math.max(0, at - ARROW_TANGENT_EPS));
+      const ahead = this.getCachedPt(entry, node, Math.min(len, at + ARROW_TANGENT_EPS));
+      const pos = this.getCachedPt(entry, node, at);
       if (!behind || !ahead || !pos) continue;
 
       const angle = Math.atan2(ahead.y - behind.y, ahead.x - behind.x) + angleOffset;
@@ -283,6 +308,25 @@ export class MarkerFlashService {
         // null → CSS default (var(--mat-sys-primary)); hex → match the pulse color.
         .style('fill', state.color ?? null);
     }
+  }
+
+  /**
+   * Cached getPointAtLength. Like getTotalLength(), each call is a sync reflow
+   * that scales with the whole SVG, so reuse the result for a stable path.
+   * `at` is rounded to 0.01px for the key (positions are deterministic from the
+   * cached length, so identical across flashes of the same geometry).
+   */
+  private getCachedPt(
+    entry: { pts: Map<number, { x: number; y: number } | null> },
+    node: SVGPathElement,
+    at: number
+  ): { x: number; y: number } | null {
+    const key = Math.round(at * 100);
+    const cached = entry.pts.get(key);
+    if (cached !== undefined) return cached;
+    const pt = this.pointAt(node, at);
+    entry.pts.set(key, pt);
+    return pt;
   }
 
   /** Safe getPointAtLength wrapper (jsdom throws / returns non-finite values). */

--- a/src/app/services/marker-flash.service.ts
+++ b/src/app/services/marker-flash.service.ts
@@ -262,7 +262,11 @@ export class MarkerFlashService {
       .style('stroke', null);
     // Remove ALL direction arrows (both tx and rx slots).
     group.selectAll('g.marker-arrow-tx, g.marker-arrow-rx').remove();
-    this.geoCache.delete(id);
+    // geoCache deliberately NOT deleted here: link geometry hasn't changed, and
+    // the next flash would re-trigger getTotalLength()/getPointAtLength() sync
+    // reflows on the whole SVG (~10k elements on a 1000-node topology).  The
+    // cache self-invalidates when the path's "d" attribute changes (node drag /
+    // link redraw), so persisting it across flash cycles is safe.
   }
 
   private selectLinkGroup(id: string) {

--- a/src/app/services/marker-flash.service.ts
+++ b/src/app/services/marker-flash.service.ts
@@ -25,7 +25,7 @@ const ARROW_TANGENT_EPS = 6;
 
 /**
  * Composite-key helpers.  Entries are keyed by `linkId` + direction so that
- * tx and rx slots on the same link live independently (独立过期, 同方向续命).
+ * tx and rx slots on the same link live independently (independent expiry, same-direction renewal).
  * A null byte separates the two parts; linkIds are UUIDs so the separator is safe.
  */
 const SEP = '\x00';
@@ -37,13 +37,13 @@ let _seq = 0;
 
 /**
  * Flashes a link when its marker matches live traffic, and — when the match
- * carries a direction (`dir`) — draws evenly-spaced arrows (鱼鳞) along the link
+ * carries a direction (`dir`) — draws evenly-spaced arrows along the link
  * pointing toward the traffic receiver.
  *
  * State is a signal of composite-key → FlashState.  `flash(...)` only stages
  * the (linkId, dir) slot into a per-frame buffer (last-write-wins); a
  * requestAnimationFrame flush applies the whole frame's changes in ONE signal
- * update and renews each slot's timer once (同方向续命, 不同方向独立过期).
+ * update and renews each slot's timer once (same-direction renewal, cross-direction expiry).
  * This decouples cost from the marker.match rate — N thousand matches/sec still
  * process at ~60 flushes/sec.
  *
@@ -60,7 +60,7 @@ let _seq = 0;
 export class MarkerFlashService {
   /** composite-key → flash state. */
   private readonly _flashing = signal<ReadonlyMap<string, FlashState>>(new Map());
-  /** Per-slot debounce timers (续命). */
+  /** Per-slot debounce timers. */
   private readonly timers = new Map<string, ReturnType<typeof setTimeout>>();
   /** UI default highlight duration when a marker has no `highlight_duration`. */
   private readonly DEFAULT_FLASH_MS = 800;
@@ -113,9 +113,9 @@ export class MarkerFlashService {
 
   /**
    * Flash a link. Repeated calls with the same direction within the duration
-   * window keep that direction lit (续命).  Calls with a *different* direction
+   * window keep that direction lit.  Calls with a *different* direction
    * start an independent timer — the old direction stays active until its own
-   * timer expires (方向变化不续命).
+   * timer expires.
    *
    * @param color resolved marker color (hex), or null to use the default theme color.
    * @param durationMs how long to stay lit after the last match
@@ -161,7 +161,7 @@ export class MarkerFlashService {
     if (this.pending.size === 0) return;
     const updates = this.pending;
     this.pending = new Map();
-    // Renew each slot's timer once per frame (续命).
+    // Renew each slot's timer once per frame.
     for (const [key, { ms }] of updates) {
       clearTimeout(this.timers.get(key));
       this.timers.set(key, setTimeout(() => this.expire(key), ms));

--- a/src/app/services/marker-registry.service.ts
+++ b/src/app/services/marker-registry.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, signal } from '@angular/core';
 import { Link } from '@models/link';
+import { AggregateMarkerMap } from '@models/marker';
 
 /** A marker definition in the project, projected from `link.markers` for the legend. */
 export interface MarkerEntry {
@@ -34,6 +35,28 @@ export class MarkerRegistryService {
     const entries: MarkerEntry[] = [];
     for (const link of links) {
       this.collect(link, entries);
+    }
+    this.setEntries(entries);
+  }
+
+  /**
+   * Rebuild from the aggregate marker map (GET /projects/{pid}/markers).
+   * Used when definition CRUD fans out to many links — the aggregate API has
+   * the authoritative per-link state while local link objects may be stale.
+   */
+  rebuildFromAggregate(map: AggregateMarkerMap) {
+    const entries: MarkerEntry[] = [];
+    for (const [key, entry] of Object.entries(map)) {
+      // key is "{link_id}/{name}"
+      const slashIdx = key.indexOf('/');
+      const name = slashIdx >= 0 ? key.slice(slashIdx + 1) : key;
+      entries.push({
+        name,
+        linkId: entry.link_id,
+        bpf: entry.bpf,
+        tag: entry.tag ?? null,
+        color: entry.color,
+      });
     }
     this.setEntries(entries);
   }

--- a/src/app/services/marker-registry.service.ts
+++ b/src/app/services/marker-registry.service.ts
@@ -73,7 +73,7 @@ function sameSet(a: MarkerEntry[], b: MarkerEntry[]): boolean {
   if (a.length !== b.length) {
     return false;
   }
-  const key = (e: MarkerEntry) => `${e.linkId}\0${e.name}\0${e.bpf}\0${e.tag ?? ''}`;
+  const key = (e: MarkerEntry) => `${e.linkId}\0${e.name}\0${e.bpf}\0${e.tag ?? ''}\0${e.color ?? ''}`;
   const sa = new Set(a.map(key));
   for (const e of b) {
     if (!sa.has(key(e))) {

--- a/src/app/services/notification.service.ts
+++ b/src/app/services/notification.service.ts
@@ -49,6 +49,15 @@ export class NotificationService {
     return `${protocol}://${controller.host}:${controller.port}/${environment.current_version}/projects/${project_id}/notifications/ws?token=${controller.authToken}`;
   }
 
+  markerNotificationsPath(controller: Controller, project_id: string): string {
+    let protocol: string = 'ws';
+    if (controller.protocol === 'https:') {
+      protocol = 'wss';
+    }
+
+    return `${protocol}://${controller.host}:${controller.port}/${environment.current_version}/projects/${project_id}/notifications/markers/ws?token=${controller.authToken}`;
+  }
+
   connectToComputeNotifications(controller: Controller) {
     // If already connected to the same controller, skip
     if (this.ws && this.currentController === controller) {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -307,6 +307,7 @@ body .cdk-overlay-container .cdk-overlay-pane .mat-mdc-menu-panel.template-menu 
 // ============================================= */
 .ethernet_link.marker-pulse,
 .serial_link.marker-pulse {
+  transition: none;
   stroke: var(--mat-sys-primary);
   stroke-width: 5px;
 }


### PR DESCRIPTION
## Summary  

Two-tier render pipeline overhaul for 1000-node topologies. Tier 1 eliminates redundant redraws and coalesces triggers to one per frame. Tier 2 replaces full O(N+L) graphLayout.draw with per-item incremental diff and targeted DOM updates that bypass D3 data-join entirely.

### Tier 1 — Render Coalescing & Signal-Driven Render  

**rAF coalescing**: All redraw triggers funnel through a single requestAnimationFrame chokepoint — max 1 full redraw per frame regardless of WS notification rate.  

**L1 visual-signature gate**: Skip the entire redraw when no canvas-rendered field changed (excludes markers/console/properties/command_line). Per-def marker fan-out (2500 link.updated events) now produces zero map redraws.  

**marker-flash batching + geometry cache**: Per-frame pending buffer (last-write-wins) collapses N marker.match events into one flush. getTotalLength/getPointAtLength results cached per link (keyed by path d), eliminating reflow on every flash.  

**WS auto-reconnect + liveness**: Silent exponential-backoff reconnect on unexpected close. 15s liveness check (server pings every ~5s) catches silent/half-open drops.  

**Fix: cursor-centered zoom**: Uniform proportional zoom steps (exp(-zoom/10)) centered on the mouse cursor. Canvas origin anchored to content center, not scene center — every open deterministic. Stop page scroll when wheel-zooming.  

**Fix: drag snap on small moves**: Force un-gated redraw after drag end so snap-to-grid corrections apply even when the snap target is the same grid cell.  

### Tier 2 — Pure-Signal Incremental Rendering  

**Data layer — incremental graphDataManager diff**  
- Per-item visual signatures with grouped sub-signatures (xY/z/visual/label/ports/type for nodes; nodes/visual for links; xY/z/visual for drawings)  
- setNodes/setLinks/setDrawings only convert changed items via Object.assign (preserving reference stability for SelectionManager/drag/D3 data-join)  
- Returns AffectedIds describing exactly which items changed and in what groups  

**DOM patcher — targeted updates bypassing D3 data-join**  
- Node xY changes: direct g.node_body transform update → skip graphLayout.draw (no data-join, no getBBox reflow)  
- Drawing xY changes: direct g.drawing_body transform update  
- Node label changes: targeted text update + conditional getBBox on just that label  
- Structural changes (add/remove) and non-handled updates fall through to full draw  

**Zoom decoupled from redraw**: zooming-canvas already updates canvas.attr('transform') directly — remove the scaleChangeEmitter→scheduleRedraw() subscription.  

### Additional Fixes  

- Prevent ghost frames on project open (clear app-singleton LayersManager in createGraph)  
- Remove ngOnInit getSize() that read residual graphDataManager before first redraw  
- Marker-manager: lazy tab rendering (only active tab DOM exists) + threshold guard on Links aggregate view  
- Tool switches made instant (call tool widgets directly, no full redraw)  
- Canvas deletion made WS-driven (no optimistic remove)  
- Connect to dedicated marker notifications WebSocket  

### Related  
- Server-side: https://github.com/GNS3/gns3-server/pull/2848
