### PR TITLE
fix(cartography): Tier 2 incremental render fixes + marker color sync

### DIFF
--- a/src/app/cartography/datasources/datasource.ts
+++ b/src/app/cartography/datasources/datasource.ts
@@ -80,19 +80,25 @@ export abstract class DataSource<T> {
    * changes (new / dropped keys) require applyBatch.
    */
   public applyBatch(additions: T[], removals: T[]): void {
-    for (const item of additions) {
-      this.data = [...this.data, item];
-      this.keyIndex.set(this.getItemKey(item), this.data.length - 1);
+    // Single array copy for all additions (was O(K·N) — one [...data, item]
+    // per addition). Index each new item by its position directly.
+    if (additions.length > 0) {
+      const startIdx = this.data.length;
+      this.data = [...this.data, ...additions];
+      for (let i = 0; i < additions.length; i++) {
+        this.keyIndex.set(this.getItemKey(additions[i]), startIdx + i);
+      }
     }
 
     if (removals.length > 0) {
       const removeKeys = new Set(removals.map((r) => this.getItemKey(r)));
       this.data = this.data.filter((item) => !removeKeys.has(this.getItemKey(item)));
       this.reindex();
+    } else if (additions.length === 0) {
+      // Fresh array reference so signal consumers re-fire
+      this.data = [...this.data];
     }
 
-    // Fresh array reference so signal consumers re-fire
-    this.data = [...this.data];
     this.dataChange.next(this.data);
   }
 

--- a/src/app/cartography/helpers/dom-patcher.ts
+++ b/src/app/cartography/helpers/dom-patcher.ts
@@ -2,11 +2,10 @@
  * Targeted DOM patcher for incremental D3 map updates.
  *
  * When a data-driven (gated) redraw only contains xY-position changes on
- * nodes, we can skip the full graphLayout.draw (D3 data-join + getBBox
- * reflows) and directly update the affected DOM elements.  Everything else
- * (structural changes, link/drawing updates, non-xY visual changes) falls
- * back to full draw for now — widget-specific targeted-update methods
- * (Commit 3) will extend this gradually.
+ * nodes/drawings, we can skip the full graphLayout.draw (D3 data-join +
+ * getBBox reflows) and directly update the affected DOM elements. Everything
+ * else (structural changes, link path changes, z/layer changes, non-xY visual
+ * changes) falls back to full draw.
  */
 
 import * as d3 from 'd3';
@@ -15,9 +14,9 @@ import { AffectedIds } from './item-signature';
 import { GraphDataManager } from '../managers/graph-data-manager';
 
 /**
- * Apply incremental DOM patches for items that only had xY position changes.
- * Returns `true` if a FULL draw is still required (structural changes or
- * non-xY updates were found).
+ * Apply incremental DOM patches. Returns `true` if a FULL draw is still
+ * required (structural changes, z/layer migration, link recompute, or any
+ * non-xY/label update).
  */
 export function applyIncrementalPatches(
   svg: d3.Selection<SVGSVGElement, unknown, null, unknown>,
@@ -25,49 +24,63 @@ export function applyIncrementalPatches(
   graphDataManager: GraphDataManager,
   _context: Context
 ): boolean {
+  // Structural changes always need enter/exit → full draw.
+  if (
+    affected.additions.nodes.length > 0 ||
+    affected.removals.nodes.length > 0 ||
+    affected.additions.links.length > 0 ||
+    affected.removals.links.length > 0 ||
+    affected.additions.drawings.length > 0 ||
+    affected.removals.drawings.length > 0
+  ) {
+    return true;
+  }
+  if (affected.updates.size === 0) return false;
+
+  // O(1) lookup maps (one O(N) pass instead of K×O(N) .some()/.find()).
+  const nodesById = new Map(graphDataManager.getNodes().map((n) => [n.id, n]));
+  const drawingsById = new Map(graphDataManager.getDrawings().map((d) => [d.id, d]));
+
   let needsFullDraw = false;
-
-  // ── Structural changes always require full draw (enter / exit) ──
-  if (affected.additions.nodes.length > 0 || affected.removals.nodes.length > 0) needsFullDraw = true;
-  if (affected.additions.links.length > 0 || affected.removals.links.length > 0) needsFullDraw = true;
-  if (affected.additions.drawings.length > 0 || affected.removals.drawings.length > 0) needsFullDraw = true;
-
-  if (needsFullDraw) return true;
-
-  // ── Node / Drawing targeted updates ──
-  const nodes = graphDataManager.getNodes();
-  const drawings = graphDataManager.getDrawings();
 
   for (const [itemId, groups] of affected.updates) {
     const onlyXy = groups.length === 1 && groups[0] === 'xY';
-    const onlyXyZ  = groups.every((g) => g === 'xY' || g === 'z');
     const onlyLabel = groups.length === 1 && groups[0] === 'label';
 
-    // Node: only xY (or xY+z) → targeted transform
-    if (onlyXyZ && nodes.some((n) => n.id === itemId)) {
-      const node = nodes.find((n) => n.id === itemId);
+    // Node: only xY → targeted transform (no reflow)
+    // NOTE: z is intentionally NOT included here — z changes migrate the item
+    // between <g class="layer"> containers, which requires a full draw.
+    if (onlyXy) {
+      const node = nodesById.get(itemId);
       if (node) {
+        // Match NodeWidget.draw / NodesWidget.updateNodePosition: nodes
+        // without a width are offset by -30 (legacy symbol-only fallback).
+        const o = node.width ? 0 : -30;
         svg
           .select(`g.node[node_id="${d3SelectEscape(itemId)}"]`)
           .select<SVGGElement>('g.node_body')
-          .attr('transform', `translate(${node.x}, ${node.y})`);
+          .attr('transform', `translate(${node.x + o}, ${node.y + o})`);
+        continue;
       }
-      continue;
+      // Drawing: only xY → targeted transform
+      const drawing = drawingsById.get(itemId);
+      if (drawing) {
+        svg
+          .select(`g.drawing[drawing_id="${d3SelectEscape(itemId)}"]`)
+          .select<SVGGElement>('g.drawing_body')
+          .attr('transform', `translate(${drawing.x}, ${drawing.y}) rotate(${drawing.rotation})`);
+        continue;
+      }
     }
 
     // Node: only label → targeted text update + getBBox (only that label)
-    if (onlyLabel && nodes.some((n) => n.id === itemId)) {
-      const node = nodes.find((n) => n.id === itemId);
+    if (onlyLabel) {
+      const node = nodesById.get(itemId);
       if (node && node.label) {
-        const label = node.label;
         const labelSel = svg.select(`g.node[node_id="${d3SelectEscape(itemId)}"]`).select('text.label');
         if (!labelSel.empty()) {
-          labelSel
-            .attr('style', (label as any).style)
-            .text((label as any).text)
-            .attr('x', (label as any).x)
-            .attr('y', (label as any).y);
-          // Recompute the label selection rect bbox
+          const label = node.label as any;
+          labelSel.attr('style', label.style).text(label.text).attr('x', label.x).attr('y', label.y);
           const bbox = (labelSel.node() as SVGTextElement | null)?.getBBox();
           if (bbox) {
             svg
@@ -79,23 +92,12 @@ export function applyIncrementalPatches(
               .attr('height', bbox.height);
           }
         }
+        continue;
       }
-      continue;
     }
 
-    // Drawing: only xY (or xY+z) → targeted transform
-    if (onlyXyZ && drawings.some((d) => d.id === itemId)) {
-      const drawing = drawings.find((d) => d.id === itemId);
-      if (drawing) {
-        svg
-          .select(`g.drawing[drawing_id="${d3SelectEscape(itemId)}"]`)
-          .select<SVGGElement>('g.drawing_body')
-          .attr('transform', `translate(${drawing.x}, ${drawing.y}) rotate(${drawing.rotation})`);
-      }
-      continue;
-    }
-
-    // Anything else → fall through to full draw
+    // Anything else (z/layer change, link path recompute, multi-field, unknown)
+    // → full draw.
     needsFullDraw = true;
   }
 

--- a/src/app/cartography/helpers/item-signature.ts
+++ b/src/app/cartography/helpers/item-signature.ts
@@ -83,8 +83,9 @@ export function nodeSignatures(
 
 // ── Link ────────────────────────────────────────────────────────
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function linkSignatures(l: any): ItemSignatures<LinkSigGroup> {
+export function linkSignatures(
+  l: { link_id: string; nodes: unknown; capturing: unknown; suspend: unknown; show_filters_icon: unknown; wireshark: unknown; link_type: unknown; filters?: unknown; link_style?: unknown }
+): ItemSignatures<LinkSigGroup> {
   const nodes = JSON.stringify(l.nodes);
   const visual = `${l.capturing}|${l.suspend}|${l.show_filters_icon}|${l.wireshark}|${l.link_type}|${JSON.stringify(l.filters)}|${JSON.stringify(l.link_style)}`;
   return {

--- a/src/app/cartography/managers/graph-data-manager.ts
+++ b/src/app/cartography/managers/graph-data-manager.ts
@@ -101,6 +101,18 @@ export class GraphDataManager {
           if (oldZ !== undefined && oldZ !== newZ) {
             this.layersManager.moveNode(existing, Number(oldZ));
           }
+          // A node position/size change bends every link connected to it.
+          // Mark those links in affected so the dom-patcher falls through to
+          // a full draw (which recomputes link paths from source/target) —
+          // otherwise the link path DOM keeps pointing at the old coordinates.
+          if (changed.includes('xY') || changed.includes('visual')) {
+            const linkSet = this.nodeToLinks.get(n.node_id);
+            if (linkSet) {
+              for (const lid of linkSet) {
+                affected.updates.set(lid, ['linkPath']);
+              }
+            }
+          }
         }
       }
     }
@@ -113,6 +125,7 @@ export class GraphDataManager {
           this.layersManager.removeNode(m);
         }
         this.nodeSig.delete(id);
+        this.nodeToLinks.delete(id);
         affected.removals.nodes.push(id);
       }
     }
@@ -138,8 +151,13 @@ export class GraphDataManager {
     // Rebuild nodeToLinks incrementally
     const oldLinkToNodes = new Map<string, [string, string]>();
     for (const [id, l] of existingMap) {
-      if (l.source?.id && l.target?.id) {
-        oldLinkToNodes.set(id, [l.source.id, l.target.id]);
+      // Register off link.nodes[].nodeId — LinkToMapLinkConverter does NOT
+      // populate source/target (those are resolved later in assignDataToLinks);
+      // reading source?.id here is always undefined on first load.
+      const sid = l.nodes[0]?.nodeId;
+      const tid = l.nodes[1]?.nodeId;
+      if (sid && tid) {
+        oldLinkToNodes.set(id, [sid, tid]);
       }
     }
 
@@ -151,8 +169,10 @@ export class GraphDataManager {
         additions.push(converted);
         this.linkSig.set(l.link_id, sigs);
         affected.additions.links.push(l.link_id);
-        if (converted.source?.id && converted.target?.id) {
-          this.registerLinkNodes(l.link_id, converted.source.id, converted.target.id);
+        const srcId = converted.nodes[0]?.nodeId;
+        const tgtId = converted.nodes[1]?.nodeId;
+        if (srcId && tgtId) {
+          this.registerLinkNodes(l.link_id, srcId, tgtId);
         }
       } else {
         const oldSigs = this.linkSig.get(l.link_id);
@@ -168,8 +188,10 @@ export class GraphDataManager {
             if (oldPair) {
               this.unregisterLinkNodes(l.link_id, oldPair[0], oldPair[1]);
             }
-            if (existing.source?.id && existing.target?.id) {
-              this.registerLinkNodes(l.link_id, existing.source.id, existing.target.id);
+            const srcId = existing.nodes[0]?.nodeId;
+            const tgtId = existing.nodes[1]?.nodeId;
+            if (srcId && tgtId) {
+              this.registerLinkNodes(l.link_id, srcId, tgtId);
             }
           }
         }

--- a/src/app/cartography/managers/layers-manager.ts
+++ b/src/app/cartography/managers/layers-manager.ts
@@ -63,9 +63,11 @@ export class LayersManager {
     }
   }
 
-  public moveNode(node: MapNode, oldZ: number): void {
+  public moveNode(node: MapNode, _oldZ: number): void {
+    // node.z already holds the NEW z (set by the caller before move). Remove
+    // from any layer, then re-add so addNode routes to the new z bucket.
+    // Do NOT reset node.z to oldZ — that would undo the update.
     this.removeNode(node);
-    node.z = oldZ; // restored by caller if needed — we just route to new layer
     this.addNode(node);
   }
 

--- a/src/app/components/project-map/marker-manager/marker-manager.component.ts
+++ b/src/app/components/project-map/marker-manager/marker-manager.component.ts
@@ -40,6 +40,7 @@ import {
   AggregateMarkerMap,
   MarkerDefinitionCreateBody,
   MarkerDefinitionMap,
+  MarkerMap,
 } from '@models/marker';
 import { MarkerService, MarkerWriteBody } from '@services/marker.service';
 import { LinkService } from '@services/link.service';
@@ -410,6 +411,7 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
       next: (map: AggregateMarkerMap) => {
         this.linkGroups.set(this.buildGroups(map));
         this.markerRegistryService.rebuildFromAggregate(map);
+        this.syncLinkMarkersFromAggregate(map);
         this.cdr.markForCheck();
       },
       error: (err) => {
@@ -450,6 +452,46 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
     }
     groups.sort((a, b) => a.name.localeCompare(b.name));
     return groups;
+  }
+
+  /**
+   * Write the aggregate map's authoritative per-link marker state back into the
+   * cartography + map link objects.
+   *
+   * `marker.match` resolves the flash color from
+   * `linksDataSource.get(id).markers[name].color` on demand (it does not
+   * subscribe to changes), so a definition color edit that only refreshes the
+   * legend registry leaves the stored link object stale → the flash falls back
+   * to the default theme color until a full page reload. The aggregate view
+   * (`GET /projects/{pid}/markers`) carries every marker field for every link,
+   * so rebuilding each link's `markers` from it and mutating the stored objects
+   * in place (no emit, no redraw) is enough: the next `marker.match` reads the
+   * fresh color. Replacing (not merging) also drops markers removed by a
+   * definition delete; private markers are preserved because the aggregate
+   * includes them too.
+   */
+  private syncLinkMarkersFromAggregate(map: AggregateMarkerMap) {
+    const byLink = new Map<string, MarkerMap>();
+    for (const [key, entry] of Object.entries(map)) {
+      const linkId = entry.link_id;
+      if (!linkId) continue;
+      const slashIdx = key.indexOf('/');
+      const name = slashIdx >= 0 ? key.slice(slashIdx + 1) : key;
+      let mm = byLink.get(linkId);
+      if (!mm) {
+        mm = {};
+        byLink.set(linkId, mm);
+      }
+      // Strip the aggregate-only keys; keep every Marker field (bpf/color/dir/...).
+      const { link_id: _linkId, node_id: _nodeId, ...marker } = entry;
+      mm[name] = marker;
+    }
+    for (const [linkId, markers] of byLink) {
+      const link = this.linksDataSource.get(linkId);
+      if (link) link.markers = markers;
+      const mapLink = this.mapLinksDataSource.get(linkId);
+      if (mapLink) mapLink.markers = markers;
+    }
   }
 
   private linkName(linkId: string): string {


### PR DESCRIPTION
## Summary

Two fixes on top of the Tier 1 & 2 incremental render pipeline (#1779):

### 1. Tier 2 review fixes (critical regressions)

**Critical:**
- **Link breakage on non-drag node moves**: `setNodes` now marks links connected to a moved node (via `nodeToLinks`) in `affected.updates` so the dom-patcher falls through to a full draw that recomputes link paths. Previously the incremental path only updated `g.node_body` transform, leaving link paths pointing at stale coordinates (visible on server-side layout / multi-user scenarios).
- **z-layer migration**: `LayersManager.moveNode` was resetting `node.z = oldZ` then re-adding, so the node never left its old layer and z metadata was corrupted. Now the reset is dropped (node.z already holds the new value). dom-patcher no longer treats z as part of the xY fast path—z changes fall through to full draw.

**Major:**
- **`nodeToLinks` never populated**: `LinkToMapLinkConverter` leaves `source`/`target` undefined, so `registerLinkNodes` (guarded on `source?.id`) was always skipped. Now registers off `nodes[0].nodeId` / `nodes[1].nodeId`.
- **dom-patcher node transform offset**: The incremental path was missing the `-30` offset applied by `NodeWidget` for nodes without a width—incremental moves were 30px off.
- **`DataSource.applyBatch` O(K·N)**: Batched into a single `[...data, ...additions]` with direct index assignment.

### 2. Marker flash color sync after definition edit

`marker.match` resolves flash color from `linksDataSource` link objects on demand (pull), but a definition color edit only refreshed the legend registry via `loadAggregate`—the stored `link.markers` stayed stale, so the flash fell back to the default theme color until a full page reload.

Now rebuilds each link's markers from the authoritative aggregate map and mutates the stored cartography + map link objects in place (no emit, no redraw): the next `marker.match` reads the fresh color. Replacing (not merging) also drops markers removed by a definition delete; private markers are preserved since the aggregate includes them.