### PR TITLE
feat(docker): add extra_configs to inject config files into containers

### DIFF
--- a/src/app/cartography/models/node.ts
+++ b/src/app/cartography/models/node.ts
@@ -1,5 +1,6 @@
 import { Port } from '@models/port';
 import { Label } from './label';
+import { ExtraConfig } from '@models/templates/extra-config';
 
 export class PortsMapping {
   name: string;
@@ -118,6 +119,7 @@ export class Properties {
   console_http_port?: number;
   console_http_path?: string;
   extra_volumes?: string;
+  extra_configs?: ExtraConfig[];
 }
 
 export class Node {

--- a/src/app/components/preferences/docker/add-docker-template/add-docker-template.component.spec.ts
+++ b/src/app/components/preferences/docker/add-docker-template/add-docker-template.component.spec.ts
@@ -50,6 +50,7 @@ describe('AddDockerTemplateComponent', () => {
     memory: 0,
     cpus: 0,
     extra_volumes: [],
+    extra_configs: [],
     name: '',
     start_command: '',
     symbol: 'docker',

--- a/src/app/components/preferences/docker/copy-docker-template/copy-docker-template.component.spec.ts
+++ b/src/app/components/preferences/docker/copy-docker-template/copy-docker-template.component.spec.ts
@@ -59,6 +59,7 @@ describe('CopyDockerTemplateComponent', () => {
       memory: 0,
       cpus: 0,
       extra_volumes: [],
+      extra_configs: [],
       name: 'Original Docker Container',
       start_command: '',
       symbol: 'docker',

--- a/src/app/components/preferences/docker/docker-template-details/docker-template-details.component.html
+++ b/src/app/components/preferences/docker/docker-template-details/docker-template-details.component.html
@@ -267,6 +267,34 @@
     </section>
 
     <section class="docker-details__form-card">
+      <div class="docker-details__section-header" (click)="toggleSection('extraFiles')">
+        <h3 class="docker-details__section-title">Extra files</h3>
+        <mat-icon class="docker-details__expand-icon">{{ extraFilesExpanded ? 'expand_less' : 'expand_more' }}</mat-icon>
+      </div>
+      @if (extraFilesExpanded) {
+      <div class="form-container">
+        <h6 class="docker-details__section-subtitle">Configuration files</h6>
+        @for (config of extraConfigs(); track $index) {
+          <mat-form-field class="form-field">
+            <mat-label>Container target path</mat-label>
+            <input matInput type="text" [value]="config.target" (input)="updateExtraConfigTarget($index, $event.target.value)" placeholder="/first_boot.cfg" />
+            <button matSuffix mat-icon-button type="button" (click)="removeExtraConfig($index)" aria-label="Remove configuration file">
+              <mat-icon>delete</mat-icon>
+            </button>
+          </mat-form-field>
+          <mat-form-field class="form-field">
+            <mat-label>File content</mat-label>
+            <textarea matInput rows="1" cdkTextareaAutosize cdkAutosizeMinRows="1" cdkAutosizeMaxRows="12" [value]="config.content || ''" (input)="updateExtraConfigContent($index, $event.target.value)" placeholder="File contents injected (read-only) into the container at the target path"></textarea>
+          </mat-form-field>
+        }
+        <button mat-stroked-button class="form-field" type="button" (click)="addExtraConfig()">
+          <mat-icon>add</mat-icon> Add configuration file
+        </button>
+      </div>
+      }
+    </section>
+
+    <section class="docker-details__form-card">
       <div class="docker-details__section-header" (click)="toggleSection('usage')">
         <h3 class="docker-details__section-title">Usage</h3>
         <mat-icon class="docker-details__expand-icon">{{ usageExpanded ? 'expand_less' : 'expand_more' }}</mat-icon>

--- a/src/app/components/preferences/docker/docker-template-details/docker-template-details.component.spec.ts
+++ b/src/app/components/preferences/docker/docker-template-details/docker-template-details.component.spec.ts
@@ -67,6 +67,7 @@ describe('DockerTemplateDetailsComponent', () => {
     memory: 0,
     cpus: 0,
     extra_volumes: [],
+    extra_configs: [],
     name: 'Test Docker',
     start_command: '',
     symbol: 'docker',

--- a/src/app/components/preferences/docker/docker-template-details/docker-template-details.component.spec.ts
+++ b/src/app/components/preferences/docker/docker-template-details/docker-template-details.component.spec.ts
@@ -146,6 +146,7 @@ describe('DockerTemplateDetailsComponent', () => {
       validateCpus: vi.fn().mockReturnValue({ isValid: true }),
       validateConsoleHttpPort: vi.fn().mockReturnValue({ isValid: true }),
       validateEnvironment: vi.fn().mockReturnValue({ isValid: true }),
+      validateExtraConfigs: vi.fn().mockReturnValue({ isValid: true }),
     };
 
     await TestBed.configureTestingModule({

--- a/src/app/components/preferences/docker/docker-template-details/docker-template-details.component.ts
+++ b/src/app/components/preferences/docker/docker-template-details/docker-template-details.component.ts
@@ -15,6 +15,7 @@ import { COMMA, ENTER } from '@angular/cdk/keycodes';
 import { finalize } from 'rxjs';
 import { Controller } from '@models/controller';
 import { DockerTemplate } from '@models/templates/docker-template';
+import { ExtraConfig } from '@models/templates/extra-config';
 import { DockerConfigurationService } from '@services/docker-configuration.service';
 import { DockerService } from '@services/docker.service';
 import { ControllerService } from '@services/controller.service';
@@ -63,6 +64,7 @@ export class DockerTemplateDetailsComponent implements OnInit {
 
   generalSettingsExpanded = false;
   advancedExpanded = false;
+  extraFilesExpanded = false;
   usageExpanded = false;
 
   consoleTypes: string[] = [];
@@ -92,6 +94,7 @@ export class DockerTemplateDetailsComponent implements OnInit {
   environment = model('');
   extraHosts = model('');
   extraVolumes = model('');
+  extraConfigs = signal<ExtraConfig[]>([]);
   usage = model('');
   readonly isPulling = signal(false);
 
@@ -130,6 +133,9 @@ export class DockerTemplateDetailsComponent implements OnInit {
             this.environment.set(dockerTemplate.environment || '');
             this.extraHosts.set(dockerTemplate.extra_hosts || '');
             this.extraVolumes.set((dockerTemplate.extra_volumes || []).join('\n'));
+            this.extraConfigs.set(
+              (dockerTemplate.extra_configs || []).map((c) => ({ target: c.target || '', content: c.content ?? '' }))
+            );
             this.usage.set(dockerTemplate.usage || '');
             this.cd.markForCheck();
           },
@@ -166,6 +172,9 @@ export class DockerTemplateDetailsComponent implements OnInit {
         break;
       case 'advanced':
         this.advancedExpanded = !this.advancedExpanded;
+        break;
+      case 'extraFiles':
+        this.extraFilesExpanded = !this.extraFilesExpanded;
         break;
       case 'usage':
         this.usageExpanded = !this.usageExpanded;
@@ -253,6 +262,9 @@ export class DockerTemplateDetailsComponent implements OnInit {
     this.dockerTemplate.environment = this.environment();
     this.dockerTemplate.extra_hosts = this.extraHosts();
     this.dockerTemplate.extra_volumes = this.extraVolumes() ? this.extraVolumes().split('\n').filter((v) => v.trim()) : [];
+    this.dockerTemplate.extra_configs = this.extraConfigs()
+      .filter((c) => c.target && c.target.trim())
+      .map((c) => ({ target: c.target.trim(), content: c.content ?? '' }));
     this.dockerTemplate.usage = this.usage();
 
     this.dockerService.saveTemplate(this.controller, this.dockerTemplate).subscribe({
@@ -340,6 +352,22 @@ export class DockerTemplateDetailsComponent implements OnInit {
         this.symbol.set(result);
       }
     });
+  }
+
+  addExtraConfig() {
+    this.extraConfigs.update((configs) => [...configs, { target: '', content: '' }]);
+  }
+
+  removeExtraConfig(index: number) {
+    this.extraConfigs.update((configs) => configs.filter((_, i) => i !== index));
+  }
+
+  updateExtraConfigTarget(index: number, value: string) {
+    this.extraConfigs.update((configs) => configs.map((c, i) => (i === index ? { ...c, target: value } : c)));
+  }
+
+  updateExtraConfigContent(index: number, value: string) {
+    this.extraConfigs.update((configs) => configs.map((c, i) => (i === index ? { ...c, content: value } : c)));
   }
 
   addTag(event: MatChipInputEvent): void {

--- a/src/app/components/preferences/docker/docker-template-details/docker-template-details.component.ts
+++ b/src/app/components/preferences/docker/docker-template-details/docker-template-details.component.ts
@@ -241,6 +241,12 @@ export class DockerTemplateDetailsComponent implements OnInit {
       return;
     }
 
+    // Validate extra config files: content requires a target path
+    if (this.extraConfigs().some((c) => (!c.target || !c.target.trim()) && (c.content || '').trim())) {
+      this.toasterService.error('Extra files: file content requires a container target path');
+      return;
+    }
+
     // Update dockerTemplate from model signals
     this.dockerTemplate.name = this.name();
     this.dockerTemplate.default_name_format = this.defaultNameFormat();

--- a/src/app/components/preferences/docker/docker-template-details/docker-template-details.component.ts
+++ b/src/app/components/preferences/docker/docker-template-details/docker-template-details.component.ts
@@ -241,9 +241,10 @@ export class DockerTemplateDetailsComponent implements OnInit {
       return;
     }
 
-    // Validate extra config files: content requires a target path
-    if (this.extraConfigs().some((c) => (!c.target || !c.target.trim()) && (c.content || '').trim())) {
-      this.toasterService.error('Extra files: file content requires a container target path');
+    // Validate extra config files (target required with content, absolute path, no '..', unique)
+    const extraConfigsValidation = this.validationService.validateExtraConfigs(this.extraConfigs());
+    if (!extraConfigsValidation.isValid) {
+      this.toasterService.error(extraConfigsValidation.errorMessage);
       return;
     }
 
@@ -268,9 +269,11 @@ export class DockerTemplateDetailsComponent implements OnInit {
     this.dockerTemplate.environment = this.environment();
     this.dockerTemplate.extra_hosts = this.extraHosts();
     this.dockerTemplate.extra_volumes = this.extraVolumes() ? this.extraVolumes().split('\n').filter((v) => v.trim()) : [];
-    this.dockerTemplate.extra_configs = this.extraConfigs()
-      .filter((c) => c.target && c.target.trim())
+    const extraConfigs = this.extraConfigs()
+      .filter((c) => (c.target || '').trim())
       .map((c) => ({ target: c.target.trim(), content: c.content ?? '' }));
+    this.dockerTemplate.extra_configs = extraConfigs;
+    this.extraConfigs.set(extraConfigs); // drop blank rows so the editor matches what was saved
     this.dockerTemplate.usage = this.usage();
 
     this.dockerService.saveTemplate(this.controller, this.dockerTemplate).subscribe({

--- a/src/app/components/project-map/import-appliance/import-appliance.component.ts
+++ b/src/app/components/project-map/import-appliance/import-appliance.component.ts
@@ -158,7 +158,9 @@ export class ImportApplianceComponent implements OnInit {
         template.environment = appliance.docker.environment;
         template.extra_hosts = appliance.docker.extra_hosts;
         template.extra_volumes = appliance.docker.extra_volumes || [];
-        template.extra_configs = appliance.docker.extra_configs || [];
+        template.extra_configs = (appliance.docker.extra_configs || [])
+          .filter((c) => (c.target || '').trim())
+          .map((c) => ({ target: c.target.trim(), content: c.content ?? '' }));
         template.custom_adapters = appliance.custom_adapters || [];
         template.mac_address = appliance.docker.mac_address;
         template.cpus = appliance.docker.cpus;

--- a/src/app/components/project-map/import-appliance/import-appliance.component.ts
+++ b/src/app/components/project-map/import-appliance/import-appliance.component.ts
@@ -158,6 +158,7 @@ export class ImportApplianceComponent implements OnInit {
         template.environment = appliance.docker.environment;
         template.extra_hosts = appliance.docker.extra_hosts;
         template.extra_volumes = appliance.docker.extra_volumes || [];
+        template.extra_configs = appliance.docker.extra_configs || [];
         template.custom_adapters = appliance.custom_adapters || [];
         template.mac_address = appliance.docker.mac_address;
         template.cpus = appliance.docker.cpus;

--- a/src/app/components/project-map/new-template-dialog/new-template-dialog.component.ts
+++ b/src/app/components/project-map/new-template-dialog/new-template-dialog.component.ts
@@ -1015,7 +1015,9 @@ export class NewTemplateDialogComponent implements OnInit, AfterViewInit {
     dockerTemplate.environment = docker.environment;
     dockerTemplate.extra_hosts = docker.extra_hosts;
     dockerTemplate.extra_volumes = docker.extra_volumes || [];
-    dockerTemplate.extra_configs = docker.extra_configs || [];
+    dockerTemplate.extra_configs = (docker.extra_configs || [])
+      .filter((c) => (c.target || '').trim())
+      .map((c) => ({ target: c.target.trim(), content: c.content ?? '' }));
     dockerTemplate.custom_adapters = this.applianceToInstall.custom_adapters || [];
     dockerTemplate.mac_address = docker.mac_address;
     dockerTemplate.cpus = docker.cpus;

--- a/src/app/components/project-map/new-template-dialog/new-template-dialog.component.ts
+++ b/src/app/components/project-map/new-template-dialog/new-template-dialog.component.ts
@@ -1015,6 +1015,7 @@ export class NewTemplateDialogComponent implements OnInit, AfterViewInit {
     dockerTemplate.environment = docker.environment;
     dockerTemplate.extra_hosts = docker.extra_hosts;
     dockerTemplate.extra_volumes = docker.extra_volumes || [];
+    dockerTemplate.extra_configs = docker.extra_configs || [];
     dockerTemplate.custom_adapters = this.applianceToInstall.custom_adapters || [];
     dockerTemplate.mac_address = docker.mac_address;
     dockerTemplate.cpus = docker.cpus;

--- a/src/app/components/project-map/node-editors/configurator/docker/configurator-docker.component.html
+++ b/src/app/components/project-map/node-editors/configurator/docker/configurator-docker.component.html
@@ -143,6 +143,28 @@
             </div>
           </mat-tab>
 
+          <mat-tab label="Extra files">
+            <div class="form-container">
+              <h6>Configuration files</h6>
+              @for (config of extraConfigs(); track $index) {
+                <mat-form-field class="form-field">
+                  <mat-label>Container target path</mat-label>
+                  <input matInput type="text" [value]="config.target" (input)="updateExtraConfigTarget($index, $event.target.value)" placeholder="/first_boot.cfg" />
+                  <button matSuffix mat-icon-button type="button" (click)="removeExtraConfig($index)" aria-label="Remove configuration file">
+                    <mat-icon>delete</mat-icon>
+                  </button>
+                </mat-form-field>
+                <mat-form-field class="form-field">
+                  <mat-label>File content</mat-label>
+                  <textarea matInput rows="1" cdkTextareaAutosize cdkAutosizeMinRows="1" cdkAutosizeMaxRows="12" [value]="config.content || ''" (input)="updateExtraConfigContent($index, $event.target.value)" placeholder="File contents injected (read-only) into the container at the target path"></textarea>
+                </mat-form-field>
+              }
+              <button mat-stroked-button class="form-field" type="button" (click)="addExtraConfig()">
+                <mat-icon>add</mat-icon> Add configuration file
+              </button>
+            </div>
+          </mat-tab>
+
           <mat-tab label="Usage">
             <div class="form-container">
               <mat-form-field class="form-field">

--- a/src/app/components/project-map/node-editors/configurator/docker/configurator-docker.component.spec.ts
+++ b/src/app/components/project-map/node-editors/configurator/docker/configurator-docker.component.spec.ts
@@ -128,6 +128,7 @@ describe('ConfiguratorDialogDockerComponent', () => {
       validateCpus: vi.fn().mockReturnValue({ isValid: true }),
       validateConsoleHttpPath: vi.fn().mockReturnValue({ isValid: true }),
       validateEnvironment: vi.fn().mockReturnValue({ isValid: true }),
+      validateExtraConfigs: vi.fn().mockReturnValue({ isValid: true }),
     };
 
     mockNodeService = {
@@ -315,6 +316,7 @@ describe('ConfiguratorDialogDockerComponent', () => {
       mockDockerValidationService.validateCpus.mockReturnValue({ isValid: true });
       mockDockerValidationService.validateConsoleHttpPath.mockReturnValue({ isValid: true });
       mockDockerValidationService.validateEnvironment.mockReturnValue({ isValid: true });
+      mockDockerValidationService.validateExtraConfigs.mockReturnValue({ isValid: true });
     });
 
     it('should show error toast when name is empty', () => {

--- a/src/app/components/project-map/node-editors/configurator/docker/configurator-docker.component.ts
+++ b/src/app/components/project-map/node-editors/configurator/docker/configurator-docker.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, inject, model } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, inject, model, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { MatDialog, MatDialogRef, MatDialogModule } from '@angular/material/dialog';
@@ -15,6 +15,7 @@ import { CdkTextareaAutosize } from '@angular/cdk/text-field';
 import { COMMA, ENTER } from '@angular/cdk/keycodes';
 import { Node } from '../../../../../cartography/models/node';
 import { Controller } from '@models/controller';
+import { ExtraConfig } from '@models/templates/extra-config';
 import { DockerConfigurationService } from '@services/docker-configuration.service';
 import { NodeService } from '@services/node.service';
 import { ToasterService } from '@services/toaster.service';
@@ -95,6 +96,7 @@ export class ConfiguratorDialogDockerComponent implements OnInit {
   readonly environment = model('');
   readonly extraHosts = model('');
   readonly extraVolumes = model('');
+  readonly extraConfigs = signal<ExtraConfig[]>([]);
   readonly usage = model('');
 
   ngOnInit() {
@@ -121,6 +123,9 @@ export class ConfiguratorDialogDockerComponent implements OnInit {
         this.extraHosts.set(node.properties.extra_hosts || '');
         const volumes = node.properties.extra_volumes;
         this.extraVolumes.set(Array.isArray(volumes) ? volumes.join('\n') : (volumes || ''));
+        this.extraConfigs.set(
+          (node.properties.extra_configs || []).map((c) => ({ target: c.target || '', content: c.content ?? '' }))
+        );
         this.usage.set(node.properties.usage || '');
 
         this.getConfiguration();
@@ -171,6 +176,22 @@ export class ConfiguratorDialogDockerComponent implements OnInit {
     let instance = this.dialogRef.componentInstance;
     instance.controller = this.controller;
     instance.node = this.node;
+  }
+
+  addExtraConfig() {
+    this.extraConfigs.update((configs) => [...configs, { target: '', content: '' }]);
+  }
+
+  removeExtraConfig(index: number) {
+    this.extraConfigs.update((configs) => configs.filter((_, i) => i !== index));
+  }
+
+  updateExtraConfigTarget(index: number, value: string) {
+    this.extraConfigs.update((configs) => configs.map((c, i) => (i === index ? { ...c, target: value } : c)));
+  }
+
+  updateExtraConfigContent(index: number, value: string) {
+    this.extraConfigs.update((configs) => configs.map((c, i) => (i === index ? { ...c, content: value } : c)));
   }
 
   onSaveClick() {
@@ -246,6 +267,9 @@ export class ConfiguratorDialogDockerComponent implements OnInit {
     this.node.properties.environment = this.environment();
     this.node.properties.extra_hosts = this.extraHosts();
     this.node.properties.extra_volumes = this.extraVolumes() ? this.extraVolumes().split('\n').filter((v) => v.trim()) : [] as any;
+    this.node.properties.extra_configs = this.extraConfigs()
+      .filter((c) => c.target && c.target.trim())
+      .map((c) => ({ target: c.target.trim(), content: c.content ?? '' }));
     this.node.properties.usage = this.usage();
 
     this.nodeService.updateNode(this.controller, this.node).subscribe({

--- a/src/app/components/project-map/node-editors/configurator/docker/configurator-docker.component.ts
+++ b/src/app/components/project-map/node-editors/configurator/docker/configurator-docker.component.ts
@@ -250,9 +250,10 @@ export class ConfiguratorDialogDockerComponent implements OnInit {
       return;
     }
 
-    // Validate extra config files: content requires a target path
-    if (this.extraConfigs().some((c) => (!c.target || !c.target.trim()) && (c.content || '').trim())) {
-      this.toasterService.error('Extra files: file content requires a container target path');
+    // Validate extra config files (target required with content, absolute path, no '..', unique)
+    const extraConfigsValidation = this.validationService.validateExtraConfigs(this.extraConfigs());
+    if (!extraConfigsValidation.isValid) {
+      this.toasterService.error(extraConfigsValidation.errorMessage);
       return;
     }
 
@@ -273,9 +274,11 @@ export class ConfiguratorDialogDockerComponent implements OnInit {
     this.node.properties.environment = this.environment();
     this.node.properties.extra_hosts = this.extraHosts();
     this.node.properties.extra_volumes = this.extraVolumes() ? this.extraVolumes().split('\n').filter((v) => v.trim()) : [] as any;
-    this.node.properties.extra_configs = this.extraConfigs()
-      .filter((c) => c.target && c.target.trim())
+    const extraConfigs = this.extraConfigs()
+      .filter((c) => (c.target || '').trim())
       .map((c) => ({ target: c.target.trim(), content: c.content ?? '' }));
+    this.node.properties.extra_configs = extraConfigs;
+    this.extraConfigs.set(extraConfigs); // drop blank rows so the editor matches what was saved
     this.node.properties.usage = this.usage();
 
     this.nodeService.updateNode(this.controller, this.node).subscribe({

--- a/src/app/components/project-map/node-editors/configurator/docker/configurator-docker.component.ts
+++ b/src/app/components/project-map/node-editors/configurator/docker/configurator-docker.component.ts
@@ -250,6 +250,12 @@ export class ConfiguratorDialogDockerComponent implements OnInit {
       return;
     }
 
+    // Validate extra config files: content requires a target path
+    if (this.extraConfigs().some((c) => (!c.target || !c.target.trim()) && (c.content || '').trim())) {
+      this.toasterService.error('Extra files: file content requires a container target path');
+      return;
+    }
+
     // Merge signal values back into node
     this.node.name = this.nodeName();
     this.node.properties.image = this.dockerImage();

--- a/src/app/models/appliance.ts
+++ b/src/app/models/appliance.ts
@@ -1,4 +1,5 @@
 import { CustomAdapter } from './qemu/qemu-custom-adapter';
+import { ExtraConfig } from './templates/extra-config';
 
 export interface Image {
   compression?: string;
@@ -33,6 +34,7 @@ export interface Docker {
   environment?: string;
   extra_hosts?: string;
   extra_volumes?: string[];
+  extra_configs?: ExtraConfig[];
   mac_address?: string;
   cpus?: number;
   mem_limit?: number;

--- a/src/app/models/templates/docker-template.ts
+++ b/src/app/models/templates/docker-template.ts
@@ -1,4 +1,5 @@
 import { CustomAdapter } from '../qemu/qemu-custom-adapter';
+import { ExtraConfig } from './extra-config';
 
 export class DockerTemplate {
   adapters: number;
@@ -17,6 +18,7 @@ export class DockerTemplate {
   environment: string;
   extra_hosts: string;
   extra_volumes: string[];
+  extra_configs: ExtraConfig[];
   image: string;
   memory: number;
   cpus: number;

--- a/src/app/models/templates/extra-config.ts
+++ b/src/app/models/templates/extra-config.ts
@@ -1,0 +1,4 @@
+export interface ExtraConfig {
+  target: string;
+  content?: string;
+}

--- a/src/app/services/template-mocks.service.ts
+++ b/src/app/services/template-mocks.service.ts
@@ -257,6 +257,7 @@ export class TemplateMocksService {
       environment: '',
       extra_hosts: '',
       extra_volumes: [],
+      extra_configs: [],
       image: '',
       memory: 0,
       cpus: 0,

--- a/src/app/services/validation/nodes/docker-validation.service.spec.ts
+++ b/src/app/services/validation/nodes/docker-validation.service.spec.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { ValidationService } from '../base/validation.service';
+import { DockerValidationService } from './docker-validation.service';
+import { ExtraConfig } from '@models/templates/extra-config';
+
+describe('DockerValidationService', () => {
+  let service: DockerValidationService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    TestBed.configureTestingModule({
+      providers: [ValidationService, DockerValidationService],
+    });
+
+    service = TestBed.inject(DockerValidationService);
+  });
+
+  describe('validateExtraConfigs', () => {
+    it('should pass validation for an empty list', () => {
+      const result = service.validateExtraConfigs([]);
+
+      expect(result.isValid).toBe(true);
+      expect(result.errorMessage).toBeUndefined();
+    });
+
+    it('should pass validation for entirely blank rows', () => {
+      const result = service.validateExtraConfigs([{ target: '', content: '' }, { target: '   ', content: '' }]);
+
+      expect(result.isValid).toBe(true);
+      expect(result.errorMessage).toBeUndefined();
+    });
+
+    it('should pass validation for absolute targets', () => {
+      const configs: ExtraConfig[] = [
+        { target: '/firstboot.cfg', content: 'hostname xrd' },
+        { target: '/etc/frr/frr.conf', content: '' },
+      ];
+
+      const result = service.validateExtraConfigs(configs);
+
+      expect(result.isValid).toBe(true);
+      expect(result.errorMessage).toBeUndefined();
+    });
+
+    it('should fail validation for content without a target', () => {
+      const result = service.validateExtraConfigs([{ target: '/firstboot.cfg', content: 'ok' }, { target: '', content: 'hostname xrd' }]);
+
+      expect(result.isValid).toBe(false);
+      expect(result.errorMessage).toBe('Extra files, row 2: file content requires a container target path');
+    });
+
+    it('should fail validation for a relative target path', () => {
+      const result = service.validateExtraConfigs([{ target: 'etc/frr/frr.conf', content: 'frr config' }]);
+
+      expect(result.isValid).toBe(false);
+      expect(result.errorMessage).toBe('Extra files, row 1: target "etc/frr/frr.conf" must be an absolute path (e.g., /firstboot.cfg)');
+    });
+
+    it('should fail validation for a target containing ..', () => {
+      const result = service.validateExtraConfigs([{ target: '/a/../etc/passwd', content: '' }]);
+
+      expect(result.isValid).toBe(false);
+      expect(result.errorMessage).toBe("Extra files, row 1: target \"/a/../etc/passwd\" must not contain '..'");
+    });
+
+    it('should fail validation for duplicate targets', () => {
+      const configs: ExtraConfig[] = [
+        { target: '/etc/frr/frr.conf', content: 'first' },
+        { target: '/firstboot.cfg', content: 'other' },
+        { target: '/etc/frr/frr.conf', content: 'second' },
+      ];
+
+      const result = service.validateExtraConfigs(configs);
+
+      expect(result.isValid).toBe(false);
+      expect(result.errorMessage).toBe('Extra files, row 3: duplicate target path "/etc/frr/frr.conf"');
+    });
+
+    it('should pass validation for a target with empty content', () => {
+      const result = service.validateExtraConfigs([{ target: '/etc/nginx/nginx.conf', content: '' }]);
+
+      expect(result.isValid).toBe(true);
+      expect(result.errorMessage).toBeUndefined();
+    });
+  });
+});

--- a/src/app/services/validation/nodes/docker-validation.service.ts
+++ b/src/app/services/validation/nodes/docker-validation.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, inject } from '@angular/core';
 import { ValidationService, ValidationResult } from '../base/validation.service';
+import { ExtraConfig } from '@models/templates/extra-config';
 
 /**
  * Validation service for Docker nodes and templates
@@ -208,6 +209,59 @@ export class DockerValidationService {
           errorMessage: `${sectionLabel}, line ${i + 1}: Variable name "${key}" should be uppercase (e.g., ${key.toUpperCase()}=value)`,
         };
       }
+    }
+
+    return { isValid: true };
+  }
+
+  /**
+   * Validates extra config files
+   * Target must be a unique absolute container path without '..' segments;
+   * blank rows are ignored, but content without a target is rejected
+   * Optional field - an empty list passes validation
+   *
+   * Based on GNS3 server validation:
+   * - docker_vm.py: extra config target must be an absolute path
+   */
+  validateExtraConfigs(configs: ExtraConfig[]): ValidationResult {
+    const seenTargets = new Set<string>();
+
+    for (let i = 0; i < configs.length; i++) {
+      const target = (configs[i].target || '').trim();
+      const content = (configs[i].content || '').trim();
+      const row = i + 1;
+
+      if (!target) {
+        if (content) {
+          return {
+            isValid: false,
+            errorMessage: `Extra files, row ${row}: file content requires a container target path`,
+          };
+        }
+        continue; // entirely blank row, dropped on save
+      }
+
+      if (!target.startsWith('/')) {
+        return {
+          isValid: false,
+          errorMessage: `Extra files, row ${row}: target "${target}" must be an absolute path (e.g., /firstboot.cfg)`,
+        };
+      }
+
+      if (target.split('/').includes('..')) {
+        return {
+          isValid: false,
+          errorMessage: `Extra files, row ${row}: target "${target}" must not contain '..'`,
+        };
+      }
+
+      if (seenTargets.has(target)) {
+        return {
+          isValid: false,
+          errorMessage: `Extra files, row ${row}: duplicate target path "${target}"`,
+        };
+      }
+      seenTargets.add(target);
     }
 
     return { isValid: true };


### PR DESCRIPTION
## Summary

WebUI support for the new `extra_configs` field introduced by gns3-server PR #2854 (https://github.com/GNS3/gns3-server/pull/2854, `docker-shm-devices` branch, targeting 3.1), used by heavy/vendor NOS containers (Cisco XRd etc.). GNS3 writes each entry's `content` to a host file and bind-mounts it read-only at the container `target` path (startup-config injection, effective at creation time, compatible with init.sh / vendor skip_init).

Server-side issue: https://github.com/GNS3/gns3-server/issues/2678

## Changes

- **Models**: new `ExtraConfig { target, content? }` interface; `extra_configs` added to `DockerTemplate`, node `Properties`, and the appliance `Docker` interface (optional, default `[]`/`null`, matching the server schema)
- **Docker node configurator**: new "Extra files" tab (General → Advanced → Extra files → Usage) with repeatable target-path + file-content entries
- **Docker template editor**: matching collapsible "Extra files" section in the same order
- **Appliance import** (`import-appliance`, `new-template-dialog`): carry `extra_configs` from the `.gns3a` docker block, filtering blank-target entries so malformed appliance data cannot block unrelated saves later
- **Validation**: `DockerValidationService.validateExtraConfigs()` shared by both editors — target must be an absolute path without `..` segments and unique across entries; content without a target is rejected; error messages include the row number. This catches invalid targets client-side before the server's destructive update path (container reset happens before create validation on node PUT)
- **State sync**: blank rows are dropped from the editor on save so the UI matches the persisted payload
- **Specs**: unit tests for `validateExtraConfigs`, plus updated fixtures/mocks

## Notes

- `console_type: "docker_exec"` is already present in the Docker console dropdown — no change needed
- Environment-variable based features (`GNS3_SHM_SIZE`, `GNS3_DEVICES`, etc.) reuse the existing `environment` field — no UI change required

## Testing

- `yarn lint` / `yarn build` pass
- `yarn test`: 7119 passed, 0 failed (331 files), including 8 new validation cases