### PR TITLE
fix(docker): preserve appliance fields when creating docker templates

### DIFF
--- a/src/app/components/preferences/docker/add-docker-template/add-docker-template.component.html
+++ b/src/app/components/preferences/docker/add-docker-template/add-docker-template.component.html
@@ -157,7 +157,7 @@
             <mat-form-field appearance="fill" class="docker-add__field">
               <mat-label>Environment</mat-label>
               <textarea
-                matInput
+                matInput rows="1" cdkTextareaAutosize cdkAutosizeMinRows="1" cdkAutosizeMaxRows="12"
                 type="text"
                 [value]="environment()"
                 (input)="environment.set($event.target.value)"

--- a/src/app/components/preferences/docker/add-docker-template/add-docker-template.component.ts
+++ b/src/app/components/preferences/docker/add-docker-template/add-docker-template.component.ts
@@ -11,6 +11,7 @@ import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { MatStepperModule } from '@angular/material/stepper';
 import { MatCheckboxModule } from '@angular/material/checkbox';
+import { CdkTextareaAutosize } from '@angular/cdk/text-field';
 import { v4 as uuid } from 'uuid';
 import { Compute } from '@models/compute';
 import { DockerImage } from '@models/docker/docker-image';
@@ -42,6 +43,7 @@ import { ToasterService } from '@services/toaster.service';
     MatSelectModule,
     MatStepperModule,
     MatCheckboxModule,
+    CdkTextareaAutosize,
   ],
 })
 export class AddDockerTemplateComponent implements OnInit {

--- a/src/app/components/preferences/docker/docker-template-details/docker-template-details.component.html
+++ b/src/app/components/preferences/docker/docker-template-details/docker-template-details.component.html
@@ -222,7 +222,7 @@
         <mat-form-field class="form-field">
           <mat-label>Start command</mat-label>
           <textarea
-            matInput
+            matInput rows="1" cdkTextareaAutosize cdkAutosizeMinRows="1" cdkAutosizeMaxRows="12"
             [value]="startCommand()"
             (input)="startCommand.set($event.target.value)"
             type="text"
@@ -233,7 +233,7 @@
         <mat-form-field class="form-field">
           <mat-label>Environment</mat-label>
           <textarea
-            matInput
+            matInput rows="1" cdkTextareaAutosize cdkAutosizeMinRows="1" cdkAutosizeMaxRows="12"
             [value]="environment()"
             (input)="environment.set($event.target.value)"
             type="text"
@@ -244,7 +244,7 @@
         <mat-form-field class="form-field">
           <mat-label>Extra volumes</mat-label>
           <textarea
-            matInput
+            matInput rows="1" cdkTextareaAutosize cdkAutosizeMinRows="1" cdkAutosizeMaxRows="12"
             [value]="extraVolumes()"
             (input)="extraVolumes.set($event.target.value)"
             type="text"
@@ -255,7 +255,7 @@
         <mat-form-field class="form-field">
           <mat-label>Extra hosts</mat-label>
           <textarea
-            matInput
+            matInput rows="1" cdkTextareaAutosize cdkAutosizeMinRows="1" cdkAutosizeMaxRows="12"
             [value]="extraHosts()"
             (input)="extraHosts.set($event.target.value)"
             type="text"
@@ -275,7 +275,7 @@
       <div class="preferences__usage-form">
         <mat-form-field class="preferences__usage-field--full">
           <mat-label>Usage</mat-label>
-          <textarea matInput [value]="usage()" (input)="usage.set($event.target.value)" type="text"></textarea>
+          <textarea matInput rows="1" cdkTextareaAutosize cdkAutosizeMinRows="1" cdkAutosizeMaxRows="12" [value]="usage()" (input)="usage.set($event.target.value)" type="text"></textarea>
         </mat-form-field>
       </div>
       }

--- a/src/app/components/preferences/docker/docker-template-details/docker-template-details.component.ts
+++ b/src/app/components/preferences/docker/docker-template-details/docker-template-details.component.ts
@@ -9,6 +9,7 @@ import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { MatChipsModule, MatChipInputEvent } from '@angular/material/chips';
 import { MatCheckboxModule } from '@angular/material/checkbox';
+import { CdkTextareaAutosize } from '@angular/cdk/text-field';
 import { MatDialog } from '@angular/material/dialog';
 import { COMMA, ENTER } from '@angular/cdk/keycodes';
 import { finalize } from 'rxjs';
@@ -40,6 +41,7 @@ import { ConfigureCustomAdaptersDialogComponent } from '../../../project-map/nod
     MatSelectModule,
     MatChipsModule,
     MatCheckboxModule,
+    CdkTextareaAutosize,
   ],
 })
 export class DockerTemplateDetailsComponent implements OnInit {

--- a/src/app/components/project-map/context-console-menu/context-console-menu.component.ts
+++ b/src/app/components/project-map/context-console-menu/context-console-menu.component.ts
@@ -101,7 +101,11 @@ export class ContextConsoleMenuComponent implements OnInit {
       } else if (this.node.console_type && this.node.console_type.startsWith('spice')) {
         // SPICE console: not yet implemented
         this.toasterService.error('SPICE console is not yet supported.');
-      } else if (this.node.console_type === 'telnet' || this.node.console_type === 'ssh') {
+      } else if (
+        this.node.console_type === 'telnet' ||
+        this.node.console_type === 'ssh' ||
+        this.node.console_type === 'docker_exec'
+      ) {
         // Terminal console: use embedded console
         this.mapSettingsService.logConsoleSubject.next(true);
         this.consoleService.openConsoleForNode(this.node);
@@ -123,7 +127,11 @@ export class ContextConsoleMenuComponent implements OnInit {
       } else if (this.node.console_type && this.node.console_type.startsWith('spice')) {
         // SPICE console: not yet implemented
         this.toasterService.error('SPICE console is not yet supported.');
-      } else if (this.node.console_type === 'telnet' || this.node.console_type === 'ssh') {
+      } else if (
+        this.node.console_type === 'telnet' ||
+        this.node.console_type === 'ssh' ||
+        this.node.console_type === 'docker_exec'
+      ) {
         // Terminal console: use existing URL-based approach
         let url = this.router.url.split('/');
         let urlString = `/static/web-ui/${url[1]}/${url[2]}/${url[3]}/${url[4]}/nodes/${this.node.node_id}`;

--- a/src/app/components/project-map/context-menu/actions/console-device-action-browser/console-device-action-browser.component.ts
+++ b/src/app/components/project-map/context-menu/actions/console-device-action-browser/console-device-action-browser.component.ts
@@ -65,7 +65,7 @@ export class ConsoleDeviceActionBrowserComponent {
         if (ipaddr.IPv6.isValid(host)) {
           host = `[${host}]`;
         }
-        if (node.console_type === 'telnet' || node.console_type === 'ssh') {
+        if (node.console_type === 'telnet' || node.console_type === 'ssh' || node.console_type === 'docker_exec') {
           var console_port;
           if (auxiliary === true) {
             console_port = node.properties.aux;

--- a/src/app/components/project-map/context-menu/actions/http-console-new-tab/http-console-new-tab-action.component.ts
+++ b/src/app/components/project-map/context-menu/actions/http-console-new-tab/http-console-new-tab-action.component.ts
@@ -43,7 +43,7 @@ export class HttpConsoleNewTabActionComponent {
 
             const uri = `${n.console_type}://${n.console_host}:${n.console}`;
             window.open(uri, '_blank');
-          } else if (n.console_type === 'telnet' || n.console_type === 'ssh') {
+          } else if (n.console_type === 'telnet' || n.console_type === 'ssh' || n.console_type === 'docker_exec') {
             // Terminal console: use existing URL-based approach in new tab
             let url = this.router.url.split('/');
             let urlString = `/static/web-ui/${url[1]}/${url[2]}/${url[3]}/${url[4]}/nodes/${n.node_id}`;

--- a/src/app/components/project-map/context-menu/actions/http-console/http-console-action.component.ts
+++ b/src/app/components/project-map/context-menu/actions/http-console/http-console-action.component.ts
@@ -66,7 +66,7 @@ export class HttpConsoleActionComponent {
         controller,
         project,
       });
-    } else if (node.console_type === 'telnet' || node.console_type === 'ssh') {
+    } else if (node.console_type === 'telnet' || node.console_type === 'ssh' || node.console_type === 'docker_exec') {
       // Terminal console: still use embedded widget (not inline window)
       this.mapSettingsService.logConsoleSubject.next(true);
       setTimeout(() => {

--- a/src/app/components/project-map/import-appliance/import-appliance.component.ts
+++ b/src/app/components/project-map/import-appliance/import-appliance.component.ts
@@ -154,6 +154,18 @@ export class ImportApplianceComponent implements OnInit {
         template.adapters = appliance.docker.adapters;
         template.console_type = appliance.docker.console_type;
         template.image = appliance.docker.image;
+        template.start_command = appliance.docker.start_command;
+        template.environment = appliance.docker.environment;
+        template.extra_hosts = appliance.docker.extra_hosts;
+        template.extra_volumes = appliance.docker.extra_volumes || [];
+        template.custom_adapters = appliance.custom_adapters || [];
+        template.mac_address = appliance.docker.mac_address;
+        template.cpus = appliance.docker.cpus;
+        template.memory = appliance.docker.mem_limit;
+        template.console_http_path = appliance.docker.console_http_path;
+        template.console_http_port = appliance.docker.console_http_port;
+        template.console_resolution = appliance.docker.console_resolution;
+        template.usage = appliance.usage;
       } else {
         this.toasterService.error('Template type not supported');
         return;

--- a/src/app/components/project-map/log-console/log-console.component.ts
+++ b/src/app/components/project-map/log-console/log-console.component.ts
@@ -259,7 +259,11 @@ export class LogConsoleComponent implements OnInit, AfterViewInit, OnDestroy {
             if (ipaddr.IPv6.isValid(host)) {
               host = `[${host}]`;
             }
-            if (node.console_type === 'telnet' || node.console_type === 'ssh') {
+            if (
+              node.console_type === 'telnet' ||
+              node.console_type === 'ssh' ||
+              node.console_type === 'docker_exec'
+            ) {
               this.protocolHandlerService.open(
                 `gns3+${node.console_type}://${host}:${node.console}?name=${encodeURIComponent(node.name)}&project_id=${node.project_id}&node_id=${node.node_id}`
               );

--- a/src/app/components/project-map/new-template-dialog/new-template-dialog.component.ts
+++ b/src/app/components/project-map/new-template-dialog/new-template-dialog.component.ts
@@ -1007,16 +1007,30 @@ export class NewTemplateDialogComponent implements OnInit, AfterViewInit {
 
   createDockerTemplate() {
     let dockerTemplate: DockerTemplate = new DockerTemplate();
-    dockerTemplate.adapters = this.applianceToInstall.docker.adapters;
-    dockerTemplate.console_type = this.applianceToInstall.docker.console_type;
+    const docker = this.applianceToInstall.docker;
+    dockerTemplate.adapters = docker.adapters;
+    dockerTemplate.image = docker.image;
+    dockerTemplate.console_type = docker.console_type;
+    dockerTemplate.start_command = docker.start_command;
+    dockerTemplate.environment = docker.environment;
+    dockerTemplate.extra_hosts = docker.extra_hosts;
+    dockerTemplate.extra_volumes = docker.extra_volumes || [];
+    dockerTemplate.custom_adapters = this.applianceToInstall.custom_adapters || [];
+    dockerTemplate.mac_address = docker.mac_address;
+    dockerTemplate.cpus = docker.cpus;
+    dockerTemplate.memory = docker.mem_limit;
+    dockerTemplate.console_http_path = docker.console_http_path;
+    dockerTemplate.console_http_port = docker.console_http_port;
+    dockerTemplate.console_resolution = docker.console_resolution;
+    dockerTemplate.template_type = 'docker';
+
     dockerTemplate.category = this.getCategory();
     dockerTemplate.default_name_format = this.applianceToInstall.default_name_format;
     dockerTemplate.symbol = this.applianceToInstall.symbol;
     dockerTemplate.tags = this.applianceToInstall.tags || [];
+    dockerTemplate.usage = this.applianceToInstall.usage;
     dockerTemplate.compute_id = 'local';
     dockerTemplate.template_id = uuid();
-    dockerTemplate.image = this.applianceToInstall.docker.image;
-    dockerTemplate.template_type = 'docker';
 
     const dialogRef = this.dialog.open(TemplateNameDialogComponent, {
       width: '400px',

--- a/src/app/components/project-map/node-editors/configurator/docker/configurator-docker.component.html
+++ b/src/app/components/project-map/node-editors/configurator/docker/configurator-docker.component.html
@@ -121,24 +121,24 @@
               <h6>Start command</h6>
               <mat-form-field class="form-field">
                 <mat-label>Start command</mat-label>
-                <textarea matInput [value]="startCommand()" (input)="startCommand.set($event.target.value)" placeholder='Command to run when the container starts (overrides image default CMD). E.g., python app.py, nginx -g "daemon off;"'></textarea>
+                <textarea matInput rows="1" cdkTextareaAutosize cdkAutosizeMinRows="1" cdkAutosizeMaxRows="12" [value]="startCommand()" (input)="startCommand.set($event.target.value)" placeholder='Command to run when the container starts (overrides image default CMD). E.g., python app.py, nginx -g "daemon off;"'></textarea>
               </mat-form-field>
               <h6>Environment</h6>
               <mat-form-field class="form-field">
                 <mat-label>Environment variables</mat-label>
-                <textarea matInput [value]="environment()" (input)="environment.set($event.target.value)" placeholder="Environment variables (one per line, KEY=VALUE format). Supports: %vm-name%, %vm-id%, %project-id%, %project-path%"></textarea>
+                <textarea matInput rows="1" cdkTextareaAutosize cdkAutosizeMinRows="1" cdkAutosizeMaxRows="12" [value]="environment()" (input)="environment.set($event.target.value)" placeholder="Environment variables (one per line, KEY=VALUE format). Supports: %vm-name%, %vm-id%, %project-id%, %project-path%"></textarea>
               </mat-form-field>
 
               <h6>Extra hosts</h6>
               <mat-form-field class="form-field">
                 <mat-label>Extra hosts</mat-label>
-                <textarea matInput [value]="extraHosts()" (input)="extraHosts.set($event.target.value)" placeholder="Hostname to IP mappings, one per line (e.g., gns3.com:192.168.100.10)"></textarea>
+                <textarea matInput rows="1" cdkTextareaAutosize cdkAutosizeMinRows="1" cdkAutosizeMaxRows="12" [value]="extraHosts()" (input)="extraHosts.set($event.target.value)" placeholder="Hostname to IP mappings, one per line (e.g., gns3.com:192.168.100.10)"></textarea>
               </mat-form-field>
 
               <h6>Additional volumes</h6>
               <mat-form-field class="form-field">
                 <mat-label>Additional volumes</mat-label>
-                <textarea matInput [value]="extraVolumes()" (input)="extraVolumes.set($event.target.value)" placeholder="Container directories to persist, one per line (e.g., /data&#10;/config)"></textarea>
+                <textarea matInput rows="1" cdkTextareaAutosize cdkAutosizeMinRows="1" cdkAutosizeMaxRows="12" [value]="extraVolumes()" (input)="extraVolumes.set($event.target.value)" placeholder="Container directories to persist, one per line (e.g., /data&#10;/config)"></textarea>
               </mat-form-field>
             </div>
           </mat-tab>

--- a/src/app/components/project-map/node-editors/configurator/docker/configurator-docker.component.ts
+++ b/src/app/components/project-map/node-editors/configurator/docker/configurator-docker.component.ts
@@ -11,6 +11,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatChipsModule, MatChipInputEvent } from '@angular/material/chips';
 import { MatIconModule } from '@angular/material/icon';
 import { MatCheckboxModule } from '@angular/material/checkbox';
+import { CdkTextareaAutosize } from '@angular/cdk/text-field';
 import { COMMA, ENTER } from '@angular/cdk/keycodes';
 import { Node } from '../../../../../cartography/models/node';
 import { Controller } from '@models/controller';
@@ -40,6 +41,7 @@ import { EditNetworkConfigurationDialogComponent } from './edit-network-configur
     MatChipsModule,
     MatIconModule,
     MatCheckboxModule,
+    CdkTextareaAutosize,
   ],
 })
 export class ConfiguratorDialogDockerComponent implements OnInit {

--- a/src/app/components/project-map/node-editors/configurator/docker/configure-custom-adapters/configure-custom-adapters.component.html
+++ b/src/app/components/project-map/node-editors/configurator/docker/configure-custom-adapters/configure-custom-adapters.component.html
@@ -11,7 +11,15 @@
     @for (adapter of adapters(); track adapter.adapter_number; let i = $index) {
     <div class="adapter-item">
       <span class="adapter-label">Adapter {{ adapter.adapter_number }}</span>
-      <span class="adapter-port-name">eth{{ adapter.adapter_number }}</span>
+      <mat-form-field appearance="fill" subscriptSizing="dynamic" class="adapter-field">
+        <input
+          matInput
+          [value]="adapter.port_name"
+          (input)="onPortNameChange(adapter.adapter_number, $event.target.value)"
+          name="port_name_{{ i }}"
+          placeholder="eth{{ adapter.adapter_number }}"
+        />
+      </mat-form-field>
       <mat-form-field appearance="fill" subscriptSizing="dynamic" class="adapter-field">
         <input
           matInput
@@ -36,7 +44,7 @@
       Add adapter
     </button>
     <div class="info-note-text">
-      Docker port names are fixed (eth0, eth1...). Deleting an adapter reduces the total number of adapters.
+      Port names label each adapter in the topology (the in-container interface stays eth0, eth1…). Deleting an adapter reduces the total number of adapters.
     </div>
   </div>
 </div>

--- a/src/app/components/project-map/node-editors/configurator/docker/configure-custom-adapters/configure-custom-adapters.component.scss
+++ b/src/app/components/project-map/node-editors/configurator/docker/configure-custom-adapters/configure-custom-adapters.component.scss
@@ -61,18 +61,11 @@
   }
 }
 
-.adapter-label,
-.adapter-port-name {
+.adapter-label {
   font-size: 16px;
   font-weight: 500;
   color: var(--mat-sys-on-surface);
   text-align: center;
-}
-
-.adapter-port-name {
-  padding: 8px;
-  background: color-mix(in srgb, var(--mat-sys-on-surface) 5%, transparent);
-  border-radius: 4px;
 }
 
 .adapter-actions {

--- a/src/app/components/project-map/node-editors/configurator/docker/configure-custom-adapters/configure-custom-adapters.component.ts
+++ b/src/app/components/project-map/node-editors/configurator/docker/configure-custom-adapters/configure-custom-adapters.component.ts
@@ -42,18 +42,22 @@ export class ConfigureCustomAdaptersDialogComponent implements OnInit {
     if (currentAdapters.length === 0 && this.node) {
       if (!this.node.custom_adapters) {
         this.node.ports.forEach((port, i) => {
-          currentAdapters.push({ adapter_number: i, mac_address: '' });
+          currentAdapters.push({ adapter_number: i, port_name: port?.name || '', mac_address: '' });
         });
       } else {
         currentAdapters.push(
-          ...this.node.custom_adapters.map((a: any) => ({ ...a, mac_address: a.mac_address || '' }))
+          ...this.node.custom_adapters.map((a: any) => ({
+            ...a,
+            port_name: a.port_name || '',
+            mac_address: a.mac_address || '',
+          }))
         );
       }
       this.adapters.set(currentAdapters);
     } else if (currentAdapters.length > 0) {
       // Ensure mac_address defaults to empty string
       this.adapters.update((adapters) =>
-        adapters.map((a) => ({ ...a, mac_address: a.mac_address || '' }))
+        adapters.map((a) => ({ ...a, port_name: a.port_name || '', mac_address: a.mac_address || '' }))
       );
     }
   }
@@ -65,9 +69,19 @@ export class ConfigureCustomAdaptersDialogComponent implements OnInit {
     this.cdr.markForCheck();
   }
 
+  onPortNameChange(adapterNumber: number, value: string) {
+    this.adapters.update((adapters) =>
+      adapters.map((a) => (a.adapter_number === adapterNumber ? { ...a, port_name: value } : a))
+    );
+    this.cdr.markForCheck();
+  }
+
   addAdapter() {
     const maxNumber = this.adapters().reduce((max, a) => Math.max(max, a.adapter_number), -1);
-    this.adapters.update((adapters) => [...adapters, { adapter_number: maxNumber + 1, mac_address: '' }]);
+    this.adapters.update((adapters) => [
+      ...adapters,
+      { adapter_number: maxNumber + 1, port_name: '', mac_address: '' },
+    ]);
   }
 
   removeAdapter(adapterNumber: number) {

--- a/src/app/models/appliance.ts
+++ b/src/app/models/appliance.ts
@@ -1,3 +1,5 @@
+import { CustomAdapter } from './qemu/qemu-custom-adapter';
+
 export interface Image {
   compression?: string;
   direct_download_url?: string;
@@ -27,6 +29,16 @@ export interface Docker {
   adapters: number;
   console_type: string;
   image: string;
+  start_command?: string;
+  environment?: string;
+  extra_hosts?: string;
+  extra_volumes?: string[];
+  mac_address?: string;
+  cpus?: number;
+  mem_limit?: number;
+  console_http_path?: string;
+  console_http_port?: number;
+  console_resolution?: string;
 }
 
 export interface Dynamips {
@@ -91,6 +103,7 @@ export interface Appliance {
   vendor_url: string;
   versions: Version[];
   tags: string[];
+  custom_adapters?: CustomAdapter[];
 
   docker: Docker;
   dynamips: Dynamips;

--- a/src/app/services/docker-configuration.service.spec.ts
+++ b/src/app/services/docker-configuration.service.spec.ts
@@ -19,18 +19,19 @@ describe('DockerConfigurationService', () => {
   });
 
   describe('getConsoleTypes', () => {
-    it('should return 6 console types', () => {
+    it('should return 7 console types', () => {
       const result = service.getConsoleTypes();
-      expect(result).toHaveLength(6);
+      expect(result).toHaveLength(7);
     });
 
-    it('should include telnet, ssh, vnc, http, https, none', () => {
+    it('should include telnet, ssh, vnc, http, https, docker_exec, none', () => {
       const result = service.getConsoleTypes();
       expect(result).toContain('telnet');
       expect(result).toContain('ssh');
       expect(result).toContain('vnc');
       expect(result).toContain('http');
       expect(result).toContain('https');
+      expect(result).toContain('docker_exec');
       expect(result).toContain('none');
     });
   });

--- a/src/app/services/docker-configuration.service.ts
+++ b/src/app/services/docker-configuration.service.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@angular/core';
 @Injectable()
 export class DockerConfigurationService {
   getConsoleTypes() {
-    return ['telnet', 'ssh', 'vnc', 'http', 'https', 'none'];
+    return ['telnet', 'ssh', 'vnc', 'http', 'https', 'docker_exec', 'none'];
   }
 
   getAuxConsoleTypes() {

--- a/src/app/services/nodeConsole.service.ts
+++ b/src/app/services/nodeConsole.service.ts
@@ -101,7 +101,7 @@ export class NodeConsoleService {
     let nodesToStartCounter = 0;
     nodes.forEach((n) => {
       // opening a console in tab is supported for terminal console types
-      if (n.console_type === 'telnet' || n.console_type === 'ssh') {
+      if (n.console_type === 'telnet' || n.console_type === 'ssh' || n.console_type === 'docker_exec') {
         if (n.status === 'started') {
           let url = this.router.url.split('/');
           let urlString = `/static/web-ui/${url[1]}/${url[2]}/${url[3]}/${url[4]}/nodes/${n.node_id}`;


### PR DESCRIPTION
## Summary

Creating a docker template from an appliance only copied `adapters`, `console_type` and `image`, silently dropping `start_command`, `environment`, `extra_volumes`, the top-level `custom_adapters` and `usage`. Appliances such as Nokia SR Linux rely on these fields (e.g. `start_command` launches the NOS, `environment` provides `GNS3_CONSOLE_CMD` / `GNS3_INTERFACE_NAMES`, `custom_adapters` provides the port labels), so templates created from the appliance registry were broken.

## Changes

- Extend the appliance `Docker` interface (`start_command`, `environment`, `extra_volumes`, `extra_hosts`, `mac_address`, `cpus`, `mem_limit`, HTTP-console fields) and add top-level `custom_adapters` to `Appliance`
- `createDockerTemplate()` (new-template-dialog) and the import-appliance flow now map every appliance docker field that has a `DockerTemplate` counterpart, plus top-level `usage` and `custom_adapters`

Also includes docker_exec console support:

- `feat(docker): add docker_exec console type`
- `feat(docker): auto-resize Advanced textareas in Docker editors`
- `fix(docker): make custom-adapter port name editable`
