### PR TITLE
feat: template/node credentials, netmiko device type, console terminal size, dialog loading states, cartography fixes

### DIFF
--- a/src/app/cartography/cartography.module.ts
+++ b/src/app/cartography/cartography.module.ts
@@ -49,6 +49,7 @@ import { GraphDataManager } from './managers/graph-data-manager';
 import { LayersManager } from './managers/layers-manager';
 import { MapSettingsManager } from './managers/map-settings-manager';
 import { Context } from './models/context';
+import { GridAnchorService } from './services/grid-anchor.service';
 import { MapChangeDetectorRef } from './services/map-change-detector-ref';
 import { EthernetLinkWidget } from './widgets/links/ethernet-link';
 import { SerialLinkWidget } from './widgets/links/serial-link';
@@ -100,6 +101,7 @@ import { SerialLinkWidget } from './widgets/links/serial-link';
     MapSettingsManager,
     FontBBoxCalculator,
     StylesToFontConverter,
+    GridAnchorService,
     EthernetLinkWidget,
     SerialLinkWidget,
     ...D3_MAP_IMPORTS,

--- a/src/app/cartography/components/d3-map/d3-map.component.html
+++ b/src/app/cartography/components/d3-map/d3-map.component.html
@@ -1,35 +1,14 @@
-<svg id="map" #svg class="map" preserveAspectRatio="none" appMovingCanvas appZoomingCanvas>
+<svg id="map" #svg class="map" preserveAspectRatio="none" appMovingCanvas appZoomingCanvas [project]="project()">
+  <!-- Grid pattern geometry (x/y/width/height/path) is written imperatively by
+       GridAnchorService whenever the canvas transform or size changes, so the
+       grid stays anchored to the scene grid instead of the canvas size. -->
   @if (gridVisibility() > 0 && project()) {
     <defs>
-      <pattern
-        [attr.x]="drawingGridX"
-        [attr.y]="drawingGridY"
-        id="gridDrawing"
-        [attr.width]="project().drawing_grid_size"
-        [attr.height]="project().drawing_grid_size"
-        patternUnits="userSpaceOnUse"
-      >
-        <path
-          [attr.d]="'M ' + project().drawing_grid_size + ' 0 L 0 0 0 ' + project().drawing_grid_size"
-          fill="none"
-          [attr.stroke]="'var(--gns3-grid-drawing-color)'"
-          [attr.stroke-width]="1"
-        />
+      <pattern id="gridDrawing" patternUnits="userSpaceOnUse">
+        <path fill="none" stroke="var(--gns3-grid-drawing-color)" stroke-width="1" />
       </pattern>
-      <pattern
-        [attr.x]="nodeGridX"
-        [attr.y]="nodeGridY"
-        id="gridNode"
-        [attr.width]="project().grid_size"
-        [attr.height]="project().grid_size"
-        patternUnits="userSpaceOnUse"
-      >
-        <path
-          [attr.d]="'M ' + project().grid_size + ' 0 L 0 0 0 ' + project().grid_size"
-          fill="none"
-          [attr.stroke]="'var(--gns3-grid-node-color)'"
-          [attr.stroke-width]="1"
-        />
+      <pattern id="gridNode" patternUnits="userSpaceOnUse">
+        <path fill="none" stroke="var(--gns3-grid-node-color)" stroke-width="1" />
       </pattern>
     </defs>
 

--- a/src/app/cartography/components/d3-map/d3-map.component.ts
+++ b/src/app/cartography/components/d3-map/d3-map.component.ts
@@ -21,6 +21,7 @@ import { Project } from '@models/project';
 import { Controller } from '@models/controller';
 import { Symbol } from '@models/symbol';
 import { MapSettingsService } from '@services/mapsettings.service';
+import { MapScaleService } from '@services/mapScale.service';
 import { ToolsService } from '@services/tools.service';
 import { affectedIsEmpty, emptyAffectedIds, mergeAffected } from '../../helpers/item-signature';
 import { applyIncrementalPatches } from '../../helpers/dom-patcher';
@@ -33,6 +34,7 @@ import { Drawing } from '../../models/drawing';
 import { Node } from '../../models/node';
 import { Size } from '../../models/size';
 import { MapChangeDetectorRef } from '../../services/map-change-detector-ref';
+import { GridAnchorService } from '../../services/grid-anchor.service';
 import { MovingTool } from '../../tools/moving-tool';
 import { SelectionTool } from '../../tools/selection-tool';
 import { GraphLayout } from '../../widgets/graph-layout';
@@ -91,6 +93,10 @@ export class D3MapComponent implements OnInit, OnChanges, OnDestroy {
   // redraw per frame regardless of how many WS notifications / zoom events /
   // signal writes fire in between.
   private rafId: number | null = null;
+  // Pending requestAnimationFrame id for the coalesced scale-change apply
+  // (see the scaleChangeEmitter subscription) — wheel zoom emits one event per
+  // notch, and the apply is O(n) over all nodes, so at most one per frame.
+  private scaleRafId: number | null = null;
   // Whether the coalesced redraw may be gated. Only DATA-driven redraws (the
   // signal effect) are gated — zoom/resize/settings/tool switches always redraw,
   // so the gate can never skip a redraw the selection tool or canvas transform
@@ -100,11 +106,6 @@ export class D3MapComponent implements OnInit, OnChanges, OnDestroy {
     show_interface_labels: true,
   };
   public gridVisibility = signal(0);
-
-  public nodeGridX: number = 0;
-  public nodeGridY: number = 0;
-  public drawingGridX: number = 0;
-  public drawingGridY: number = 0;
 
   private graphDataManager = inject(GraphDataManager);
   private layersManager = inject(LayersManager);
@@ -118,7 +119,9 @@ export class D3MapComponent implements OnInit, OnChanges, OnDestroy {
   protected movingToolWidget = inject(MovingTool);
   public graphLayout = inject(GraphLayout);
   private toolsService = inject(ToolsService);
+  private mapScaleService = inject(MapScaleService);
   private mapSettingsService = inject(MapSettingsService);
+  private gridAnchor = inject(GridAnchorService);
 
   constructor() {
     this.parentNativeElement = this.element.nativeElement;
@@ -127,8 +130,15 @@ export class D3MapComponent implements OnInit, OnChanges, OnDestroy {
     effect(() => {
       const project = this.project();
       if (project && this.mapChangeDetectorRef.hasBeenDrawn) {
-        this.updateGrid();
         this.mapChangeDetectorRef.detectChanges();
+      }
+    });
+
+    // The grid patterns (re)enter the DOM via this template @if — every apply
+    // they missed since the last redraw must be replayed once they exist.
+    effect(() => {
+      if (this.gridVisibility() && this.mapChangeDetectorRef.hasBeenDrawn) {
+        this.applyGridAnchor();
       }
     });
 
@@ -206,17 +216,38 @@ export class D3MapComponent implements OnInit, OnChanges, OnDestroy {
     // project's nodes and leaks their content center into savedCenterX →
     // the first redraw anchors origin to the wrong content center.
 
-    // Initialize grid offsets based on project settings
-    const project = this.project();
-    if (project) {
-      this.updateGrid();
-    }
-
     this.onChangesDetected = this.mapChangeDetectorRef.changesDetected.subscribe(() => {
       if (this.mapChangeDetectorRef.hasBeenDrawn) {
         this.scheduleRedraw();
       }
     });
+
+    // Toolbar / keyboard zoom (zoomIn/zoomOut/resetZoom) only mutate
+    // context.transformation.k via MapScaleService and emit scaleChangeEmitter —
+    // nothing else applies the new scale (the old scaleChange→redraw
+    // subscription was removed when wheel zoom started applying the transform
+    // directly, which left the toolbar buttons dead). Apply it here WITHOUT a
+    // full redraw: rebuild the same transform graphLayout.draw would build and
+    // keep the SVG size getSize() would recompute, so both wheel zoom (already
+    // applied the transform itself — re-applying is idempotent) and toolbar
+    // zoom stay in sync.
+    //
+    // Wheel zoom emits one event per notch; the apply is an O(n) getSize +
+    // SVG resize + reflow, so coalesce to at most one per animation frame.
+    this.subscriptions.push(
+      this.mapScaleService.scaleChangeEmitter.subscribe(() => {
+        if (!this.mapChangeDetectorRef.hasBeenDrawn) {
+          return;
+        }
+        if (this.scaleRafId !== null) {
+          return;
+        }
+        this.scaleRafId = requestAnimationFrame(() => {
+          this.scaleRafId = null;
+          this.applyScaleChange();
+        });
+      })
+    );
 
     this.subscriptions.push(
       this.mapChangeDetectorRef.selectionChangesDetected.subscribe(() => {
@@ -300,6 +331,9 @@ export class D3MapComponent implements OnInit, OnChanges, OnDestroy {
         this.context.size = newSize;
         this.svg.attr('width', newSize.width).attr('height', newSize.height);
         this.graphLayout.draw(this.svg, this.context);
+        // Re-anchor the grid in the same frame — otherwise it sits at the old
+        // anchor until the PUT echo triggers the next redraw (visible jump).
+        this.applyGridAnchor();
         dragStartCenterX = null;
         dragStartCenterY = null;
       })
@@ -310,6 +344,10 @@ export class D3MapComponent implements OnInit, OnChanges, OnDestroy {
     if (this.rafId !== null) {
       cancelAnimationFrame(this.rafId);
       this.rafId = null;
+    }
+    if (this.scaleRafId !== null) {
+      cancelAnimationFrame(this.scaleRafId);
+      this.scaleRafId = null;
     }
     this.graphLayout.disconnect(this.svg);
     this.onChangesDetected.unsubscribe();
@@ -354,6 +392,10 @@ export class D3MapComponent implements OnInit, OnChanges, OnDestroy {
     this.context.transformation.k = 1;
     this.context.centerX = null;
     this.context.centerY = null;
+    // MapScaleService is equally app-singleton: sync its tracked scale with the
+    // fresh k=1 without emitting, or the first toolbar zoom click on the newly
+    // opened project would continue from the previous project's scale.
+    this.mapScaleService.resetScaleState();
     // LayersManager is an app-lifetime singleton — its layer buckets carry
     // over the previous project's nodes/links/drawings, which graphLayout.draw
     // would render as a ghost frame before the first data redraw clears them.
@@ -362,6 +404,33 @@ export class D3MapComponent implements OnInit, OnChanges, OnDestroy {
     this.graphLayout.connect(this.svg, this.context);
     this.graphLayout.draw(this.svg, this.context);
     this.mapChangeDetectorRef.hasBeenDrawn = true;
+  }
+
+  /**
+   * Apply a MapScaleService scale change to the canvas without a full redraw:
+   * recompute the canvas size (content bbox scales with k) and rebuild the
+   * g.canvas transform. Runs at most once per animation frame (coalesced in the
+   * scaleChangeEmitter subscription).
+   */
+  private applyScaleChange() {
+    // Keep the origin locked like redraw() does: getSize() recomputes
+    // centerX/Y from the scaled content bbox, which would shift the
+    // origin and make every visible element jump.
+    const savedCenterX = this.context.centerX;
+    const savedCenterY = this.context.centerY;
+    const newSize = this.getSize();
+    this.context.centerX = savedCenterX ?? this.context.centerX;
+    this.context.centerY = savedCenterY ?? this.context.centerY;
+    this.context.size = newSize;
+    this.svg.attr('width', newSize.width).attr('height', newSize.height);
+
+    // Canonical transform construction (same code graphLayout.draw uses).
+    this.svg
+      .selectAll<SVGGElement, Context>('g.canvas')
+      .data([this.context])
+      .attr('transform', this.graphLayout.canvasTransform(this.context));
+    // The tile scales with k — re-anchor the grid to the new transform.
+    this.applyGridAnchor();
   }
 
   public getSize(): Size {
@@ -428,8 +497,6 @@ export class D3MapComponent implements OnInit, OnChanges, OnDestroy {
   }
 
   private redraw(gated = false) {
-    this.updateGrid();
-
     if (gated) {
       // Data-driven redraw (signal effect): skip the expensive full draw
       // (graphDataManager conversion + D3 data-join + getBBox/getTotalLength
@@ -475,6 +542,11 @@ export class D3MapComponent implements OnInit, OnChanges, OnDestroy {
     this.context.centerX = savedCenterX ?? this.context.centerX;
     this.context.centerY = savedCenterY ?? this.context.centerY;
 
+    // Anchor the background grid to the (possibly new) scene origin/size.
+    // Runs after the origin lock and before the incremental-patch early
+    // return so position-only updates re-anchor the grid too.
+    this.applyGridAnchor();
+
     // For gated (data-driven) redraws try incremental DOM patches first.
     // When only node xY positions changed, targeted transform updates on the
     // affected g.node elements are enough — no D3 data-join, no getBBox /
@@ -493,23 +565,12 @@ export class D3MapComponent implements OnInit, OnChanges, OnDestroy {
     this.mapSettingsService.mapRenderedEmitter.emit(true);
   }
 
-  updateGrid() {
-    const project = this.project();
-    if (project.grid_size && project.grid_size > 0)
-      this.nodeGridX =
-        this.context.size.width / 2 - Math.floor(this.context.size.width / 2 / project.grid_size) * project.grid_size;
-    if (project.grid_size && project.grid_size > 0)
-      this.nodeGridY =
-        this.context.size.height / 2 - Math.floor(this.context.size.height / 2 / project.grid_size) * project.grid_size;
-
-    if (project.drawing_grid_size && project.drawing_grid_size > 0)
-      this.drawingGridX =
-        this.context.size.width / 2 -
-        Math.floor(this.context.size.width / 2 / project.drawing_grid_size) * project.drawing_grid_size;
-    if (project.drawing_grid_size && project.drawing_grid_size > 0)
-      this.drawingGridY =
-        this.context.size.height / 2 -
-        Math.floor(this.context.size.height / 2 / project.drawing_grid_size) * project.drawing_grid_size;
+  /** Re-anchor the background grid patterns to the current canvas transform. */
+  private applyGridAnchor() {
+    const svgNode = this.svg?.node();
+    if (svgNode) {
+      this.gridAnchor.apply(svgNode, this.context, this.project());
+    }
   }
 
   @HostListener('window:resize', ['$event'])

--- a/src/app/cartography/components/draggable-selection/draggable-selection.component.ts
+++ b/src/app/cartography/components/draggable-selection/draggable-selection.component.ts
@@ -100,6 +100,10 @@ export class DraggableSelectionComponent implements OnInit, OnDestroy {
         const lockedNodes = mapNodes.filter((item: MapNode) => item.locked);
         const selectedNodes = mapNodes.filter((item: MapNode) => !item.locked);
         selectedNodes.forEach((node: MapNode) => {
+          // While a node is dragged its live datum x/y deliberately diverge
+          // from the server — tell the graph data manager so a mid-drag WS
+          // batch doesn't reset the position under the pointer.
+          this.graphDataManager.markDragging(node.id);
           node.x += evt.dx;
           node.y += evt.dy;
 
@@ -122,6 +126,7 @@ export class DraggableSelectionComponent implements OnInit, OnDestroy {
         let mapDrawings = selected.filter((item) => item instanceof MapDrawing);
         const selectedDrawings = mapDrawings.filter((item: MapDrawing) => !item.locked);
         selectedDrawings.forEach((drawing: MapDrawing) => {
+          this.graphDataManager.markDragging(drawing.id);
           drawing.x += evt.dx;
           drawing.y += evt.dy;
           this.drawingsWidget.redrawDrawing(svg, drawing);
@@ -187,12 +192,16 @@ export class DraggableSelectionComponent implements OnInit, OnDestroy {
         const lockedNodes = mapNodes.filter((item: MapNode) => item.locked);
         const selectedNodes = mapNodes.filter((item: MapNode) => !item.locked);
         selectedNodes.forEach((item: MapNode) => {
+          // Drag over: the server echo of the PUT below carries the final
+          // position and must be allowed to correct the datum again.
+          this.graphDataManager.unmarkDragging(item.id);
           this.nodesEventSource.dragged.emit(new DraggedDataEvent<MapNode>(item, evt.dx, evt.dy));
         });
 
         let mapDrawings = selected.filter((item) => item instanceof MapDrawing);
         const selectedDrawings = mapDrawings.filter((item: MapDrawing) => !item.locked);
         selectedDrawings.forEach((item: MapDrawing) => {
+          this.graphDataManager.unmarkDragging(item.id);
           this.drawingsEventSource.dragged.emit(new DraggedDataEvent<MapDrawing>(item, evt.dx, evt.dy));
         });
 

--- a/src/app/cartography/directives/moving-canvas.directive.ts
+++ b/src/app/cartography/directives/moving-canvas.directive.ts
@@ -1,8 +1,10 @@
-import { Directive, ElementRef, HostListener, OnDestroy, OnInit } from '@angular/core';
+import { Directive, ElementRef, HostListener, Input, OnDestroy, OnInit } from '@angular/core';
 import { select } from 'd3-selection';
 import { Subscription } from 'rxjs';
+import { Project } from '@models/project';
 import { MovingEventSource } from '../events/moving-event-source';
 import { Context } from '../models/context';
+import { GridAnchorService } from '../services/grid-anchor.service';
 
 @Directive({
   standalone: true,
@@ -15,7 +17,15 @@ export class MovingCanvasDirective implements OnInit, OnDestroy {
   private activated: boolean = false;
   private isDragging: boolean = false;
 
-  constructor(private element: ElementRef, private movingEventSource: MovingEventSource, private context: Context) {}
+  constructor(
+    private element: ElementRef,
+    private movingEventSource: MovingEventSource,
+    private context: Context,
+    private gridAnchor: GridAnchorService
+  ) {}
+
+  /** Grid sizes — needed to keep the background grid anchored while panning. */
+  @Input('project') project: Project;
 
   ngOnInit() {
     this.movingModeState = this.movingEventSource.movingModeState.subscribe((event: boolean) => {
@@ -50,6 +60,10 @@ export class MovingCanvasDirective implements OnInit, OnDestroy {
 
           return `translate(${xTrans}, ${yTrans}) scale(${kTrans})`;
         });
+
+        // The grid patterns sit outside g.canvas — move their anchor with the
+        // pan so the background grid stays glued to the scene grid.
+        this.gridAnchor.apply(this.element.nativeElement, this.context, this.project);
       };
 
       this.mouseupListener = (event: MouseEvent) => {

--- a/src/app/cartography/directives/zooming-canvas.directive.ts
+++ b/src/app/cartography/directives/zooming-canvas.directive.ts
@@ -1,9 +1,11 @@
-import { Directive, ElementRef, OnDestroy, OnInit, Renderer2 } from '@angular/core';
+import { Directive, ElementRef, Input, OnDestroy, OnInit, Renderer2 } from '@angular/core';
 import { pointer, select } from 'd3-selection';
 import { Subscription } from 'rxjs';
 import { MapScaleService } from '@services/mapScale.service';
+import { Project } from '@models/project';
 import { MovingEventSource } from '../events/moving-event-source';
 import { Context } from '../models/context';
+import { GridAnchorService } from '../services/grid-anchor.service';
 
 @Directive({
   standalone: true,
@@ -18,8 +20,12 @@ export class ZoomingCanvasDirective implements OnInit, OnDestroy {
     private renderer: Renderer2,
     private movingEventSource: MovingEventSource,
     private context: Context,
-    private mapsScaleService: MapScaleService
+    private mapsScaleService: MapScaleService,
+    private gridAnchor: GridAnchorService
   ) {}
+
+  /** Grid sizes — needed to keep the background grid anchored while zooming. */
+  @Input('project') project: Project;
 
   ngOnInit() {
     // Disable default browser zoom via CSS for passive event listener support
@@ -55,7 +61,10 @@ export class ZoomingCanvasDirective implements OnInit, OnDestroy {
         // Proportional zoom: each wheel notch multiplies k by ~exp(∓0.1), so the
         // step feels uniform at every zoom level. (The old absolute −zoom/10
         // step made one notch a 50%+ jump when zoomed far out.)
-        const newK = Math.max(0.01, oldK * Math.exp(-zoom / 10));
+        const newK = Math.min(
+          MapScaleService.MAX_SCALE,
+          Math.max(MapScaleService.MIN_SCALE, oldK * Math.exp(-zoom / 10))
+        );
 
         // Cursor-centered zoom: keep the canvas point under the cursor fixed.
         // That canvas point is (svg cursor - origin - pan) / k.
@@ -79,6 +88,10 @@ export class ZoomingCanvasDirective implements OnInit, OnDestroy {
 
         return `translate(${xTrans}, ${yTrans}) scale(${newK})`;
       });
+
+      // The grid tile scales with k — re-anchor the background grid in the
+      // same event so it doesn't lag a frame behind the zoom.
+      this.gridAnchor.apply(this.element.nativeElement, this.context, this.project);
     };
 
     // Non-passive so preventDefault() can stop the page from scrolling while

--- a/src/app/cartography/helpers/dom-patcher.ts
+++ b/src/app/cartography/helpers/dom-patcher.ts
@@ -15,8 +15,8 @@ import { GraphDataManager } from '../managers/graph-data-manager';
 
 /**
  * Apply incremental DOM patches. Returns `true` if a FULL draw is still
- * required (structural changes, z/layer migration, link recompute, or any
- * non-xY/label update).
+ * required (structural changes, z/layer migration, link recompute, label
+ * updates, or any non-xY visual change).
  */
 export function applyIncrementalPatches(
   svg: d3.Selection<SVGSVGElement, unknown, null, unknown>,
@@ -45,7 +45,6 @@ export function applyIncrementalPatches(
 
   for (const [itemId, groups] of affected.updates) {
     const onlyXy = groups.length === 1 && groups[0] === 'xY';
-    const onlyLabel = groups.length === 1 && groups[0] === 'label';
 
     // Node: only xY → targeted transform (no reflow)
     // NOTE: z is intentionally NOT included here — z changes migrate the item
@@ -73,31 +72,12 @@ export function applyIncrementalPatches(
       }
     }
 
-    // Node: only label → targeted text update + getBBox (only that label)
-    if (onlyLabel) {
-      const node = nodesById.get(itemId);
-      if (node && node.label) {
-        const labelSel = svg.select(`g.node[node_id="${d3SelectEscape(itemId)}"]`).select('text.label');
-        if (!labelSel.empty()) {
-          const label = node.label as any;
-          labelSel.attr('style', label.style).text(label.text).attr('x', label.x).attr('y', label.y);
-          const bbox = (labelSel.node() as SVGTextElement | null)?.getBBox();
-          if (bbox) {
-            svg
-              .select(`g.node[node_id="${d3SelectEscape(itemId)}"]`)
-              .select('rect.label_selection')
-              .attr('x', bbox.x)
-              .attr('y', bbox.y)
-              .attr('width', bbox.width)
-              .attr('height', bbox.height);
-          }
-        }
-        continue;
-      }
-    }
-
-    // Anything else (z/layer change, link path recompute, multi-field, unknown)
-    // → full draw.
+    // Anything else (z/layer change, link path recompute, label update,
+    // multi-field, unknown) → full draw. Labels in particular MUST go through
+    // the full LabelWidget pipeline (cssFixer / fontFixer /
+    // removeInlineFillColor) — writing the raw server style string drops
+    // unitless font-size declarations and re-introduces inline fills that
+    // override the theme.
     needsFullDraw = true;
   }
 

--- a/src/app/cartography/managers/graph-data-manager.spec.ts
+++ b/src/app/cartography/managers/graph-data-manager.spec.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { GraphDataManager } from './graph-data-manager';
+
+/**
+ * Focused unit spec for GraphDataManager's incremental diff behaviour around
+ * drags and link removal. The drag fix is the important one: while a node or
+ * drawing is being dragged, its live datum x/y deliberately diverge from the
+ * server (the drag PUTs only at drag end), and a mid-drag WS batch carrying the
+ * pre-drag position used to reset the datum — the node teleported back under
+ * the pointer and the drag-end PUT persisted an offset position.
+ */
+
+// Minimal in-memory stand-ins for the map data sources: enough of the real
+// interface for the incremental setters (getItems/get/applyBatch).
+function createDataSource<T>() {
+  const items: T[] = [];
+  return {
+    items,
+    getItems: () => items,
+    get: (id: string) => items.find((i) => (i as any).id === id),
+    applyBatch: (additions: T[], removals: T[]) => {
+      for (const r of removals) {
+        const idx = items.indexOf(r);
+        if (idx >= 0) items.splice(idx, 1);
+      }
+      items.push(...additions);
+    },
+    set: (next: T[]) => {
+      items.length = 0;
+      items.push(...next);
+    },
+  };
+}
+
+describe('GraphDataManager', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let manager: GraphDataManager;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let nodesDataSource: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let linksDataSource: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let drawingsDataSource: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let symbolsDataSource: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let markerFlashService: any;
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const makeNode = (nodeId: string, x: number, y: number): any => ({
+    node_id: nodeId,
+    name: nodeId,
+    x,
+    y,
+    z: 1,
+    symbol: '',
+    symbol_url: '',
+    width: 60,
+    height: 60,
+    status: 'stopped',
+    locked: false,
+    node_type: 'qemu',
+    first_port_name: '',
+    port_name_format: '',
+    port_segment_size: 0,
+    label: null,
+    ports: null,
+  });
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const makeDrawing = (drawingId: string, x: number, y: number): any => ({
+    drawing_id: drawingId,
+    x,
+    y,
+    z: 1,
+    rotation: 0,
+    locked: false,
+    svg: '',
+  });
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const makeLink = (linkId: string): any => ({
+    link_id: linkId,
+    nodes: [],
+    capturing: false,
+    suspend: false,
+    show_filters_icon: false,
+    wireshark: false,
+    link_type: 'ethernet',
+    filters: null,
+    link_style: null,
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    nodesDataSource = createDataSource<any>();
+    linksDataSource = createDataSource<any>();
+    drawingsDataSource = createDataSource<any>();
+    symbolsDataSource = createDataSource<any>();
+    markerFlashService = { evictLink: vi.fn() };
+
+    manager = new GraphDataManager(
+      nodesDataSource,
+      linksDataSource,
+      drawingsDataSource,
+      symbolsDataSource,
+      // Passthrough converters: mirror the real ones' node_id → id mapping.
+      { convert: (n: any) => ({ id: n.node_id, ...n }) } as any,
+      {
+        convert: (l: any) => ({
+          id: l.link_id,
+          ...l,
+          nodes: (l.nodes || []).map((nd: any) => ({ ...nd, nodeId: nd.node_id })),
+        }),
+      } as any,
+      { convert: (d: any) => ({ id: d.drawing_id, ...d }) } as any,
+      { convert: (s: any) => ({ ...s }) } as any,
+      {
+        addNode: vi.fn(),
+        removeNode: vi.fn(),
+        moveNode: vi.fn(),
+        addLink: vi.fn(),
+        removeLink: vi.fn(),
+        moveLink: vi.fn(),
+        addDrawing: vi.fn(),
+        removeDrawing: vi.fn(),
+        moveDrawing: vi.fn(),
+        clear: vi.fn(),
+        setNodes: vi.fn(),
+        setLinks: vi.fn(),
+        setDrawings: vi.fn(),
+      } as any,
+      { assignDataToLinks: vi.fn() } as any,
+      markerFlashService
+    );
+  });
+
+  describe('drag awareness in setNodes', () => {
+    it('does not reset a dragged node live position on a mid-drag WS batch', () => {
+      manager.setNodes([makeNode('n1', 10, 10)]);
+      const datum = manager.getNodes()[0];
+      expect(datum.x).toBe(10);
+
+      // DraggableSelectionComponent mutates the datum while dragging.
+      manager.markDragging('n1');
+      datum.x += 25;
+
+      // Same server data arrives mid-drag (e.g. an unrelated peer change
+      // echoed in a node.updated batch) — position must NOT reset.
+      manager.setNodes([makeNode('n1', 10, 10)]);
+
+      expect(datum.x).toBe(35);
+    });
+
+    it('corrects drag drift once the drag ends (snap-back correction preserved)', () => {
+      manager.setNodes([makeNode('n1', 10, 10)]);
+      const datum = manager.getNodes()[0];
+      manager.markDragging('n1');
+      datum.x += 25;
+      manager.setNodes([makeNode('n1', 10, 10)]);
+      manager.unmarkDragging('n1');
+
+      // The drag-end PUT echo corrects the datum again after the gesture.
+      manager.setNodes([makeNode('n1', 10, 10)]);
+
+      expect(datum.x).toBe(10);
+    });
+
+    it('applies non-position updates to a dragged node while keeping live x/y', () => {
+      manager.setNodes([makeNode('n1', 10, 10)]);
+      const datum = manager.getNodes()[0];
+      manager.markDragging('n1');
+      datum.x += 25;
+
+      const renamed = makeNode('n1', 10, 10);
+      renamed.name = 'renamed';
+      manager.setNodes([renamed]);
+
+      expect(datum.name).toBe('renamed');
+      expect(datum.x).toBe(35); // live drag position preserved
+    });
+
+    it('lets an explicit server move win over an active drag', () => {
+      manager.setNodes([makeNode('n1', 10, 10)]);
+      const datum = manager.getNodes()[0];
+      manager.markDragging('n1');
+      datum.x += 25;
+
+      manager.setNodes([makeNode('n1', 500, 500)]); // server moved it (xY change)
+
+      expect(datum.x).toBe(500);
+    });
+  });
+
+  describe('drag awareness in setDrawings', () => {
+    it('does not reset a dragged drawing live position on a mid-drag WS batch', () => {
+      manager.setDrawings([makeDrawing('d1', 20, 20)]);
+      const datum = manager.getDrawings()[0];
+      manager.markDragging('d1');
+      datum.y += 40;
+
+      manager.setDrawings([makeDrawing('d1', 20, 20)]);
+
+      expect(datum.y).toBe(60);
+    });
+
+    it('corrects drawing drift once the drag ends', () => {
+      manager.setDrawings([makeDrawing('d1', 20, 20)]);
+      const datum = manager.getDrawings()[0];
+      manager.markDragging('d1');
+      datum.y += 40;
+      manager.setDrawings([makeDrawing('d1', 20, 20)]);
+      manager.unmarkDragging('d1');
+
+      manager.setDrawings([makeDrawing('d1', 20, 20)]);
+
+      expect(datum.y).toBe(20);
+    });
+  });
+
+  describe('link removal', () => {
+    it('evicts the flash geometry cache for links removed via data-diff replacement', () => {
+      // Regression: evictLink was only called from the WS link.deleted
+      // handler — links removed by data-diff (project reload, server restart,
+      // diff sync) leaked their geoCache entries in the app-singleton service.
+      manager.setLinks([makeLink('l1'), makeLink('l2')]);
+      expect(manager.getLinks().length).toBe(2);
+
+      manager.setLinks([makeLink('l2')]); // l1 disappears via diff, not WS
+
+      expect(markerFlashService.evictLink).toHaveBeenCalledWith('l1');
+      expect(markerFlashService.evictLink).not.toHaveBeenCalledWith('l2');
+    });
+  });
+});

--- a/src/app/cartography/managers/graph-data-manager.ts
+++ b/src/app/cartography/managers/graph-data-manager.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Link } from '@models/link';
+import { MarkerFlashService } from '@services/marker-flash.service';
 import { Symbol } from '@models/symbol';
 import { DrawingToMapDrawingConverter } from '../converters/map/drawing-to-map-drawing-converter';
 import { LinkToMapLinkConverter } from '../converters/map/link-to-map-link-converter';
@@ -43,6 +44,13 @@ export class GraphDataManager {
   // Maintained incrementally by setLinks and recomputed on first load.
   private nodeToLinks = new Map<string, Set<string>>();
 
+  // Ids of nodes/drawings with an ACTIVE drag gesture. DraggableSelectionComponent
+  // mutates the live datum x/y while dragging and PUTs only at drag end, so a
+  // mid-drag WS batch still carrying the pre-drag position must not reset the
+  // datum (the node would teleport back and the drag-end PUT would persist an
+  // offset position). Set by markDragging/unmarkDragging around the gesture.
+  private draggingIds = new Set<string>();
+
   constructor(
     private mapNodesDataSource: MapNodesDataSource,
     private mapLinksDataSource: MapLinksDataSource,
@@ -53,8 +61,21 @@ export class GraphDataManager {
     private drawingToMapDrawing: DrawingToMapDrawingConverter,
     private symbolToMapSymbol: SymbolToMapSymbolConverter,
     private layersManager: LayersManager,
-    private multiLinkCalculator: MultiLinkCalculatorHelper
+    private multiLinkCalculator: MultiLinkCalculatorHelper,
+    private markerFlashService: MarkerFlashService
   ) {}
+
+  public markDragging(id: string) {
+    this.draggingIds.add(id);
+  }
+
+  public unmarkDragging(id: string) {
+    this.draggingIds.delete(id);
+  }
+
+  private isDragging(id: string) {
+    return this.draggingIds.has(id);
+  }
 
   // ── Public read-access ────────────────────────────────────────
 
@@ -90,16 +111,53 @@ export class GraphDataManager {
       } else {
         const oldSigs = this.nodeSig.get(n.node_id);
         const changed = changedGroups(oldSigs?.groups, sigs.groups);
+        // Re-apply the server value even when the signature is unchanged: the
+        // live datum may have been mutated by a drag (DraggableSelectionComponent
+        // writes cursor positions into the MapNode while dragging), and a drag
+        // that snaps back onto the same signed position (small move +
+        // snap_to_grid) must still correct the datum — otherwise the drag-end
+        // redraw re-renders the cursor position and the node stays off-grid,
+        // diverging from the server.
+        //
+        // While a drag is ACTIVE the same position drift is the drag's own work,
+        // so a mid-drag WS batch carrying the pre-drag position must NOT reset
+        // the datum. Dragged items keep their live x/y (the drag-end echo
+        // corrects them); an explicit server move of the dragged item
+        // (changed.includes('xY')) still wins.
         if (changed.length > 0) {
+          const converted = this.nodeToMapNode.convert(n);
+          if (this.isDragging(n.node_id) && !changed.includes('xY')) {
+            const live = { x: existing.x, y: existing.y };
+            Object.assign(existing, converted);
+            Object.assign(existing, live);
+          } else {
+            Object.assign(existing, converted);
+          }
+          this.nodeSig.set(n.node_id, sigs);
+        } else if (!this.isDragging(n.node_id) && (existing.x !== n.x || existing.y !== n.y)) {
           const converted = this.nodeToMapNode.convert(n);
           Object.assign(existing, converted);
           this.nodeSig.set(n.node_id, sigs);
+        }
+        if (changed.length > 0) {
           affected.updates.set(n.node_id, changed);
           // Layer migration when z changes
           const oldZ = oldSigs?.groups.z;
           const newZ = sigs.groups.z;
           if (oldZ !== undefined && oldZ !== newZ) {
             this.layersManager.moveNode(existing, Number(oldZ));
+            // A node's z change also re-layers every link attached to it (a
+            // link's layer is min(source.z, target.z)); without this the full
+            // draw below renders those links from the stale layer bucket.
+            const linkSet = this.nodeToLinks.get(n.node_id);
+            if (linkSet) {
+              for (const lid of linkSet) {
+                const link = this.mapLinksDataSource.get(lid);
+                if (link) {
+                  this.layersManager.moveLink(link);
+                }
+              }
+            }
           }
           // A node position/size change bends every link connected to it.
           // Mark those links in affected so the dom-patcher falls through to
@@ -206,6 +264,12 @@ export class GraphDataManager {
           this.layersManager.removeLink(m);
         }
         this.linkSig.delete(id);
+        // The link is gone from the map — evict its flash geometry cache entry,
+        // which would otherwise live forever in the app-singleton service.
+        // (WS link.deleted evicts too, but removals arriving as data-diff
+        // replacements — project reload, server restart, diff sync — never go
+        // through the WS handler.)
+        this.markerFlashService.evictLink(id);
         const oldPair = oldLinkToNodes.get(id);
         if (oldPair) {
           this.unregisterLinkNodes(id, oldPair[0], oldPair[1]);
@@ -253,10 +317,25 @@ export class GraphDataManager {
       } else {
         const oldSigs = this.drawingSig.get(d.drawing_id);
         const changed = changedGroups(oldSigs?.groups, sigs.groups);
+        // Same drag-mutation correction as setNodes (see the comment there):
+        // re-apply the server value when the datum drifted, but keep the live
+        // x/y while the drawing is being dragged.
         if (changed.length > 0) {
+          const converted = this.drawingToMapDrawing.convert(d);
+          if (this.isDragging(d.drawing_id) && !changed.includes('xY')) {
+            const live = { x: existing.x, y: existing.y };
+            Object.assign(existing, converted);
+            Object.assign(existing, live);
+          } else {
+            Object.assign(existing, converted);
+          }
+          this.drawingSig.set(d.drawing_id, sigs);
+        } else if (!this.isDragging(d.drawing_id) && (existing.x !== d.x || existing.y !== d.y)) {
           const converted = this.drawingToMapDrawing.convert(d);
           Object.assign(existing, converted);
           this.drawingSig.set(d.drawing_id, sigs);
+        }
+        if (changed.length > 0) {
           affected.updates.set(d.drawing_id, changed);
           if (changed.includes('z')) {
             const oldZ = oldSigs?.groups.z;

--- a/src/app/cartography/managers/layers-manager.ts
+++ b/src/app/cartography/managers/layers-manager.ts
@@ -83,7 +83,9 @@ export class LayersManager {
     }
   }
 
-  public moveLink(link: MapLink, oldSourceZ: number, oldTargetZ: number): void {
+  public moveLink(link: MapLink): void {
+    // Re-bucket to the link's current layer (min(source.z, target.z)): remove
+    // from any layer, then re-add so addLink routes to the updated bucket.
     this.removeLink(link);
     this.addLink(link);
   }

--- a/src/app/cartography/models/node.ts
+++ b/src/app/cartography/models/node.ts
@@ -156,4 +156,10 @@ export class Node {
   y: number;
   z: number;
   aux_type?: string;
+  netmiko_device_type?: string | null;
+  template_id?: string;
+  // controller-only credentials (seeded from the template appliance metadata
+  // on creation, editable per node, not sent to the compute)
+  default_username?: string | null;
+  default_password?: string | null;
 }

--- a/src/app/cartography/services/grid-anchor.service.spec.ts
+++ b/src/app/cartography/services/grid-anchor.service.spec.ts
@@ -1,0 +1,131 @@
+import { select } from 'd3-selection';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { Context } from '../models/context';
+import { Size } from '../models/size';
+import { GridAnchorService } from './grid-anchor.service';
+
+/**
+ * The grid patterns live at the SVG root, outside the transformed g.canvas
+ * group, so their anchor must be derived from the canvas transform: tile =
+ * grid_size * k, origin ≡ scene origin (centerX/Y + pan, mod tile). The old
+ * size/2-based anchor jumped whenever a node drag resized the canvas — the
+ * "background grid wobbles when dragging" bug these tests pin down.
+ */
+describe('GridAnchorService', () => {
+  let service: GridAnchorService;
+  let context: Context;
+  let svg: SVGSVGElement;
+
+  beforeEach(() => {
+    service = new GridAnchorService();
+    context = new Context();
+    context.size = new Size(2000, 1000);
+    context.centerX = 700;
+    context.centerY = 400;
+    context.transformation.x = 0;
+    context.transformation.y = 0;
+    context.transformation.k = 1;
+
+    svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    const defs = select(svg).append('defs');
+    for (const id of ['gridNode', 'gridDrawing']) {
+      defs
+        .append('pattern')
+        .attr('id', id)
+        .attr('patternUnits', 'userSpaceOnUse')
+        .append('path')
+        .attr('fill', 'none');
+    }
+  });
+
+  const pattern = (id: string) => select(svg).select<SVGPatternElement>(`#${id}`);
+
+  it('anchors the tile to grid_size and the origin to the scene origin', () => {
+    service.apply(svg, context, { grid_size: 75, drawing_grid_size: 25 } as never);
+
+    // 700 mod 75 = 25, 400 mod 75 = 25
+    expect(pattern('gridNode').attr('width')).toBe('75');
+    expect(pattern('gridNode').attr('height')).toBe('75');
+    expect(pattern('gridNode').attr('x')).toBe('25');
+    expect(pattern('gridNode').attr('y')).toBe('25');
+    expect(pattern('gridNode').select('path').attr('d')).toBe('M 75 0 L 0 0 0 75');
+  });
+
+  it('anchors the drawing grid to its own drawing_grid_size', () => {
+    service.apply(svg, context, { grid_size: 75, drawing_grid_size: 25 } as never);
+
+    expect(pattern('gridDrawing').attr('width')).toBe('25');
+    // 700 mod 25 = 0
+    expect(pattern('gridDrawing').attr('x')).toBe('0');
+  });
+
+  it('scales the tile with the zoom factor', () => {
+    context.transformation.k = 2;
+
+    service.apply(svg, context, { grid_size: 75, drawing_grid_size: 25 } as never);
+
+    // tile 150; 700 mod 150 = 100
+    expect(pattern('gridNode').attr('width')).toBe('150');
+    expect(pattern('gridNode').attr('x')).toBe('100');
+  });
+
+  it('shifts the anchor by the pan', () => {
+    context.transformation.x = -30;
+    context.transformation.y = 5;
+
+    service.apply(svg, context, { grid_size: 75, drawing_grid_size: 25 } as never);
+
+    // (700 - 30) mod 75 = 70, (400 + 5) mod 75 = 30
+    expect(pattern('gridNode').attr('x')).toBe('70');
+    expect(pattern('gridNode').attr('y')).toBe('30');
+  });
+
+  it('normalizes negative origins to a positive pattern offset', () => {
+    context.centerX = 0;
+    context.centerY = 0;
+    context.transformation.x = -10;
+    context.transformation.y = -10;
+
+    service.apply(svg, context, { grid_size: 75, drawing_grid_size: 25 } as never);
+
+    expect(pattern('gridNode').attr('x')).toBe('65');
+    expect(pattern('gridNode').attr('y')).toBe('65');
+  });
+
+  it('falls back to size/2 when the origin is not anchored yet (centerX null)', () => {
+    context.centerX = null;
+    context.centerY = null;
+
+    service.apply(svg, context, { grid_size: 75, drawing_grid_size: 25 } as never);
+
+    // 2000/2 mod 75 = 25, 1000/2 mod 75 = 50
+    expect(pattern('gridNode').attr('x')).toBe('25');
+    expect(pattern('gridNode').attr('y')).toBe('50');
+  });
+
+  it('does not move the anchor when only the canvas size changes (the drag bug)', () => {
+    service.apply(svg, context, { grid_size: 75, drawing_grid_size: 25 } as never);
+    const before = pattern('gridNode').attr('x');
+
+    // What a node drag does: grow during the drag, full recalc on drag end.
+    context.size = new Size(4000, 2000);
+    service.apply(svg, context, { grid_size: 75, drawing_grid_size: 25 } as never);
+
+    expect(pattern('gridNode').attr('x')).toBe(before);
+  });
+
+  it('leaves the patterns untouched when grid sizes are missing or invalid', () => {
+    pattern('gridNode').attr('x', '999');
+
+    service.apply(svg, context, {} as never);
+    service.apply(svg, context, { grid_size: 0, drawing_grid_size: -5 } as never);
+
+    expect(pattern('gridNode').attr('x')).toBe('999');
+  });
+
+  it('is a no-op when the patterns are not in the DOM (grid hidden)', () => {
+    const empty = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+
+    expect(() => service.apply(empty, context, { grid_size: 75 } as never)).not.toThrow();
+  });
+});

--- a/src/app/cartography/services/grid-anchor.service.ts
+++ b/src/app/cartography/services/grid-anchor.service.ts
@@ -1,0 +1,51 @@
+import { Injectable } from '@angular/core';
+import { select } from 'd3-selection';
+import { Project } from '@models/project';
+import { Context } from '../models/context';
+
+/**
+ * Anchors the background grid patterns to the scene grid in screen space.
+ *
+ * The grid patterns (patternUnits="userSpaceOnUse") live at the SVG root,
+ * outside the transformed g.canvas group, so their tile size and origin must
+ * be derived from the canvas transform: the scene origin (0,0) sits at
+ * centerX/centerY + pan, and one grid cell measures grid_size * k screen
+ * pixels. Anchoring the pattern origin to (scene origin mod tile) makes the
+ * visible grid coincide with the coordinates snap-to-grid rounds to, and
+ * keeps it glued to the content through pans, zooms and canvas resizes.
+ *
+ * The old computation anchored the pattern to "canvas size / 2 mod grid_size".
+ * Node drags resize the canvas (grow while dragging, full recalc on drag
+ * end), so every drag recomputed a different anchor and the whole background
+ * grid jumped — the "grid wobbles when I drag a node" bug. It also ignored
+ * pan/zoom entirely, detaching the grid from the scene grid.
+ */
+@Injectable()
+export class GridAnchorService {
+  apply(svgElement: SVGSVGElement, context: Context, project: Project) {
+    this.anchor(svgElement, context, project?.grid_size, '#gridNode');
+    this.anchor(svgElement, context, project?.drawing_grid_size, '#gridDrawing');
+  }
+
+  private anchor(svgElement: SVGSVGElement, context: Context, gridSize: number | undefined, patternId: string) {
+    const pattern = select(svgElement).select<SVGPatternElement>(patternId);
+    if (pattern.empty() || !gridSize || gridSize <= 0) {
+      return;
+    }
+
+    const scale = context.transformation?.k || 1;
+    const tile = gridSize * scale;
+    const originX = context.getZeroZeroTransformationPoint().x + (context.transformation?.x || 0);
+    const originY = context.getZeroZeroTransformationPoint().y + (context.transformation?.y || 0);
+
+    // userSpaceOnUse patterns tile from their x/y; any point congruent to the
+    // scene origin (mod tile) draws the same grid, so normalize to keep the
+    // attribute values small.
+    pattern.attr('x', mod(originX, tile)).attr('y', mod(originY, tile)).attr('width', tile).attr('height', tile);
+    pattern.select('path').attr('d', `M ${tile} 0 L 0 0 0 ${tile}`);
+  }
+}
+
+function mod(value: number, m: number): number {
+  return ((value % m) + m) % m;
+}

--- a/src/app/cartography/widgets/graph-layout.ts
+++ b/src/app/cartography/widgets/graph-layout.ts
@@ -43,6 +43,18 @@ export class GraphLayout implements Widget {
     this.drawingLineTool.connect(view, context);
   }
 
+  /**
+   * Canonical canvas transform: origin anchor + user pan + scale. Everything
+   * that (re)applies the g.canvas transform must go through here so pan/zoom
+   * semantics stay in one place (d3-map's scale-change handler calls it too).
+   */
+  public canvasTransform(ctx: Context): string {
+    const xTrans = ctx.getZeroZeroTransformationPoint().x + ctx.transformation.x;
+    const yTrans = ctx.getZeroZeroTransformationPoint().y + ctx.transformation.y;
+    const kTrans = ctx.transformation.k;
+    return `translate(${xTrans}, ${yTrans}) scale(${kTrans})`;
+  }
+
   draw(view: SVGSelection, context: Context) {
     view.attr('width', context.size.width).attr('height', context.size.height);
 
@@ -50,12 +62,7 @@ export class GraphLayout implements Widget {
 
     const canvasEnter = canvas.enter().append<SVGGElement>('g').attr('class', 'canvas');
 
-    canvas.merge(canvasEnter).attr('transform', (ctx: Context) => {
-      const xTrans = ctx.getZeroZeroTransformationPoint().x + ctx.transformation.x;
-      const yTrans = ctx.getZeroZeroTransformationPoint().y + ctx.transformation.y;
-      const kTrans = ctx.transformation.k;
-      return `translate(${xTrans}, ${yTrans}) scale(${kTrans})`;
-    });
+    canvas.merge(canvasEnter).attr('transform', (ctx: Context) => this.canvasTransform(ctx));
 
     this.layersWidget.draw(canvas, this.layersManager.getLayersList());
 

--- a/src/app/cartography/widgets/link.ts
+++ b/src/app/cartography/widgets/link.ts
@@ -6,6 +6,7 @@ import { Subscription } from 'rxjs';
 import { LinkContextMenu } from '../events/event-source';
 import { LinksEventSource } from '../events/links-event-source';
 import { MultiLinkCalculatorHelper } from '../helpers/multi-link-calculator-helper';
+import { MarkerFlashService } from '@services/marker-flash.service';
 import { SelectionManager } from '../managers/selection-manager';
 import { MapLink } from '../models/map/map-link';
 import { MapLinksDataSource } from '../datasources/map-datasource';
@@ -30,7 +31,8 @@ export class LinkWidget implements Widget, OnDestroy {
     private ethernetLinkWidget: EthernetLinkWidget,
     private serialLinkWidget: SerialLinkWidget,
     private linksEventSource: LinksEventSource,
-    private mapLinksDataSource: MapLinksDataSource
+    private mapLinksDataSource: MapLinksDataSource,
+    private markerFlashService: MarkerFlashService
   ) {
     this.subscription = this.mapLinksDataSource.itemChanged.subscribe((mapLink: MapLink) => {
       this.updateFilterIconsVisibility(mapLink);
@@ -61,6 +63,13 @@ export class LinkWidget implements Widget, OnDestroy {
       const translation = this.multiLinkCalculatorHelper.linkTranslation(link.distance, link.source, link.target);
       return `translate (${translation.dx}, ${translation.dy})`;
     });
+
+    // Direction arrows are positioned in path-local coordinates, so after a
+    // redraw (e.g. an endpoint node dragged) their cached positions are stale.
+    // Remove them, then re-render for links with an ACTIVE flash — the flash
+    // state diff only re-renders on state changes, so without this a redraw
+    // mid-flash strips the arrows until the state changes or expires.
+    link_body.selectAll('g.marker-arrow-tx, g.marker-arrow-rx').remove();
 
     link_body.select('.capture-icon').remove();
     link_body
@@ -190,6 +199,10 @@ export class LinkWidget implements Widget, OnDestroy {
 
     this.serialLinkWidget.draw(link_body_merge);
     this.ethernetLinkWidget.draw(link_body_merge);
+
+    // The paths are drawn now — re-render flash arrows (removed above) along
+    // the new geometry for links that are currently flashing.
+    link_body_merge.each((l: MapLink) => this.markerFlashService.redrawArrows(l.id));
 
     link_body_merge
       .select<SVGPathElement>('path')

--- a/src/app/components/netmiko-device-type-select/netmiko-device-type-select.component.html
+++ b/src/app/components/netmiko-device-type-select/netmiko-device-type-select.component.html
@@ -1,0 +1,40 @@
+<mat-form-field [appearance]="appearance()" class="netmiko-device-type-select__field">
+  <mat-label>Netmiko device type</mat-label>
+  @if (hasList()) {
+    <input
+      matInput
+      type="text"
+      [value]="value()"
+      (input)="onInput($event)"
+      (focus)="load()"
+      placeholder="Search device type…"
+      [matAutocomplete]="deviceTypeAuto"
+    />
+    @if (notInList()) {
+      <span matSuffix class="netmiko-device-type-select__not-in-list">not in list</span>
+    }
+    <mat-autocomplete #deviceTypeAuto="matAutocomplete" (optionSelected)="onOptionSelected($event.option.value)">
+      @for (group of groups(); track group.vendor) {
+        <mat-optgroup [label]="group.vendor">
+          @for (type of group.types; track type.name) {
+            <mat-option [value]="type.name">
+              {{ type.name }}
+              @if (type.telnet) {
+                <span class="netmiko-device-type-select__telnet">telnet</span>
+              }
+            </mat-option>
+          }
+        </mat-optgroup>
+      }
+    </mat-autocomplete>
+  } @else {
+    <input
+      matInput
+      type="text"
+      [value]="value()"
+      (input)="onInput($event)"
+      (focus)="load()"
+      placeholder="e.g. cisco_xr, nokia_srl"
+    />
+  }
+</mat-form-field>

--- a/src/app/components/netmiko-device-type-select/netmiko-device-type-select.component.scss
+++ b/src/app/components/netmiko-device-type-select/netmiko-device-type-select.component.scss
@@ -1,0 +1,23 @@
+:host {
+  display: block;
+}
+
+.netmiko-device-type-select__field {
+  width: 100%;
+}
+
+.netmiko-device-type-select__telnet {
+  margin-left: 8px;
+  font-size: 11px;
+  line-height: 16px;
+  color: var(--mat-sys-on-surface-variant);
+  border: 1px solid var(--mat-sys-outline-variant);
+  border-radius: 4px;
+  padding: 0 4px;
+}
+
+.netmiko-device-type-select__not-in-list {
+  font-size: 11px;
+  color: var(--mat-sys-on-surface-variant);
+  white-space: nowrap;
+}

--- a/src/app/components/netmiko-device-type-select/netmiko-device-type-select.component.spec.ts
+++ b/src/app/components/netmiko-device-type-select/netmiko-device-type-select.component.spec.ts
@@ -1,0 +1,85 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { Controller } from '@models/controller';
+import { NetmikoDeviceType } from '@models/netmiko-device-type';
+import { NetmikoDeviceTypesService } from '@services/netmiko-device-types.service';
+import { NetmikoDeviceTypeSelectComponent } from './netmiko-device-type-select.component';
+
+const DEVICE_TYPES: NetmikoDeviceType[] = [
+  { name: 'cisco_ios', telnet: false, custom: false },
+  { name: 'cisco_ios_telnet', telnet: true, custom: false },
+  { name: 'huawei_vrp', telnet: false, custom: false },
+  { name: 'gns3_vpcs_telnet', telnet: true, custom: true },
+];
+
+/** The input gets aria-autocomplete="list" only when the matAutocomplete trigger is attached. */
+const hasDropdown = (fixture: ComponentFixture<NetmikoDeviceTypeSelectComponent>) =>
+  (fixture.nativeElement.querySelector('input') as HTMLInputElement).getAttribute('aria-autocomplete') === 'list';
+
+describe('NetmikoDeviceTypeSelectComponent', () => {
+  let fixture: ComponentFixture<NetmikoDeviceTypeSelectComponent>;
+  let component: NetmikoDeviceTypeSelectComponent;
+  let getDeviceTypes: ReturnType<typeof vi.fn>;
+
+  beforeEach(async () => {
+    getDeviceTypes = vi.fn().mockReturnValue(of({ deviceTypes: DEVICE_TYPES, netmikoVersion: '4.7.0' }));
+    TestBed.configureTestingModule({
+      imports: [NetmikoDeviceTypeSelectComponent],
+      providers: [{ provide: NetmikoDeviceTypesService, useValue: { getDeviceTypes } }],
+    }).compileComponents();
+    fixture = TestBed.createComponent(NetmikoDeviceTypeSelectComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('controller', { id: 1 } as Controller);
+    fixture.detectChanges();
+  });
+
+  it('loads the list when a controller is set and renders a dropdown input', () => {
+    expect(getDeviceTypes).toHaveBeenCalledWith({ id: 1 });
+    expect(hasDropdown(fixture)).toBe(true);
+  });
+
+  it('renders a plain free-text input (no dropdown) when the list is unavailable', () => {
+    getDeviceTypes.mockReturnValue(of({ deviceTypes: null, netmikoVersion: null }));
+    component['state'].set('idle');
+    component['deviceTypes'].set(null);
+    component.load();
+    fixture.detectChanges();
+
+    expect(hasDropdown(fixture)).toBe(false);
+  });
+
+  it('groups the device types by vendor prefix', () => {
+    expect(component.groups().map((g) => g.vendor)).toEqual(['cisco', 'gns3', 'huawei']);
+    expect(component.groups()[0].types.map((t) => t.name)).toEqual(['cisco_ios', 'cisco_ios_telnet']);
+  });
+
+  it('filters groups by the typed text', () => {
+    component.value.set('cisco_ios_telnet');
+
+    const names = component.groups().flatMap((g) => g.types.map((t) => t.name));
+    expect(names).toEqual(['cisco_ios_telnet']);
+  });
+
+  it('writes free-typed input through to the model (out-of-list values are legal)', () => {
+    component.onInput({ target: { value: 'my_custom_driver' } } as never);
+
+    expect(component.value()).toBe('my_custom_driver');
+    expect(component.notInList()).toBe(true);
+  });
+
+  it('applies a picked option to the model', () => {
+    component.onOptionSelected('huawei_vrp');
+
+    expect(component.value()).toBe('huawei_vrp');
+    expect(component.notInList()).toBe(false);
+  });
+
+  it('marks a pre-filled value that is not in the list', () => {
+    fixture.componentRef.setInput('value', 'legacy_type');
+    fixture.detectChanges();
+
+    expect(component.value()).toBe('legacy_type');
+    expect(component.notInList()).toBe(true);
+  });
+});

--- a/src/app/components/netmiko-device-type-select/netmiko-device-type-select.component.ts
+++ b/src/app/components/netmiko-device-type-select/netmiko-device-type-select.component.ts
@@ -1,0 +1,101 @@
+import { ChangeDetectionStrategy, Component, computed, effect, inject, input, model, signal } from '@angular/core';
+import { MatAutocompleteModule } from '@angular/material/autocomplete';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { Controller } from '@models/controller';
+import { NetmikoDeviceType } from '@models/netmiko-device-type';
+import { NetmikoDeviceTypesService } from '@services/netmiko-device-types.service';
+
+interface DeviceTypeGroup {
+  vendor: string;
+  types: NetmikoDeviceType[];
+}
+
+/**
+ * Netmiko device type input for template and node editors: a free-text
+ * field that becomes a searchable, vendor-grouped dropdown when the server
+ * exposes the device type list. Typing always writes through — values
+ * outside the list are legal and saved as-is; with a list loaded, such a
+ * value is marked "not in list" but never blocked.
+ */
+@Component({
+  selector: 'app-netmiko-device-type-select',
+  standalone: true,
+  imports: [MatAutocompleteModule, MatFormFieldModule, MatInputModule],
+  templateUrl: './netmiko-device-type-select.component.html',
+  styleUrl: './netmiko-device-type-select.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class NetmikoDeviceTypeSelectComponent {
+  readonly value = model('');
+  /** The server to query; the editors all hold the current controller. */
+  readonly controller = input<Controller>(undefined);
+  /** 'fill' on the preferences pages, default (outline) in the node configurator dialogs. */
+  readonly appearance = input<'fill' | 'outline'>('outline');
+
+  private readonly netmikoDeviceTypesService = inject(NetmikoDeviceTypesService);
+
+  private readonly state = signal<'idle' | 'loading' | 'ready' | 'unavailable'>('idle');
+  private readonly deviceTypes = signal<NetmikoDeviceType[] | null>(null);
+
+  readonly hasList = computed(() => this.state() === 'ready');
+
+  /** Vendor-grouped (name.split('_')[0]) list, filtered by the typed text. */
+  readonly groups = computed<DeviceTypeGroup[]>(() => {
+    const types = this.deviceTypes() ?? [];
+    const term = this.value().trim().toLowerCase();
+    const filtered = term ? types.filter((type) => type.name.toLowerCase().includes(term)) : types;
+
+    const byVendor = new Map<string, NetmikoDeviceType[]>();
+    for (const type of filtered) {
+      const vendor = type.name.split('_')[0];
+      const bucket = byVendor.get(vendor);
+      if (bucket) {
+        bucket.push(type);
+      } else {
+        byVendor.set(vendor, [type]);
+      }
+    }
+    return [...byVendor.entries()].sort(([a], [b]) => a.localeCompare(b)).map(([vendor, list]) => ({ vendor, types: list }));
+  });
+
+  /** Current value is set but not among the server's types (historic/manual data). */
+  readonly notInList = computed(() => {
+    const types = this.deviceTypes();
+    const value = this.value().trim();
+    if (!types || !value) return false;
+    return !types.some((type) => type.name === value);
+  });
+
+  constructor() {
+    effect(() => {
+      if (this.controller() && this.state() === 'idle') {
+        this.load();
+      }
+    });
+  }
+
+  /** Fetch once per controller (service caches); also retried on focus while idle. */
+  load() {
+    const controller = this.controller();
+    if (!controller || this.state() !== 'idle') return;
+
+    this.state.set('loading');
+    this.netmikoDeviceTypesService.getDeviceTypes(controller).subscribe((result) => {
+      if (result.deviceTypes) {
+        this.deviceTypes.set(result.deviceTypes);
+        this.state.set('ready');
+      } else {
+        this.state.set('unavailable');
+      }
+    });
+  }
+
+  onInput(event: Event) {
+    this.value.set((event.target as HTMLInputElement).value);
+  }
+
+  onOptionSelected(value: string) {
+    this.value.set(value);
+  }
+}

--- a/src/app/components/preferences/docker/add-docker-template/add-docker-template.component.html
+++ b/src/app/components/preferences/docker/add-docker-template/add-docker-template.component.html
@@ -293,6 +293,29 @@
             </section>
           </div>
         </mat-step>
+        <mat-step [optional]="true">
+          <ng-template matStepLabel>
+            <span class="template-wizard__step-label">
+              <mat-icon>settings_ethernet</mat-icon>
+              <span class="template-wizard__step-label-text">
+                <span class="template-wizard__step-label-title">Netmiko device type</span>
+                <span class="template-wizard__step-label-description">Optional device type</span>
+              </span>
+            </span>
+          </ng-template>
+          <div class="docker-add__step-content template-wizard__panel">
+            <section class="template-wizard__section">
+              <h2 class="template-wizard__section-title">Netmiko device type</h2>
+              <p class="template-wizard__section-copy">Default device type used for netmiko-driven configuration pushes.</p>
+              <app-netmiko-device-type-select
+                [(value)]="netmikoDeviceType"
+                [controller]="controller"
+                appearance="fill"
+                class="docker-add__field"
+              />
+            </section>
+          </div>
+        </mat-step>
       </mat-horizontal-stepper>
     </section>
 
@@ -304,7 +327,7 @@
           <mat-icon>arrow_back</mat-icon>
           Back
         </button>
-        } @if (selectedStepIndex() < 7) {
+        } @if (selectedStepIndex() < 8) {
         <button
           mat-raised-button
           color="primary"

--- a/src/app/components/preferences/docker/add-docker-template/add-docker-template.component.spec.ts
+++ b/src/app/components/preferences/docker/add-docker-template/add-docker-template.component.spec.ts
@@ -6,6 +6,7 @@ import { DockerService } from '@services/docker.service';
 import { ControllerService } from '@services/controller.service';
 import { TemplateMocksService } from '@services/template-mocks.service';
 import { ToasterService } from '@services/toaster.service';
+import { NetmikoDeviceTypesService } from '@services/netmiko-device-types.service';
 import { DockerConfigurationService } from '@services/docker-configuration.service';
 import { DockerImage } from '@models/docker/docker-image';
 import { DockerTemplate } from '@models/templates/docker-template';
@@ -127,6 +128,7 @@ describe('AddDockerTemplateComponent', () => {
         { provide: DockerService, useValue: mockDockerService },
         { provide: TemplateMocksService, useValue: mockTemplateMocksService },
         { provide: ToasterService, useValue: mockToasterService },
+        { provide: NetmikoDeviceTypesService, useValue: { getDeviceTypes: vi.fn().mockReturnValue(of({ deviceTypes: null, netmikoVersion: null })) } },
         { provide: DockerConfigurationService, useValue: mockConfigurationService },
       ],
     }).compileComponents();

--- a/src/app/components/preferences/docker/add-docker-template/add-docker-template.component.ts
+++ b/src/app/components/preferences/docker/add-docker-template/add-docker-template.component.ts
@@ -11,12 +11,14 @@ import { CdkTextareaAutosize } from '@angular/cdk/text-field';
 import { v4 as uuid } from 'uuid';
 import { DockerImage } from '@models/docker/docker-image';
 import { Controller } from '@models/controller';
+import { NetmikoDeviceTypeSelectComponent } from '@components/netmiko-device-type-select/netmiko-device-type-select.component';
 import { DockerTemplate } from '@models/templates/docker-template';
 import { DockerConfigurationService } from '@services/docker-configuration.service';
 import { DockerService } from '@services/docker.service';
 import { ControllerService } from '@services/controller.service';
 import { TemplateMocksService } from '@services/template-mocks.service';
 import { ToasterService } from '@services/toaster.service';
+import { ValidationService } from '@services/validation';
 import { TemplateInfoFieldsComponent } from '../../common/template-info-fields/template-info-fields.component';
 
 @Component({
@@ -26,6 +28,7 @@ import { TemplateInfoFieldsComponent } from '../../common/template-info-fields/t
   templateUrl: './add-docker-template.component.html',
   styleUrls: ['./add-docker-template.component.scss', '../../preferences.component.scss'],
   imports: [
+    NetmikoDeviceTypeSelectComponent,
     MatIconModule,
     MatButtonModule,
     MatRadioModule,
@@ -45,6 +48,7 @@ export class AddDockerTemplateComponent implements OnInit {
   private router = inject(Router);
   private templateMocksService = inject(TemplateMocksService);
   private configurationService = inject(DockerConfigurationService);
+  private validationService = inject(ValidationService);
   private cd = inject(ChangeDetectorRef);
 
   controller?: Controller;
@@ -65,6 +69,7 @@ export class AddDockerTemplateComponent implements OnInit {
   consoleType = model('');
   auxConsoleType = model('');
   environment = model('');
+  netmikoDeviceType = model('');
   usage = model('');
   symbol = model('docker_guest');
 
@@ -159,6 +164,12 @@ export class AddDockerTemplateComponent implements OnInit {
       return;
     }
 
+    const netmikoValidation = this.validationService.validateNetmikoDeviceType(this.netmikoDeviceType());
+    if (!netmikoValidation.isValid) {
+      this.toasterService.error(netmikoValidation.errorMessage);
+      return;
+    }
+
     template.template_id = uuid();
     template.image = this.newImageSelected ? this.filename() : selectedImage.image;
     template.name = this.templateName();
@@ -168,6 +179,7 @@ export class AddDockerTemplateComponent implements OnInit {
     template.console_type = this.consoleType() || 'none';
     template.aux_type = this.auxConsoleType() || 'none';
     template.environment = this.environment();
+    template.netmiko_device_type = this.netmikoDeviceType().trim() || null;
     template.usage = this.usage();
     template.symbol = this.symbol();
 

--- a/src/app/components/preferences/docker/docker-template-details/docker-template-details.component.html
+++ b/src/app/components/preferences/docker/docker-template-details/docker-template-details.component.html
@@ -25,6 +25,7 @@
         Extra files
       </button>
       <button type="button" [class.is-active]="activeSection === 'usage'" (click)="selectSection('usage')">Usage</button>
+      <button type="button" [class.is-active]="activeSection === 'metadata'" (click)="selectSection('metadata')">Metadata</button>
     </nav>
     <section class="docker-details__form-card">
       <div class="docker-details__section-header" (click)="toggleSection('general')">
@@ -371,7 +372,12 @@
     </section>
 
     <section class="docker-details__form-card">
+      <div class="docker-details__section-header">
+        <h3 class="docker-details__section-title">Appliance metadata</h3>
+      </div>
+      @if (activeSection === 'metadata') {
       <app-template-metadata-section [(metadata)]="applianceMetadata" />
+      }
     </section>
     <div class="docker-details__actions">
       <button class="docker-details__cancel-btn" (click)="goBack()" mat-button>Cancel</button>

--- a/src/app/components/preferences/docker/docker-template-details/docker-template-details.component.html
+++ b/src/app/components/preferences/docker/docker-template-details/docker-template-details.component.html
@@ -222,13 +222,36 @@
               placeholder="HTTP path"
             />
           </mat-form-field>
-          <mat-checkbox
-            [checked]="consoleAutoStart()"
-            (change)="consoleAutoStart.set($event.checked)"
-            class="grid-span-2"
-          >
-            Auto start console
-          </mat-checkbox>
+          <div class="three-column-grid grid-span-2">
+            <app-netmiko-device-type-select
+              [(value)]="netmikoDeviceType"
+              [controller]="controller"
+              appearance="fill"
+              class="form-field"
+            />
+            <mat-form-field class="form-field">
+              <mat-label>Default username</mat-label>
+              <input
+                matInput
+                [value]="defaultUsername()"
+                (input)="onCredentialInput('default_username', $event)"
+                type="text"
+                placeholder="Username to log into this node"
+              />
+            </mat-form-field>
+            <mat-form-field class="form-field">
+              <mat-label>Default password</mat-label>
+              <input
+                matInput
+                [value]="defaultPassword()"
+                (input)="onCredentialInput('default_password', $event)"
+                type="text"
+                placeholder="Password to log into this node"
+              />
+            </mat-form-field>
+          </div>
+
+          <mat-checkbox [checked]="consoleAutoStart()" (change)="consoleAutoStart.set($event.checked)" class="grid-span-2"> Auto start console </mat-checkbox>
         </div>
         <button mat-button class="form-field docker-details__config-btn" (click)="editCustomAdapters()">
           Configure custom adapters
@@ -347,6 +370,9 @@
       }
     </section>
 
+    <section class="docker-details__form-card">
+      <app-template-metadata-section [(metadata)]="applianceMetadata" />
+    </section>
     <div class="docker-details__actions">
       <button class="docker-details__cancel-btn" (click)="goBack()" mat-button>Cancel</button>
       <button mat-raised-button color="primary" class="docker-details__save-btn" (click)="onSave()">Save</button>

--- a/src/app/components/preferences/docker/docker-template-details/docker-template-details.component.scss
+++ b/src/app/components/preferences/docker/docker-template-details/docker-template-details.component.scss
@@ -116,6 +116,13 @@
       grid-column: 1 / -1;
     }
   }
+
+  .three-column-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 16px;
+    align-items: start;
+  }
 }
 
 .docker-details__field,

--- a/src/app/components/preferences/docker/docker-template-details/docker-template-details.component.spec.ts
+++ b/src/app/components/preferences/docker/docker-template-details/docker-template-details.component.spec.ts
@@ -147,6 +147,7 @@ describe('DockerTemplateDetailsComponent', () => {
       validateConsoleHttpPort: vi.fn().mockReturnValue({ isValid: true }),
       validateEnvironment: vi.fn().mockReturnValue({ isValid: true }),
       validateExtraConfigs: vi.fn().mockReturnValue({ isValid: true }),
+      validateNetmikoDeviceType: vi.fn().mockReturnValue({ isValid: true }),
     };
 
     await TestBed.configureTestingModule({

--- a/src/app/components/preferences/docker/docker-template-details/docker-template-details.component.ts
+++ b/src/app/components/preferences/docker/docker-template-details/docker-template-details.component.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy, ChangeDetectorRef, OnInit, model, inject, signal } from '@angular/core';
+import { Component, ChangeDetectionStrategy, ChangeDetectorRef, OnInit, model, inject, signal, computed } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
@@ -15,6 +15,13 @@ import { COMMA, ENTER } from '@angular/cdk/keycodes';
 import { finalize } from 'rxjs';
 import { Controller } from '@models/controller';
 import { DockerTemplate } from '@models/templates/docker-template';
+import { ApplianceMetadata } from '@models/appliance-metadata';
+import { NetmikoDeviceTypeSelectComponent } from '@components/netmiko-device-type-select/netmiko-device-type-select.component';
+import {
+  applianceCredentialValue,
+  ApplianceCredentialField,
+  setApplianceCredential,
+} from '../../template-metadata-section/appliance-metadata-field';
 import { ExtraConfig } from '@models/templates/extra-config';
 import { DockerConfigurationService } from '@services/docker-configuration.service';
 import { DockerService } from '@services/docker.service';
@@ -22,6 +29,7 @@ import { ControllerService } from '@services/controller.service';
 import { ToasterService } from '@services/toaster.service';
 import { DockerValidationService } from '@services/validation';
 import { TemplateSymbolDialogComponent } from '@components/project-map/template-symbol-dialog/template-symbol-dialog.component';
+import { TemplateMetadataSectionComponent } from '../../template-metadata-section/template-metadata-section.component';
 import { DialogConfigService } from '@services/dialog-config.service';
 import { ConfigureCustomAdaptersDialogComponent } from '../../../project-map/node-editors/configurator/docker/configure-custom-adapters/configure-custom-adapters.component';
 
@@ -41,11 +49,13 @@ import { ConfigureCustomAdaptersDialogComponent } from '../../../project-map/nod
     RouterModule,
     MatIconModule,
     MatButtonModule,
+    TemplateMetadataSectionComponent,
     MatFormFieldModule,
     MatInputModule,
     MatSelectModule,
     MatChipsModule,
     MatCheckboxModule,
+    NetmikoDeviceTypeSelectComponent,
     CdkTextareaAutosize,
   ],
 })
@@ -100,6 +110,10 @@ export class DockerTemplateDetailsComponent implements OnInit {
   extraVolumes = model('');
   extraConfigs = signal<ExtraConfig[]>([]);
   usage = model('');
+  netmikoDeviceType = model('');
+  readonly applianceMetadata = signal<ApplianceMetadata | null>(null);
+  readonly defaultUsername = computed(() => applianceCredentialValue(this.applianceMetadata(), 'default_username'));
+  readonly defaultPassword = computed(() => applianceCredentialValue(this.applianceMetadata(), 'default_password'));
   readonly isPulling = signal(false);
 
   constructor() {}
@@ -141,6 +155,8 @@ export class DockerTemplateDetailsComponent implements OnInit {
               (dockerTemplate.extra_configs || []).map((c) => ({ target: c.target || '', content: c.content ?? '' }))
             );
             this.usage.set(dockerTemplate.usage || '');
+            this.netmikoDeviceType.set(dockerTemplate.netmiko_device_type || '');
+            this.applianceMetadata.set(dockerTemplate.appliance_metadata ?? null);
             this.cd.markForCheck();
           },
           error: (err) => {
@@ -181,6 +197,11 @@ export class DockerTemplateDetailsComponent implements OnInit {
         this.usageExpanded = !this.usageExpanded;
         break;
     }
+  }
+
+  onCredentialInput(field: ApplianceCredentialField, event: Event) {
+    const value = (event.target as HTMLInputElement).value;
+    this.applianceMetadata.set(setApplianceCredential(this.applianceMetadata(), field, value));
   }
 
   selectSection(section: string): void { this.activeSection = section; }
@@ -251,6 +272,13 @@ export class DockerTemplateDetailsComponent implements OnInit {
       return;
     }
 
+    // Validate netmiko device type format if provided
+    const netmikoValidation = this.validationService.validateNetmikoDeviceType(this.netmikoDeviceType());
+    if (!netmikoValidation.isValid) {
+      this.toasterService.error(netmikoValidation.errorMessage);
+      return;
+    }
+
     // Update dockerTemplate from model signals
     this.dockerTemplate.name = this.name();
     this.dockerTemplate.default_name_format = this.defaultNameFormat();
@@ -282,6 +310,8 @@ export class DockerTemplateDetailsComponent implements OnInit {
     this.dockerTemplate.extra_configs = extraConfigs;
     this.extraConfigs.set(extraConfigs); // drop blank rows so the editor matches what was saved
     this.dockerTemplate.usage = this.usage();
+    this.dockerTemplate.netmiko_device_type = this.netmikoDeviceType().trim() || null;
+    this.dockerTemplate.appliance_metadata = this.applianceMetadata();
 
     this.dockerService.saveTemplate(this.controller, this.dockerTemplate).subscribe({
       next: () => {

--- a/src/app/components/preferences/dynamips/add-ios-template/add-ios-template.component.html
+++ b/src/app/components/preferences/dynamips/add-ios-template/add-ios-template.component.html
@@ -328,6 +328,31 @@
             </section>
           </div>
         </mat-step>
+        <mat-step [optional]="true">
+          <ng-template matStepLabel>
+            <span class="template-wizard__step-label">
+              <mat-icon>settings_ethernet</mat-icon>
+              <span class="template-wizard__step-label-text">
+                <span class="template-wizard__step-label-title">Netmiko device type</span>
+                <span class="template-wizard__step-label-description">Optional device type</span>
+              </span>
+            </span>
+          </ng-template>
+          <div class="ios-add__step-content template-wizard__panel">
+            <section class="template-wizard__section">
+              <h2 class="template-wizard__section-title">Netmiko device type</h2>
+              <p class="template-wizard__section-copy">Default device type used for netmiko-driven configuration pushes.</p>
+              <div class="ios-add__form">
+                <app-netmiko-device-type-select
+                  [(value)]="netmikoDeviceType"
+                  [controller]="controller()"
+                  appearance="fill"
+                  class="ios-add__field"
+                />
+              </div>
+            </section>
+          </div>
+        </mat-step>
       </mat-horizontal-stepper>
     </section>
 

--- a/src/app/components/preferences/dynamips/add-ios-template/add-ios-template.component.spec.ts
+++ b/src/app/components/preferences/dynamips/add-ios-template/add-ios-template.component.spec.ts
@@ -8,6 +8,7 @@ import { IosService } from '@services/ios.service';
 import { IosConfigurationService } from '@services/ios-configuration.service';
 import { TemplateMocksService } from '@services/template-mocks.service';
 import { ToasterService } from '@services/toaster.service';
+import { NetmikoDeviceTypesService } from '@services/netmiko-device-types.service';
 import { UploadServiceService } from 'app/common/uploading-processbar/upload-service.service';
 import { ProgressService } from 'app/common/progress/progress.service';
 import { Controller } from '@models/controller';
@@ -235,6 +236,7 @@ describe('AddIosTemplateComponent', () => {
         { provide: IosConfigurationService, useValue: mockIosConfigurationService },
         { provide: TemplateMocksService, useValue: mockTemplateMocksService },
         { provide: ToasterService, useValue: mockToasterService },
+        { provide: NetmikoDeviceTypesService, useValue: { getDeviceTypes: vi.fn().mockReturnValue(of({ deviceTypes: null, netmikoVersion: null })) } },
         { provide: UploadServiceService, useValue: mockUploadServiceService },
         { provide: ProgressService, useValue: mockProgressService },
         { provide: MatSnackBar, useValue: mockMatSnackBar },

--- a/src/app/components/preferences/dynamips/add-ios-template/add-ios-template.component.ts
+++ b/src/app/components/preferences/dynamips/add-ios-template/add-ios-template.component.ts
@@ -26,12 +26,14 @@ import { Subscription } from 'rxjs';
 import { v4 as uuid } from 'uuid';
 import { IosImage } from '@models/images/ios-image';
 import { Controller } from '@models/controller';
+import { NetmikoDeviceTypeSelectComponent } from '@components/netmiko-device-type-select/netmiko-device-type-select.component';
 import { IosTemplate } from '@models/templates/ios-template';
 import { IosConfigurationService } from '@services/ios-configuration.service';
 import { IosService } from '@services/ios.service';
 import { ControllerService } from '@services/controller.service';
 import { TemplateMocksService } from '@services/template-mocks.service';
 import { ToasterService } from '@services/toaster.service';
+import { ValidationService } from '@services/validation';
 import { ProgressService } from '../../../../common/progress/progress.service';
 import { TemplateInfoFieldsComponent } from '../../common/template-info-fields/template-info-fields.component';
 
@@ -40,6 +42,7 @@ import { TemplateInfoFieldsComponent } from '../../common/template-info-fields/t
   templateUrl: './add-ios-template.component.html',
   styleUrls: ['./add-ios-template.component.scss', '../../preferences.component.scss'],
   imports: [
+    NetmikoDeviceTypeSelectComponent,
     MatIconModule,
     MatButtonModule,
     MatCheckboxModule,
@@ -58,6 +61,7 @@ export class AddIosTemplateComponent implements OnInit, OnDestroy {
   private controllerService = inject(ControllerService);
   private iosService = inject(IosService);
   private toasterService = inject(ToasterService);
+  private validationService = inject(ValidationService);
   private router = inject(Router);
   private templateMocksService = inject(TemplateMocksService);
   private iosConfigurationService = inject(IosConfigurationService);
@@ -77,6 +81,7 @@ export class AddIosTemplateComponent implements OnInit, OnDestroy {
   chassis = model('');
   memory = model('');
   idlepc = model('');
+  netmikoDeviceType = model('');
   usage = model('');
   symbol = model('router');
 
@@ -252,6 +257,12 @@ export class AddIosTemplateComponent implements OnInit, OnDestroy {
 
   addTemplate() {
     if (this.canCreateTemplate()) {
+      const netmikoValidation = this.validationService.validateNetmikoDeviceType(this.netmikoDeviceType());
+      if (!netmikoValidation.isValid) {
+        this.toasterService.error(netmikoValidation.errorMessage);
+        return;
+      }
+
       const template = this.iosTemplate();
       template.template_id = uuid();
       template.image = this.imageName();
@@ -271,6 +282,7 @@ export class AddIosTemplateComponent implements OnInit, OnDestroy {
       if (this.networkAdaptersForTemplate().length > 0) this.completeAdaptersData(template);
       if (this.wicsForTemplate().length > 0) this.completeWicsData(template);
       if (this.idlepc()) template.idlepc = this.idlepc();
+      template.netmiko_device_type = this.netmikoDeviceType().trim() || null;
       template.compute_id = 'local';
 
       this.iosService.addTemplate(this.controller(), template).subscribe({

--- a/src/app/components/preferences/dynamips/ios-template-details/ios-template-details.component.html
+++ b/src/app/components/preferences/dynamips/ios-template-details/ios-template-details.component.html
@@ -26,6 +26,7 @@
       <button type="button" [class.is-active]="activeSection === 'slots'" (click)="selectSection('slots')">Slots</button>
       <button type="button" [class.is-active]="activeSection === 'advanced'" (click)="selectSection('advanced')">Advanced</button>
       <button type="button" [class.is-active]="activeSection === 'usage'" (click)="selectSection('usage')">Usage</button>
+      <button type="button" [class.is-active]="activeSection === 'metadata'" (click)="selectSection('metadata')">Metadata</button>
     </nav>
     <section class="ios-details__form-card">
       <div class="ios-details__section-header" (click)="toggleSection('general')">
@@ -460,7 +461,12 @@
     </section>
 
     <section class="ios-details__form-card">
+      <div class="ios-details__section-header">
+        <h3 class="ios-details__section-title">Appliance metadata</h3>
+      </div>
+      @if (activeSection === 'metadata') {
       <app-template-metadata-section [(metadata)]="applianceMetadata" />
+      }
     </section>
     <div class="ios-details__actions">
       <button class="ios-details__cancel-btn" (click)="goBack()" mat-button>Cancel</button>

--- a/src/app/components/preferences/dynamips/ios-template-details/ios-template-details.component.html
+++ b/src/app/components/preferences/dynamips/ios-template-details/ios-template-details.component.html
@@ -169,12 +169,36 @@
           </mat-form-field>
         </div>
 
-        <mat-checkbox
-          class="ios-details__checkbox"
-          [checked]="iosTemplate.console_auto_start"
-          (change)="iosTemplate.console_auto_start = $event.checked"
-          >Auto start console</mat-checkbox
-        >
+        <div class="three-column-grid">
+          <app-netmiko-device-type-select
+            [(value)]="netmikoDeviceType"
+            [controller]="controller"
+            appearance="fill"
+            class="ios-details__field"
+          />
+          <mat-form-field appearance="fill" class="ios-details__field">
+            <mat-label>Default username</mat-label>
+            <input
+              matInput
+              [value]="defaultUsername()"
+              (input)="onCredentialInput('default_username', $event)"
+              type="text"
+              placeholder="Username to log into this node"
+            />
+          </mat-form-field>
+          <mat-form-field appearance="fill" class="ios-details__field">
+            <mat-label>Default password</mat-label>
+            <input
+              matInput
+              [value]="defaultPassword()"
+              (input)="onCredentialInput('default_password', $event)"
+              type="text"
+              placeholder="Password to log into this node"
+            />
+          </mat-form-field>
+        </div>
+
+        <mat-checkbox class="ios-details__checkbox" [checked]="iosTemplate.console_auto_start" (change)="iosTemplate.console_auto_start = $event.checked">Auto start console</mat-checkbox>
       </div>
       }
     </section>
@@ -435,6 +459,9 @@
       }
     </section>
 
+    <section class="ios-details__form-card">
+      <app-template-metadata-section [(metadata)]="applianceMetadata" />
+    </section>
     <div class="ios-details__actions">
       <button class="ios-details__cancel-btn" (click)="goBack()" mat-button>Cancel</button>
       <button mat-raised-button color="primary" class="ios-details__save-btn" (click)="onSave()">Save</button>

--- a/src/app/components/preferences/dynamips/ios-template-details/ios-template-details.component.spec.ts
+++ b/src/app/components/preferences/dynamips/ios-template-details/ios-template-details.component.spec.ts
@@ -7,6 +7,7 @@ import { IosService } from '@services/ios.service';
 import { IosConfigurationService } from '@services/ios-configuration.service';
 import { ControllerService } from '@services/controller.service';
 import { ToasterService } from '@services/toaster.service';
+import { NetmikoDeviceTypesService } from '@services/netmiko-device-types.service';
 import { ProgressService } from '../../../../common/progress/progress.service';
 import { DialogConfigService } from '@services/dialog-config.service';
 import { Controller } from '@models/controller';
@@ -150,6 +151,7 @@ describe('IosTemplateDetailsComponent', () => {
       validateNvramForPlatform: vi.fn().mockReturnValue({ isValid: true }),
       validateMacAddress: vi.fn().mockReturnValue({ isValid: true }),
       validateIdlepc: vi.fn().mockReturnValue({ isValid: true }),
+      validateNetmikoDeviceType: vi.fn().mockReturnValue({ isValid: true }),
     };
 
     mockToasterService = {
@@ -187,6 +189,7 @@ describe('IosTemplateDetailsComponent', () => {
         { provide: IosValidationService, useValue: mockIosValidationService },
         { provide: ControllerService, useValue: mockControllerService },
         { provide: ToasterService, useValue: mockToasterService },
+        { provide: NetmikoDeviceTypesService, useValue: { getDeviceTypes: vi.fn().mockReturnValue(of({ deviceTypes: null, netmikoVersion: null })) } },
         { provide: ProgressService, useValue: mockProgressService },
         { provide: DialogConfigService, useValue: mockDialogConfigService },
         { provide: MatDialog, useValue: mockDialog },

--- a/src/app/components/preferences/dynamips/ios-template-details/ios-template-details.component.ts
+++ b/src/app/components/preferences/dynamips/ios-template-details/ios-template-details.component.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy, ChangeDetectorRef, OnInit, inject, model } from '@angular/core';
+import { Component, ChangeDetectionStrategy, ChangeDetectorRef, OnInit, inject, model, signal, computed } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
@@ -14,6 +14,13 @@ import { MatDialog } from '@angular/material/dialog';
 import { COMMA, ENTER } from '@angular/cdk/keycodes';
 import { Controller } from '@models/controller';
 import { IosTemplate } from '@models/templates/ios-template';
+import { ApplianceMetadata } from '@models/appliance-metadata';
+import { NetmikoDeviceTypeSelectComponent } from '@components/netmiko-device-type-select/netmiko-device-type-select.component';
+import {
+  applianceCredentialValue,
+  ApplianceCredentialField,
+  setApplianceCredential,
+} from '../../template-metadata-section/appliance-metadata-field';
 import { IosConfigurationService } from '@services/ios-configuration.service';
 import { IosService } from '@services/ios.service';
 import { ControllerService } from '@services/controller.service';
@@ -21,6 +28,7 @@ import { ToasterService } from '@services/toaster.service';
 import { IosValidationService } from '@services/validation';
 import { ProgressService } from '../../../../common/progress/progress.service';
 import { TemplateSymbolDialogComponent } from '@components/project-map/template-symbol-dialog/template-symbol-dialog.component';
+import { TemplateMetadataSectionComponent } from '../../template-metadata-section/template-metadata-section.component';
 import { DialogConfigService } from '@services/dialog-config.service';
 
 @Component({
@@ -42,9 +50,11 @@ import { DialogConfigService } from '@services/dialog-config.service';
     MatInputModule,
     MatSelectModule,
     MatButtonModule,
+    TemplateMetadataSectionComponent,
     MatIconModule,
     MatExpansionModule,
     MatCheckboxModule,
+    NetmikoDeviceTypeSelectComponent,
   ],
 })
 export class IosTemplateDetailsComponent implements OnInit {
@@ -104,6 +114,10 @@ export class IosTemplateDetailsComponent implements OnInit {
   readonly mmap = model(true);
   readonly sparsemem = model(true);
   readonly usage = model('');
+  readonly netmikoDeviceType = model('');
+  readonly applianceMetadata = signal<ApplianceMetadata | null>(null);
+  readonly defaultUsername = computed(() => applianceCredentialValue(this.applianceMetadata(), 'default_username'));
+  readonly defaultPassword = computed(() => applianceCredentialValue(this.applianceMetadata(), 'default_password'));
 
   ngOnInit() {
     const controller_id = this.route.snapshot.paramMap.get('controller_id');
@@ -229,6 +243,8 @@ export class IosTemplateDetailsComponent implements OnInit {
     this.mmap.set(this.iosTemplate.mmap ?? true);
     this.sparsemem.set(this.iosTemplate.sparsemem ?? true);
     this.usage.set(this.iosTemplate.usage || '');
+    this.netmikoDeviceType.set(this.iosTemplate.netmiko_device_type || '');
+    this.applianceMetadata.set(this.iosTemplate.appliance_metadata ?? null);
   }
 
   saveSlotsData() {
@@ -255,6 +271,11 @@ export class IosTemplateDetailsComponent implements OnInit {
         delete this.iosTemplate[`wic${i}`];
       }
     }
+  }
+
+  onCredentialInput(field: ApplianceCredentialField, event: Event) {
+    const value = (event.target as HTMLInputElement).value;
+    this.applianceMetadata.set(setApplianceCredential(this.applianceMetadata(), field, value));
   }
 
   onSave() {
@@ -290,6 +311,8 @@ export class IosTemplateDetailsComponent implements OnInit {
       this.toasterService.error(idlepcValidation.errorMessage);
       return;
     }
+    const netmikoValidation = this.validationService.validateNetmikoDeviceType(this.netmikoDeviceType());
+    if (!netmikoValidation.isValid) { this.toasterService.error(netmikoValidation.errorMessage); return; }
 
     this.saveSlotsData();
 
@@ -312,6 +335,8 @@ export class IosTemplateDetailsComponent implements OnInit {
     this.iosTemplate.mmap = this.mmap();
     this.iosTemplate.sparsemem = this.sparsemem();
     this.iosTemplate.usage = this.usage();
+    this.iosTemplate.netmiko_device_type = this.netmikoDeviceType().trim() || null;
+    this.iosTemplate.appliance_metadata = this.applianceMetadata();
 
     this.iosService.saveTemplate(this.controller, this.iosTemplate).subscribe({
       next: () => {

--- a/src/app/components/preferences/ios-on-unix/add-iou-template/add-iou-template.component.html
+++ b/src/app/components/preferences/ios-on-unix/add-iou-template/add-iou-template.component.html
@@ -178,6 +178,32 @@
             </section>
           </div>
         </mat-step>
+
+        <mat-step [optional]="true">
+          <ng-template matStepLabel>
+            <span class="template-wizard__step-label">
+              <mat-icon>settings_ethernet</mat-icon>
+              <span class="template-wizard__step-label-text">
+                <span class="template-wizard__step-label-title">Netmiko device type</span>
+                <span class="template-wizard__step-label-description">Optional device type</span>
+              </span>
+            </span>
+          </ng-template>
+          <div class="iou-add__step-content template-wizard__panel">
+            <section class="template-wizard__section">
+              <h2 class="template-wizard__section-title">Netmiko device type</h2>
+              <p class="template-wizard__section-copy">Default device type used for netmiko-driven configuration pushes.</p>
+              <div class="iou-add__form">
+                <app-netmiko-device-type-select
+                  [(value)]="netmikoDeviceType"
+                  [controller]="controller()"
+                  appearance="fill"
+                  class="iou-add__field"
+                />
+              </div>
+            </section>
+          </div>
+        </mat-step>
       </mat-horizontal-stepper>
     </section>
 
@@ -189,7 +215,7 @@
           <mat-icon>arrow_back</mat-icon>
           Back
         </button>
-        } @if (selectedStepIndex() < 2) {
+        } @if (selectedStepIndex() < 3) {
         <button
           mat-raised-button
           color="primary"

--- a/src/app/components/preferences/ios-on-unix/add-iou-template/add-iou-template.component.spec.ts
+++ b/src/app/components/preferences/ios-on-unix/add-iou-template/add-iou-template.component.spec.ts
@@ -6,6 +6,7 @@ import { IouService } from '@services/iou.service';
 import { ControllerService } from '@services/controller.service';
 import { TemplateMocksService } from '@services/template-mocks.service';
 import { ToasterService } from '@services/toaster.service';
+import { NetmikoDeviceTypesService } from '@services/netmiko-device-types.service';
 import { UploadServiceService } from 'app/common/uploading-processbar/upload-service.service';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { IouTemplate } from '@models/templates/iou-template';
@@ -132,6 +133,7 @@ describe('AddIouTemplateComponent', () => {
         { provide: IouService, useValue: mockIouService },
         { provide: TemplateMocksService, useValue: mockTemplateMocksService },
         { provide: ToasterService, useValue: mockToasterService },
+        { provide: NetmikoDeviceTypesService, useValue: { getDeviceTypes: vi.fn().mockReturnValue(of({ deviceTypes: null, netmikoVersion: null })) } },
         { provide: UploadServiceService, useValue: mockUploadServiceService },
         { provide: MatSnackBar, useValue: mockSnackBar },
       ],

--- a/src/app/components/preferences/ios-on-unix/add-iou-template/add-iou-template.component.ts
+++ b/src/app/components/preferences/ios-on-unix/add-iou-template/add-iou-template.component.ts
@@ -25,11 +25,13 @@ import { Subscription } from 'rxjs';
 import { v4 as uuid } from 'uuid';
 import { IouImage } from '@models/iou/iou-image';
 import { Controller } from '@models/controller';
+import { NetmikoDeviceTypeSelectComponent } from '@components/netmiko-device-type-select/netmiko-device-type-select.component';
 import { IouTemplate } from '@models/templates/iou-template';
 import { IouService } from '@services/iou.service';
 import { ControllerService } from '@services/controller.service';
 import { TemplateMocksService } from '@services/template-mocks.service';
 import { ToasterService } from '@services/toaster.service';
+import { ValidationService } from '@services/validation';
 import { TemplateInfoFieldsComponent } from '../../common/template-info-fields/template-info-fields.component';
 
 @Component({
@@ -37,6 +39,7 @@ import { TemplateInfoFieldsComponent } from '../../common/template-info-fields/t
   templateUrl: './add-iou-template.component.html',
   styleUrls: ['./add-iou-template.component.scss', '../../preferences.component.scss'],
   imports: [
+    NetmikoDeviceTypeSelectComponent,
     MatIconModule,
     MatButtonModule,
     MatRadioModule,
@@ -54,6 +57,7 @@ export class AddIouTemplateComponent implements OnInit, OnDestroy {
   private controllerService = inject(ControllerService);
   private iouService = inject(IouService);
   private toasterService = inject(ToasterService);
+  private validationService = inject(ValidationService);
   private router = inject(Router);
   private templateMocksService = inject(TemplateMocksService);
   private uploadServiceService = inject(UploadServiceService);
@@ -74,6 +78,7 @@ export class AddIouTemplateComponent implements OnInit, OnDestroy {
   templateName = model('');
   imageName = model('');
   selectedType = model('');
+  netmikoDeviceType = model('');
   usage = model('');
   symbol = model('multilayer_switch');
 
@@ -197,6 +202,12 @@ export class AddIouTemplateComponent implements OnInit, OnDestroy {
 
   addTemplate() {
     if (this.canCreateTemplate()) {
+      const netmikoValidation = this.validationService.validateNetmikoDeviceType(this.netmikoDeviceType());
+      if (!netmikoValidation.isValid) {
+        this.toasterService.error(netmikoValidation.errorMessage);
+        return;
+      }
+
       const template = this.iouTemplate();
       template.template_id = uuid();
       template.name = this.templateName();
@@ -212,6 +223,7 @@ export class AddIouTemplateComponent implements OnInit, OnDestroy {
         template.ethernet_adapters = 2;
         template.serial_adapters = 2;
       }
+      template.netmiko_device_type = this.netmikoDeviceType().trim() || null;
 
       this.iouService.addTemplate(this.controller(), template).subscribe({
         next: () => {

--- a/src/app/components/preferences/ios-on-unix/iou-template-details/iou-template-details.component.html
+++ b/src/app/components/preferences/ios-on-unix/iou-template-details/iou-template-details.component.html
@@ -22,6 +22,7 @@
       </button>
       <button type="button" [class.is-active]="activeSection === 'network'" (click)="selectSection('network')">Network</button>
       <button type="button" [class.is-active]="activeSection === 'usage'" (click)="selectSection('usage')">Usage</button>
+      <button type="button" [class.is-active]="activeSection === 'metadata'" (click)="selectSection('metadata')">Metadata</button>
     </nav>
     <section class="iou-template-details__form-card">
       <div class="iou-template-details__section-header" (click)="toggleSection('general')">
@@ -278,7 +279,12 @@
     </section>
 
     <section class="iou-template-details__form-card">
+      <div class="iou-template-details__section-header">
+        <h3 class="iou-template-details__section-title">Appliance metadata</h3>
+      </div>
+      @if (activeSection === 'metadata') {
       <app-template-metadata-section [(metadata)]="applianceMetadata" />
+      }
     </section>
     <div class="iou-template-details__actions">
       <button class="iou-template-details__cancel-btn" (click)="goBack()" mat-button>Cancel</button>

--- a/src/app/components/preferences/ios-on-unix/iou-template-details/iou-template-details.component.html
+++ b/src/app/components/preferences/ios-on-unix/iou-template-details/iou-template-details.component.html
@@ -155,6 +155,35 @@
           </mat-select>
         </mat-form-field>
 
+        <div class="three-column-grid">
+          <app-netmiko-device-type-select
+            [(value)]="netmikoDeviceType"
+            [controller]="controller"
+            appearance="fill"
+            class="iou-template-details__field"
+          />
+          <mat-form-field appearance="fill" class="iou-template-details__field">
+            <mat-label>Default username</mat-label>
+            <input
+              matInput
+              [value]="defaultUsername()"
+              (input)="onCredentialInput('default_username', $event)"
+              type="text"
+              placeholder="Username to log into this node"
+            />
+          </mat-form-field>
+          <mat-form-field appearance="fill" class="iou-template-details__field">
+            <mat-label>Default password</mat-label>
+            <input
+              matInput
+              [value]="defaultPassword()"
+              (input)="onCredentialInput('default_password', $event)"
+              type="text"
+              placeholder="Password to log into this node"
+            />
+          </mat-form-field>
+        </div>
+
         <mat-checkbox [checked]="consoleAutoStart()" (change)="consoleAutoStart.set($event.checked)">
           Auto start console
         </mat-checkbox>
@@ -248,6 +277,9 @@
       }
     </section>
 
+    <section class="iou-template-details__form-card">
+      <app-template-metadata-section [(metadata)]="applianceMetadata" />
+    </section>
     <div class="iou-template-details__actions">
       <button class="iou-template-details__cancel-btn" (click)="goBack()" mat-button>Cancel</button>
       <button mat-raised-button color="primary" class="iou-template-details__save-btn" (click)="onSave()">Save</button>

--- a/src/app/components/preferences/ios-on-unix/iou-template-details/iou-template-details.component.scss
+++ b/src/app/components/preferences/ios-on-unix/iou-template-details/iou-template-details.component.scss
@@ -82,6 +82,13 @@
     grid-template-columns: 1fr 1fr;
     gap: var(--gns3-density-card-gap);
   }
+
+  .three-column-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 16px;
+    align-items: start;
+  }
 }
 
 .iou-template-details__field {

--- a/src/app/components/preferences/ios-on-unix/iou-template-details/iou-template-details.component.spec.ts
+++ b/src/app/components/preferences/ios-on-unix/iou-template-details/iou-template-details.component.spec.ts
@@ -9,6 +9,7 @@ import { IouConfigurationService } from '@services/iou-configuration.service';
 import { ControllerService } from '@services/controller.service';
 import { ToasterService } from '@services/toaster.service';
 import { DialogConfigService } from '@services/dialog-config.service';
+import { NetmikoDeviceTypesService } from '@services/netmiko-device-types.service';
 import { Controller } from '@models/controller';
 import { TemplateSymbolDialogComponent } from '@components/project-map/template-symbol-dialog/template-symbol-dialog.component';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
@@ -132,6 +133,7 @@ describe('IouTemplateDetailsComponent', () => {
         { provide: ToasterService, useValue: mockToasterService },
         { provide: MatDialog, useValue: mockMatDialog },
         { provide: DialogConfigService, useValue: mockDialogConfigService },
+        { provide: NetmikoDeviceTypesService, useValue: { getDeviceTypes: vi.fn().mockReturnValue(of({ deviceTypes: null, netmikoVersion: null })) } },
       ],
     }).compileComponents();
 

--- a/src/app/components/preferences/ios-on-unix/iou-template-details/iou-template-details.component.ts
+++ b/src/app/components/preferences/ios-on-unix/iou-template-details/iou-template-details.component.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy, ChangeDetectorRef, OnInit, model, inject } from '@angular/core';
+import { Component, ChangeDetectionStrategy, ChangeDetectorRef, OnInit, model, inject, signal, computed } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
@@ -13,11 +13,19 @@ import { MatDialog } from '@angular/material/dialog';
 import { COMMA, ENTER } from '@angular/cdk/keycodes';
 import { Controller } from '@models/controller';
 import { IouTemplate } from '@models/templates/iou-template';
+import { ApplianceMetadata } from '@models/appliance-metadata';
+import { NetmikoDeviceTypeSelectComponent } from '@components/netmiko-device-type-select/netmiko-device-type-select.component';
+import {
+  applianceCredentialValue,
+  ApplianceCredentialField,
+  setApplianceCredential,
+} from '../../template-metadata-section/appliance-metadata-field';
 import { IouConfigurationService } from '@services/iou-configuration.service';
 import { IouService } from '@services/iou.service';
 import { ControllerService } from '@services/controller.service';
 import { ToasterService } from '@services/toaster.service';
 import { TemplateSymbolDialogComponent } from '@components/project-map/template-symbol-dialog/template-symbol-dialog.component';
+import { TemplateMetadataSectionComponent } from '../../template-metadata-section/template-metadata-section.component';
 import { DialogConfigService } from '@services/dialog-config.service';
 import { IouValidationService } from '@services/validation';
 
@@ -37,11 +45,13 @@ import { IouValidationService } from '@services/validation';
     RouterModule,
     MatIconModule,
     MatButtonModule,
+    TemplateMetadataSectionComponent,
     MatFormFieldModule,
     MatInputModule,
     MatSelectModule,
     MatChipsModule,
     MatCheckboxModule,
+    NetmikoDeviceTypeSelectComponent,
   ],
 })
 export class IouTemplateDetailsComponent implements OnInit {
@@ -81,6 +91,10 @@ export class IouTemplateDetailsComponent implements OnInit {
   ethernetAdapters = model(0);
   serialAdapters = model(0);
   usage = model('');
+  netmikoDeviceType = model('');
+  readonly applianceMetadata = signal<ApplianceMetadata | null>(null);
+  readonly defaultUsername = computed(() => applianceCredentialValue(this.applianceMetadata(), 'default_username'));
+  readonly defaultPassword = computed(() => applianceCredentialValue(this.applianceMetadata(), 'default_password'));
   tags = model<string[]>([]);
 
   // Section collapse states
@@ -122,6 +136,8 @@ export class IouTemplateDetailsComponent implements OnInit {
             this.ethernetAdapters.set(iouTemplate.ethernet_adapters || 0);
             this.serialAdapters.set(iouTemplate.serial_adapters || 0);
             this.usage.set(iouTemplate.usage || '');
+            this.netmikoDeviceType.set(iouTemplate.netmiko_device_type || '');
+            this.applianceMetadata.set(iouTemplate.appliance_metadata ?? null);
             this.tags.set(iouTemplate.tags || []);
 
             this.cd.markForCheck();
@@ -150,6 +166,11 @@ export class IouTemplateDetailsComponent implements OnInit {
     this.router.navigate(['/controller', this.controller.id, 'preferences']);
   }
 
+  onCredentialInput(field: ApplianceCredentialField, event: Event) {
+    const value = (event.target as HTMLInputElement).value;
+    this.applianceMetadata.set(setApplianceCredential(this.applianceMetadata(), field, value));
+  }
+
   onSave() {
     // Validate required fields
     const nameValidation = this.validationService.validateName(this.templateName());
@@ -162,6 +183,8 @@ export class IouTemplateDetailsComponent implements OnInit {
       this.toasterService.error(pathValidation.errorMessage);
       return;
     }
+    const netmikoValidation = this.validationService.validateNetmikoDeviceType(this.netmikoDeviceType());
+    if (!netmikoValidation.isValid) { this.toasterService.error(netmikoValidation.errorMessage); return; }
 
     // Update iouTemplate from model signals
     this.iouTemplate.name = this.templateName();
@@ -180,6 +203,8 @@ export class IouTemplateDetailsComponent implements OnInit {
     this.iouTemplate.ethernet_adapters = this.ethernetAdapters();
     this.iouTemplate.serial_adapters = this.serialAdapters();
     this.iouTemplate.usage = this.usage();
+    this.iouTemplate.netmiko_device_type = this.netmikoDeviceType().trim() || null;
+    this.iouTemplate.appliance_metadata = this.applianceMetadata();
     this.iouTemplate.tags = this.tags();
 
     this.iouService.saveTemplate(this.controller, this.iouTemplate).subscribe({

--- a/src/app/components/preferences/qemu/add-qemu-vm-template/add-qemu-vm-template.component.html
+++ b/src/app/components/preferences/qemu/add-qemu-vm-template/add-qemu-vm-template.component.html
@@ -297,6 +297,30 @@
           </div>
         </mat-step>
 
+        <mat-step [optional]="true">
+          <ng-template matStepLabel>
+            <span class="template-wizard__step-label">
+              <mat-icon>settings_ethernet</mat-icon>
+              <span class="template-wizard__step-label-text">
+                <span class="template-wizard__step-label-title">Netmiko device type</span>
+                <span class="template-wizard__step-label-description">Optional device type</span>
+              </span>
+            </span>
+          </ng-template>
+          <div class="template-wizard__panel">
+            <section class="template-wizard__section">
+              <h2 class="template-wizard__section-title">Netmiko device type</h2>
+              <p class="template-wizard__section-copy">Default device type used for netmiko-driven configuration pushes.</p>
+              <app-netmiko-device-type-select
+                [(value)]="netmikoDeviceType"
+                [controller]="controller()"
+                appearance="fill"
+                class="qemu-add__field"
+              />
+            </section>
+          </div>
+        </mat-step>
+
         <mat-step [completed]="canCreateTemplate()">
           <ng-template matStepLabel>
             <span class="template-wizard__step-label">
@@ -350,7 +374,7 @@
           <mat-icon>arrow_back</mat-icon>
           Back
         </button>
-        } @if (selectedStepIndex() < 6) {
+        } @if (selectedStepIndex() < 7) {
         <button
           mat-raised-button
           color="primary"

--- a/src/app/components/preferences/qemu/add-qemu-vm-template/add-qemu-vm-template.component.spec.ts
+++ b/src/app/components/preferences/qemu/add-qemu-vm-template/add-qemu-vm-template.component.spec.ts
@@ -8,6 +8,7 @@ import { QemuConfigurationService } from '@services/qemu-configuration.service';
 import { ControllerService } from '@services/controller.service';
 import { TemplateMocksService } from '@services/template-mocks.service';
 import { ToasterService } from '@services/toaster.service';
+import { NetmikoDeviceTypesService } from '@services/netmiko-device-types.service';
 import { UploadServiceService } from 'app/common/uploading-processbar/upload-service.service';
 import { UploadingProcessbarComponent } from 'app/common/uploading-processbar/uploading-processbar.component';
 import { Controller } from '@models/controller';
@@ -167,6 +168,7 @@ describe('AddQemuVmTemplateComponent', () => {
         { provide: ControllerService, useValue: mockControllerService },
         { provide: TemplateMocksService, useValue: mockTemplateMocksService },
         { provide: ToasterService, useValue: mockToasterService },
+        { provide: NetmikoDeviceTypesService, useValue: { getDeviceTypes: vi.fn().mockReturnValue(of({ deviceTypes: null, netmikoVersion: null })) } },
         { provide: Router, useValue: mockRouter },
         { provide: ActivatedRoute, useValue: mockActivatedRoute },
         { provide: MatSnackBar, useValue: mockSnackBar },
@@ -473,8 +475,8 @@ describe('AddQemuVmTemplateComponent', () => {
     const compiled = fixture.nativeElement as HTMLElement;
 
     expect(compiled.querySelector('mat-horizontal-stepper')).toBeTruthy();
-    expect(compiled.querySelectorAll('.template-wizard__step-label')).toHaveLength(7);
-    expect(compiled.querySelectorAll('.template-wizard__step-label-description')).toHaveLength(7);
+    expect(compiled.querySelectorAll('.template-wizard__step-label')).toHaveLength(8);
+    expect(compiled.querySelectorAll('.template-wizard__step-label-description')).toHaveLength(8);
     expect(compiled.textContent).toContain('Controller type');
     expect(compiled.textContent).toContain('Run this QEMU VM locally');
     expect(compiled.querySelector('.template-wizard__notice')).toBeNull();

--- a/src/app/components/preferences/qemu/add-qemu-vm-template/add-qemu-vm-template.component.ts
+++ b/src/app/components/preferences/qemu/add-qemu-vm-template/add-qemu-vm-template.component.ts
@@ -26,18 +26,21 @@ import { Subscription } from 'rxjs';
 import { v4 as uuid } from 'uuid';
 import { QemuImage } from '@models/qemu/qemu-image';
 import { Controller } from '@models/controller';
+import { NetmikoDeviceTypeSelectComponent } from '@components/netmiko-device-type-select/netmiko-device-type-select.component';
 import { QemuTemplate } from '@models/templates/qemu-template';
 import { QemuConfigurationService } from '@services/qemu-configuration.service';
 import { QemuService } from '@services/qemu.service';
 import { ControllerService } from '@services/controller.service';
 import { TemplateMocksService } from '@services/template-mocks.service';
 import { ToasterService } from '@services/toaster.service';
+import { ValidationService } from '@services/validation';
 
 @Component({
   selector: 'app-add-qemu-virtual-machine-template',
   templateUrl: './add-qemu-vm-template.component.html',
   styleUrls: ['./add-qemu-vm-template.component.scss', '../../preferences.component.scss'],
   imports: [
+    NetmikoDeviceTypeSelectComponent,
     MatIconModule,
     MatButtonModule,
     MatRadioModule,
@@ -55,6 +58,7 @@ export class AddQemuVmTemplateComponent implements OnInit, OnDestroy {
   private controllerService = inject(ControllerService);
   private qemuService = inject(QemuService);
   private toasterService = inject(ToasterService);
+  private validationService = inject(ValidationService);
   private router = inject(Router);
   private templateMocksService = inject(TemplateMocksService);
   private configurationService = inject(QemuConfigurationService);
@@ -86,6 +90,7 @@ export class AddQemuVmTemplateComponent implements OnInit, OnDestroy {
   selectedPlatform = model('');
   consoleType = model('');
   auxConsoleType = model('');
+  netmikoDeviceType = model('');
 
   // Step completion computed signals
   nameStepCompleted = computed(() => !!this.templateName().trim());
@@ -277,6 +282,12 @@ export class AddQemuVmTemplateComponent implements OnInit, OnDestroy {
 
   addTemplate() {
     if (this.canCreateTemplate()) {
+      const netmikoValidation = this.validationService.validateNetmikoDeviceType(this.netmikoDeviceType());
+      if (!netmikoValidation.isValid) {
+        this.toasterService.error(netmikoValidation.errorMessage);
+        return;
+      }
+
       const template = this.qemuTemplate();
       template.ram = this.ramMemory();
       template.platform = this.selectedPlatform();
@@ -292,6 +303,7 @@ export class AddQemuVmTemplateComponent implements OnInit, OnDestroy {
       template.compute_id = 'local';
       template.console_type = this.consoleType();
       template.aux_type = this.auxConsoleType();
+      template.netmiko_device_type = this.netmikoDeviceType().trim() || null;
 
       this.qemuService.addTemplate(this.controller(), template).subscribe({
         next: () => {

--- a/src/app/components/preferences/qemu/qemu-preferences/qemu-preferences.component.html
+++ b/src/app/components/preferences/qemu/qemu-preferences/qemu-preferences.component.html
@@ -42,7 +42,13 @@
 
     <div class="buttons-bar">
       <button mat-button color="accent" (click)="restoreDefaults()">Restore defaults</button>
-      <button mat-raised-button color="primary" (click)="apply()">Apply</button>
+      <button mat-raised-button color="primary" (click)="apply()" [disabled]="isApplying()">
+        @if (isApplying()) {
+          <mat-spinner diameter="20"></mat-spinner>
+        } @else {
+          Apply
+        }
+      </button>
     </div>
   </div>
 </div>

--- a/src/app/components/preferences/qemu/qemu-preferences/qemu-preferences.component.ts
+++ b/src/app/components/preferences/qemu/qemu-preferences/qemu-preferences.component.ts
@@ -1,9 +1,10 @@
-import { Component, ChangeDetectionStrategy, ChangeDetectorRef, OnInit, inject } from '@angular/core';
+import { Component, ChangeDetectionStrategy, ChangeDetectorRef, OnInit, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute, RouterModule } from '@angular/router';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatListModule } from '@angular/material/list';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { Controller } from '@models/controller';
 import { QemuSettings } from '@models/settings/qemu-settings';
 import { ControllerSettingsService } from '@services/controller-settings.service';
@@ -16,7 +17,7 @@ import { ToasterService } from '@services/toaster.service';
   selector: 'app-qemu-preferences',
   templateUrl: './qemu-preferences.component.html',
   styleUrls: ['./qemu-preferences.component.scss'],
-  imports: [CommonModule, RouterModule, MatButtonModule, MatCheckboxModule, MatListModule],
+  imports: [CommonModule, RouterModule, MatButtonModule, MatCheckboxModule, MatListModule, MatProgressSpinnerModule],
 })
 export class QemuPreferencesComponent implements OnInit {
   private readonly route: ActivatedRoute = inject(ActivatedRoute);
@@ -27,6 +28,7 @@ export class QemuPreferencesComponent implements OnInit {
 
   controller: Controller;
   settings: QemuSettings;
+  readonly isApplying = signal(false);
 
   ngOnInit() {
     const controller_id = this.route.snapshot.paramMap.get('controller_id');
@@ -56,17 +58,21 @@ export class QemuPreferencesComponent implements OnInit {
   }
 
   apply() {
+    if (this.isApplying()) return;
     if (!this.settings.enable_hardware_acceleration) {
       this.settings.require_hardware_acceleration = false;
     }
 
+    this.isApplying.set(true);
     this.controllerSettingsService.updateSettingsForQemu(this.controller, this.settings).subscribe({
       next: (qemuSettings: QemuSettings) => {
         this.toasterService.success(`Changes applied`);
+        this.isApplying.set(false);
       },
       error: (err) => {
         const message = err.error?.message || err.message || 'Failed to apply QEMU settings';
         this.toasterService.error(message);
+        this.isApplying.set(false);
         this.cd.markForCheck();
       },
     });

--- a/src/app/components/preferences/qemu/qemu-vm-template-details/qemu-vm-template-details.component.html
+++ b/src/app/components/preferences/qemu/qemu-vm-template-details/qemu-vm-template-details.component.html
@@ -28,6 +28,7 @@
       <button type="button" [class.is-active]="activeSection === 'network'" (click)="selectSection('network')">Network</button>
       <button type="button" [class.is-active]="activeSection === 'advanced'" (click)="selectSection('advanced')">Advanced</button>
       <button type="button" [class.is-active]="activeSection === 'usage'" (click)="selectSection('usage')">Usage</button>
+      <button type="button" [class.is-active]="activeSection === 'metadata'" (click)="selectSection('metadata')">Metadata</button>
     </nav>
     <section class="qemu-template-details__form-card">
       <div class="qemu-template-details__section-header" (click)="toggleSection('general')">
@@ -716,7 +717,12 @@
     </section>
 
     <section class="qemu-template-details__form-card">
+      <div class="qemu-template-details__section-header">
+        <h3 class="qemu-template-details__section-title">Appliance metadata</h3>
+      </div>
+      @if (activeSection === 'metadata') {
       <app-template-metadata-section [(metadata)]="applianceMetadata" />
+      }
     </section>
 
     <div class="qemu-template-details__actions">

--- a/src/app/components/preferences/qemu/qemu-vm-template-details/qemu-vm-template-details.component.html
+++ b/src/app/components/preferences/qemu/qemu-vm-template-details/qemu-vm-template-details.component.html
@@ -163,6 +163,35 @@
           </mat-form-field>
         </div>
 
+        <div class="three-column-grid">
+          <app-netmiko-device-type-select
+            [(value)]="netmikoDeviceType"
+            [controller]="controller"
+            appearance="fill"
+            class="qemu-template-details__field"
+          />
+          <mat-form-field appearance="fill" class="qemu-template-details__field">
+            <mat-label>Default username</mat-label>
+            <input
+              matInput
+              [value]="defaultUsername()"
+              (input)="onCredentialInput('default_username', $event)"
+              type="text"
+              placeholder="Username to log into this node"
+            />
+          </mat-form-field>
+          <mat-form-field appearance="fill" class="qemu-template-details__field">
+            <mat-label>Default password</mat-label>
+            <input
+              matInput
+              [value]="defaultPassword()"
+              (input)="onCredentialInput('default_password', $event)"
+              type="text"
+              placeholder="Password to log into this node"
+            />
+          </mat-form-field>
+        </div>
+
         <mat-checkbox [checked]="consoleAutoStart()" (change)="consoleAutoStart.set($event.checked)"
           >Auto start console</mat-checkbox
         >
@@ -684,6 +713,10 @@
         </mat-form-field>
       </div>
       }
+    </section>
+
+    <section class="qemu-template-details__form-card">
+      <app-template-metadata-section [(metadata)]="applianceMetadata" />
     </section>
 
     <div class="qemu-template-details__actions">

--- a/src/app/components/preferences/qemu/qemu-vm-template-details/qemu-vm-template-details.component.scss
+++ b/src/app/components/preferences/qemu/qemu-vm-template-details/qemu-vm-template-details.component.scss
@@ -82,6 +82,13 @@
     grid-template-columns: 1fr 1fr;
     gap: var(--gns3-density-card-gap);
   }
+
+  .three-column-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 16px;
+    align-items: start;
+  }
 }
 
 .qemu-template-details__field {

--- a/src/app/components/preferences/qemu/qemu-vm-template-details/qemu-vm-template-details.component.spec.ts
+++ b/src/app/components/preferences/qemu/qemu-vm-template-details/qemu-vm-template-details.component.spec.ts
@@ -10,6 +10,7 @@ import { QemuConfigurationService } from '@services/qemu-configuration.service';
 import { ToasterService } from '@services/toaster.service';
 import { QemuValidationService } from '@services/validation';
 import { DialogConfigService } from '@services/dialog-config.service';
+import { NetmikoDeviceTypesService } from '@services/netmiko-device-types.service';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { of, throwError } from 'rxjs';
 import { MatDialog } from '@angular/material/dialog';
@@ -142,6 +143,7 @@ describe('QemuVmTemplateDetailsComponent', () => {
       validateFirstPortName: vi.fn().mockReturnValue({ isValid: true, errorMessage: '' }),
       validatePortSegmentSize: vi.fn().mockReturnValue({ isValid: true, errorMessage: '' }),
       validateMacAddress: vi.fn().mockReturnValue({ isValid: true, errorMessage: '' }),
+      validateNetmikoDeviceType: vi.fn().mockReturnValue({ isValid: true }),
     };
 
     mockQemuConfigurationService = {
@@ -208,6 +210,7 @@ describe('QemuVmTemplateDetailsComponent', () => {
         { provide: DialogConfigService, useValue: mockDialogConfigService },
         { provide: ImageManagerService, useValue: mockImageManagerService },
         { provide: QemuValidationService, useValue: mockValidationService },
+        { provide: NetmikoDeviceTypesService, useValue: { getDeviceTypes: vi.fn().mockReturnValue(of({ deviceTypes: null, netmikoVersion: null })) } },
       ],
     }).compileComponents();
 

--- a/src/app/components/preferences/qemu/qemu-vm-template-details/qemu-vm-template-details.component.ts
+++ b/src/app/components/preferences/qemu/qemu-vm-template-details/qemu-vm-template-details.component.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy, ChangeDetectorRef, OnInit, model, inject } from '@angular/core';
+import { Component, ChangeDetectionStrategy, ChangeDetectorRef, OnInit, model, signal, inject, computed } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
@@ -17,6 +17,13 @@ import { QemuImage } from '@models/qemu/qemu-image';
 import { Image } from '@models/images';
 import { Controller } from '@models/controller';
 import { QemuTemplate } from '@models/templates/qemu-template';
+import { ApplianceMetadata } from '@models/appliance-metadata';
+import { NetmikoDeviceTypeSelectComponent } from '@components/netmiko-device-type-select/netmiko-device-type-select.component';
+import {
+  applianceCredentialValue,
+  ApplianceCredentialField,
+  setApplianceCredential,
+} from '../../template-metadata-section/appliance-metadata-field';
 import { QemuConfigurationService } from '@services/qemu-configuration.service';
 import { QemuService } from '@services/qemu.service';
 import { ControllerService } from '@services/controller.service';
@@ -29,6 +36,7 @@ import {
   CustomAdaptersDialogResult,
 } from '../../common/custom-adapters/custom-adapters.component';
 import { TemplateSymbolDialogComponent } from '@components/project-map/template-symbol-dialog/template-symbol-dialog.component';
+import { TemplateMetadataSectionComponent } from '../../template-metadata-section/template-metadata-section.component';
 import { DialogConfigService } from '@services/dialog-config.service';
 
 @Component({
@@ -52,7 +60,9 @@ import { DialogConfigService } from '@services/dialog-config.service';
     MatSelectModule,
     MatChipsModule,
     MatCheckboxModule,
+    NetmikoDeviceTypeSelectComponent,
     MatAutocompleteModule,
+    TemplateMetadataSectionComponent,
   ],
 })
 export class QemuVmTemplateDetailsComponent implements OnInit {
@@ -150,6 +160,10 @@ export class QemuVmTemplateDetailsComponent implements OnInit {
 
   // Usage & Tags
   usage = model('');
+  netmikoDeviceType = model('');
+  readonly applianceMetadata = signal<ApplianceMetadata | null>(null);
+  readonly defaultUsername = computed(() => applianceCredentialValue(this.applianceMetadata(), 'default_username'));
+  readonly defaultPassword = computed(() => applianceCredentialValue(this.applianceMetadata(), 'default_password'));
   tags = model<string[]>([]);
 
   ngOnInit() {
@@ -262,6 +276,8 @@ export class QemuVmTemplateDetailsComponent implements OnInit {
     this.uefi.set(this.qemuTemplate.uefi || false);
 
     this.usage.set(this.qemuTemplate.usage || '');
+    this.netmikoDeviceType.set(this.qemuTemplate.netmiko_device_type || '');
+    this.applianceMetadata.set(this.qemuTemplate.appliance_metadata ?? null);
     this.tags.set(this.qemuTemplate.tags || []);
   }
 
@@ -443,6 +459,11 @@ export class QemuVmTemplateDetailsComponent implements OnInit {
     this.router.navigate(['/controller', this.controller.id, 'preferences']);
   }
 
+  onCredentialInput(field: ApplianceCredentialField, event: Event) {
+    const value = (event.target as HTMLInputElement).value;
+    this.applianceMetadata.set(setApplianceCredential(this.applianceMetadata(), field, value));
+  }
+
   onSave() {
     const nameValidation = this.validationService.validateName(this.templateName());
     if (!nameValidation.isValid) {
@@ -469,6 +490,8 @@ export class QemuVmTemplateDetailsComponent implements OnInit {
       this.toasterService.error(macValidation.errorMessage);
       return;
     }
+    const netmikoValidation = this.validationService.validateNetmikoDeviceType(this.netmikoDeviceType());
+    if (!netmikoValidation.isValid) { this.toasterService.error(netmikoValidation.errorMessage); return; }
 
     // Update qemuTemplate from model signals
     this.qemuTemplate.name = this.templateName();
@@ -518,6 +541,8 @@ export class QemuVmTemplateDetailsComponent implements OnInit {
     this.qemuTemplate.uefi = this.uefi();
 
     this.qemuTemplate.usage = this.usage();
+    this.qemuTemplate.netmiko_device_type = this.netmikoDeviceType().trim() || null;
+    this.qemuTemplate.appliance_metadata = this.applianceMetadata();
     this.qemuTemplate.tags = this.tags();
 
     // Custom adapters are already managed through the dialog (incremental save)

--- a/src/app/components/preferences/template-metadata-section/appliance-metadata-field.spec.ts
+++ b/src/app/components/preferences/template-metadata-section/appliance-metadata-field.spec.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { ApplianceMetadata } from '@models/appliance-metadata';
+import { applianceCredentialValue, setApplianceCredential } from './appliance-metadata-field';
+
+/** Field-level updates behind the template details General settings credential inputs. */
+describe('appliance-metadata-field', () => {
+  it('reads null/absent credentials as empty strings', () => {
+    expect(applianceCredentialValue(null, 'default_username')).toBe('');
+    expect(applianceCredentialValue({ default_username: null }, 'default_username')).toBe('');
+    expect(applianceCredentialValue({}, 'default_password')).toBe('');
+    expect(applianceCredentialValue({ default_username: 'vyos' }, 'default_username')).toBe('vyos');
+  });
+
+  it('sets the one key and preserves everything else', () => {
+    const current: ApplianceMetadata = { vendor_name: 'Vendor', appliance_id: 'abc', default_password: 's3cret' };
+
+    const next = setApplianceCredential(current, 'default_username', 'root')!;
+    expect(next['default_username']).toBe('root');
+    expect(next['vendor_name']).toBe('Vendor');
+    expect(next['appliance_id']).toBe('abc');
+    expect(next['default_password']).toBe('s3cret');
+    expect(current['default_username']).toBeUndefined(); // input not mutated
+  });
+
+  it('drops the key when the value is empty', () => {
+    const next = setApplianceCredential({ default_username: 'root', vendor_name: 'Vendor' }, 'default_username', '  ')!;
+
+    expect(next['default_username']).toBeUndefined();
+    expect(next['vendor_name']).toBe('Vendor');
+  });
+
+  it('yields null when clearing the last key (PUT null semantics)', () => {
+    expect(setApplianceCredential({ default_username: 'root' }, 'default_username', '')).toBeNull();
+    expect(setApplianceCredential(null, 'default_password', '')).toBeNull();
+  });
+});

--- a/src/app/components/preferences/template-metadata-section/appliance-metadata-field.ts
+++ b/src/app/components/preferences/template-metadata-section/appliance-metadata-field.ts
@@ -1,0 +1,29 @@
+import { ApplianceMetadata } from '@models/appliance-metadata';
+
+/** Credential keys edited in the template details General settings section. */
+export type ApplianceCredentialField = 'default_username' | 'default_password';
+
+/** Read a credential for an input's [value]; null/absent render as ''. */
+export function applianceCredentialValue(metadata: ApplianceMetadata | null, field: ApplianceCredentialField): string {
+  const value = metadata?.[field];
+  return value === undefined || value === null || value === '' ? '' : String(value);
+}
+
+/**
+ * Field-level update behind the General settings credential inputs: clone the
+ * current metadata, set (or drop, when empty) the one key, preserve everything
+ * else. An all-empty object becomes null (the server's clear semantics).
+ */
+export function setApplianceCredential(
+  current: ApplianceMetadata | null,
+  field: ApplianceCredentialField,
+  value: string
+): ApplianceMetadata | null {
+  const next: { [key: string]: unknown } = { ...(current || {}) };
+  if (value.trim() !== '') {
+    next[field] = value;
+  } else {
+    delete next[field];
+  }
+  return Object.keys(next).length > 0 ? (next as ApplianceMetadata) : null;
+}

--- a/src/app/components/preferences/template-metadata-section/template-metadata-section.component.html
+++ b/src/app/components/preferences/template-metadata-section/template-metadata-section.component.html
@@ -1,9 +1,4 @@
 <div class="template-metadata">
-  <div class="template-metadata__section-header" (click)="toggle()">
-    <h3 class="template-metadata__section-title">Appliance metadata</h3>
-    <mat-icon class="template-metadata__expand-icon">{{ expanded() ? 'expand_less' : 'expand_more' }}</mat-icon>
-  </div>
-  @if (expanded()) {
   <div class="template-metadata__form">
     <div class="template-metadata__two-column-grid">
       @for (entry of fields; track entry.field) {
@@ -50,5 +45,4 @@
       </button>
     </div>
   </div>
-  }
 </div>

--- a/src/app/components/preferences/template-metadata-section/template-metadata-section.component.html
+++ b/src/app/components/preferences/template-metadata-section/template-metadata-section.component.html
@@ -1,0 +1,54 @@
+<div class="template-metadata">
+  <div class="template-metadata__section-header" (click)="toggle()">
+    <h3 class="template-metadata__section-title">Appliance metadata</h3>
+    <mat-icon class="template-metadata__expand-icon">{{ expanded() ? 'expand_less' : 'expand_more' }}</mat-icon>
+  </div>
+  @if (expanded()) {
+  <div class="template-metadata__form">
+    <div class="template-metadata__two-column-grid">
+      @for (entry of fields; track entry.field) {
+      <mat-form-field
+        appearance="fill"
+        class="template-metadata__field"
+        [class.template-metadata__field--full]="entry.multiline"
+      >
+        <mat-label>{{ entry.label }}</mat-label>
+        @if (entry.multiline) {
+        <textarea
+          matInput
+          rows="3"
+          [value]="formValues()[entry.field] || ''"
+          (input)="onInput(entry.field, $event)"
+          [placeholder]="entry.placeholder || ''"
+        ></textarea>
+        } @else {
+        <input
+          matInput
+          type="text"
+          [value]="formValues()[entry.field] || ''"
+          (input)="onInput(entry.field, $event)"
+          [placeholder]="entry.placeholder || ''"
+        />
+        }
+        @if (entry.copy && text(entry.field)) {
+        <button mat-icon-button matSuffix type="button" matTooltip="Copy {{ entry.label }}" (click)="copy(entry.field, entry.label)">
+          <mat-icon>content_copy</mat-icon>
+        </button>
+        }
+        @if (entry.link && text(entry.field)) {
+        <button mat-icon-button matSuffix type="button" matTooltip="Open link" (click)="openLink(entry.field)">
+          <mat-icon>open_in_new</mat-icon>
+        </button>
+        }
+      </mat-form-field>
+      }
+    </div>
+    <div class="template-metadata__actions">
+      <button mat-button type="button" (click)="remove()">
+        <mat-icon>delete</mat-icon>
+        Remove metadata
+      </button>
+    </div>
+  </div>
+  }
+</div>

--- a/src/app/components/preferences/template-metadata-section/template-metadata-section.component.scss
+++ b/src/app/components/preferences/template-metadata-section/template-metadata-section.component.scss
@@ -1,0 +1,68 @@
+/**
+ * Appliance metadata section — styled after the template details dialogs'
+ * collapsible form sections. The card surface is provided by the host
+ * dialog's __form-card wrapper.
+ */
+.template-metadata {
+  display: block;
+
+  &__section-header {
+    padding: 16px 24px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    cursor: pointer;
+    transition: background-color 0.2s ease;
+    border-bottom: 1px solid color-mix(in srgb, var(--mat-sys-outline) 30%, transparent);
+
+    &:hover {
+      background-color: color-mix(in srgb, var(--mat-sys-on-surface) 5%, transparent);
+    }
+  }
+
+  &__section-title {
+    margin: 0;
+    font-size: 16px;
+    font-weight: 500;
+    color: var(--mat-sys-on-surface-variant);
+  }
+
+  &__expand-icon {
+    color: var(--mat-sys-on-surface-variant);
+    transition: transform 0.2s ease;
+  }
+
+  &__form {
+    padding: 16px 24px 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+
+  &__two-column-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 16px;
+  }
+
+  &__field {
+    width: 100%;
+
+    &--full {
+      grid-column: 1 / -1;
+    }
+  }
+
+  &__actions {
+    display: flex;
+    justify-content: flex-end;
+  }
+}
+
+@media (max-width: 768px) {
+  .template-metadata {
+    &__two-column-grid {
+      grid-template-columns: 1fr;
+    }
+  }
+}

--- a/src/app/components/preferences/template-metadata-section/template-metadata-section.component.scss
+++ b/src/app/components/preferences/template-metadata-section/template-metadata-section.component.scss
@@ -1,36 +1,9 @@
 /**
- * Appliance metadata section — styled after the template details dialogs'
- * collapsible form sections. The card surface is provided by the host
- * dialog's __form-card wrapper.
+ * Appliance metadata form — the card surface and section header come from the
+ * host page's __form-card section (Metadata tab).
  */
 .template-metadata {
   display: block;
-
-  &__section-header {
-    padding: 16px 24px;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    cursor: pointer;
-    transition: background-color 0.2s ease;
-    border-bottom: 1px solid color-mix(in srgb, var(--mat-sys-outline) 30%, transparent);
-
-    &:hover {
-      background-color: color-mix(in srgb, var(--mat-sys-on-surface) 5%, transparent);
-    }
-  }
-
-  &__section-title {
-    margin: 0;
-    font-size: 16px;
-    font-weight: 500;
-    color: var(--mat-sys-on-surface-variant);
-  }
-
-  &__expand-icon {
-    color: var(--mat-sys-on-surface-variant);
-    transition: transform 0.2s ease;
-  }
 
   &__form {
     padding: 16px 24px 24px;

--- a/src/app/components/preferences/template-metadata-section/template-metadata-section.component.spec.ts
+++ b/src/app/components/preferences/template-metadata-section/template-metadata-section.component.spec.ts
@@ -1,0 +1,131 @@
+import { Component, signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { TemplateMetadataSectionComponent } from './template-metadata-section.component';
+import { ApplianceMetadata } from '@models/appliance-metadata';
+
+/** Host binding [(metadata)] to a parent signal, like the details dialogs do. */
+@Component({
+  standalone: true,
+  imports: [TemplateMetadataSectionComponent],
+  template: '<app-template-metadata-section [(metadata)]="metadata" />',
+})
+class HostComponent {
+  readonly metadata = signal<ApplianceMetadata | null>(null);
+}
+
+describe('TemplateMetadataSectionComponent', () => {
+  let fixture: ComponentFixture<HostComponent>;
+  let host: HostComponent;
+  let comp: TemplateMetadataSectionComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [HostComponent],
+      providers: [{ provide: MatSnackBar, useValue: { open: vi.fn() } }],
+    }).compileComponents();
+    fixture = TestBed.createComponent(HostComponent);
+    host = fixture.componentInstance;
+    comp = fixture.debugElement.query((e) => e.componentInstance instanceof TemplateMetadataSectionComponent)
+      .componentInstance as TemplateMetadataSectionComponent;
+    fixture.detectChanges();
+  });
+
+  it('starts collapsed like the other template sections', () => {
+    expect(comp.expanded()).toBe(false);
+  });
+
+  it('syncs the form when the parent loads a template (external metadata set)', () => {
+    host.metadata.set({ vendor_name: 'Vendor', default_username: 'vyos' });
+    fixture.detectChanges();
+
+    expect(comp.formValues()['vendor_name']).toBe('Vendor');
+    expect(comp.formValues()['description']).toBe('');
+    // credentials are edited in the General settings section, not this form
+    expect(comp.formValues()['default_username']).toBeUndefined();
+  });
+
+  it('treats null materialized keys like missing ones', () => {
+    // the server response materializes every known key as null
+    host.metadata.set({ vendor_name: 'Vendor', description: null, maintainer: null });
+    fixture.detectChanges();
+
+    expect(comp.text('vendor_name')).toBe('Vendor');
+    expect(comp.text('description')).toBe('');
+    expect(comp.text('maintainer')).toBe('');
+  });
+
+  it('rebuilds the object on input: non-empty known fields only', () => {
+    host.metadata.set({ vendor_name: 'Vendor' });
+    fixture.detectChanges();
+
+    comp.setField('vendor_name', 'Vendor2');
+    comp.setField('description', '   ');
+
+    const result = host.metadata()! as { [key: string]: unknown };
+    expect(result['vendor_name']).toBe('Vendor2');
+    // whitespace-only fields are dropped (whole-object replace semantics)
+    expect(result['description']).toBeUndefined();
+  });
+
+  it('preserves credentials edited in the General settings section (not owned by this form)', () => {
+    host.metadata.set({ vendor_name: 'Vendor', default_username: 'root', default_password: 's3cret' });
+    fixture.detectChanges();
+
+    comp.setField('vendor_name', 'Vendor2');
+
+    const result = host.metadata()! as { [key: string]: unknown };
+    expect(result['vendor_name']).toBe('Vendor2');
+    expect(result['default_username']).toBe('root'); // not wiped by the rebuild
+    expect(result['default_password']).toBe('s3cret');
+  });
+
+  it('preserves unknown keys passed through by the server', () => {
+    host.metadata.set({ vendor_name: 'Vendor', future_key: { nested: true } } as ApplianceMetadata);
+    fixture.detectChanges();
+
+    comp.setField('vendor_name', 'Vendor2');
+
+    const result = host.metadata()! as { [key: string]: unknown };
+    expect(result['vendor_name']).toBe('Vendor2');
+    expect(result['future_key']).toEqual({ nested: true }); // preserved untouched
+  });
+
+  it('keeps appliance_id on rebuild', () => {
+    host.metadata.set({ appliance_id: 'abc', vendor_name: 'Vendor' });
+    fixture.detectChanges();
+
+    comp.setField('vendor_name', 'Vendor2');
+
+    expect((host.metadata()! as { [key: string]: unknown })['appliance_id']).toBe('abc');
+  });
+
+  it('clearing every field yields null (PUT null semantics)', () => {
+    host.metadata.set({ vendor_name: 'Vendor' });
+    fixture.detectChanges();
+
+    comp.setField('vendor_name', '');
+
+    expect(host.metadata()).toBeNull();
+  });
+
+  it('remove clears the whole metadata and the form', () => {
+    host.metadata.set({ vendor_name: 'Vendor', default_username: 'vyos' });
+    fixture.detectChanges();
+
+    comp.remove();
+
+    expect(host.metadata()).toBeNull();
+    expect(comp.formValues()['vendor_name']).toBe('');
+  });
+
+  it('external reload after edits resyncs the form', () => {
+    comp.setField('vendor_name', 'Typed');
+
+    host.metadata.set({ vendor_name: 'Reloaded' });
+    fixture.detectChanges();
+
+    expect(comp.formValues()['vendor_name']).toBe('Reloaded');
+  });
+});

--- a/src/app/components/preferences/template-metadata-section/template-metadata-section.component.spec.ts
+++ b/src/app/components/preferences/template-metadata-section/template-metadata-section.component.spec.ts
@@ -32,8 +32,11 @@ describe('TemplateMetadataSectionComponent', () => {
     fixture.detectChanges();
   });
 
-  it('starts collapsed like the other template sections', () => {
-    expect(comp.expanded()).toBe(false);
+  it('renders the edit form fields when mounted (hosted in the Metadata tab)', () => {
+    const text = (fixture.nativeElement as HTMLElement).textContent || '';
+    expect(text).toContain('Description');
+    expect(text).toContain('Vendor name');
+    expect(text).toContain('Remove metadata');
   });
 
   it('syncs the form when the parent loads a template (external metadata set)', () => {

--- a/src/app/components/preferences/template-metadata-section/template-metadata-section.component.ts
+++ b/src/app/components/preferences/template-metadata-section/template-metadata-section.component.ts
@@ -1,0 +1,179 @@
+import { ChangeDetectionStrategy, Component, effect, inject, model, signal } from '@angular/core';
+import { Clipboard } from '@angular/cdk/clipboard';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { ApplianceMetadata } from '@models/appliance-metadata';
+
+/** Metadata keys this section's form owns. appliance_id is read-only; the credential keys are edited in the General settings section and only preserved here. */
+type KnownField =
+  | 'description'
+  | 'vendor_name'
+  | 'vendor_url'
+  | 'vendor_logo_url'
+  | 'documentation_url'
+  | 'product_name'
+  | 'product_url'
+  | 'status'
+  | 'availability'
+  | 'maintainer'
+  | 'maintainer_email'
+  | 'installation_instructions';
+
+/** Form fields with their labels; link fields get an open-in-new suffix. */
+const FORM_FIELDS: {
+  field: KnownField;
+  label: string;
+  multiline?: boolean;
+  link?: boolean;
+  copy?: boolean;
+  placeholder?: string;
+}[] = [
+  { field: 'description', label: 'Description', multiline: true },
+  { field: 'vendor_name', label: 'Vendor name' },
+  { field: 'vendor_url', label: 'Vendor URL', link: true, placeholder: 'https://…' },
+  { field: 'vendor_logo_url', label: 'Vendor logo URL', link: true, placeholder: 'https://…' },
+  { field: 'documentation_url', label: 'Documentation URL', link: true, placeholder: 'https://…' },
+  { field: 'product_name', label: 'Product name' },
+  { field: 'product_url', label: 'Product URL', link: true, placeholder: 'https://…' },
+  { field: 'status', label: 'Status', placeholder: 'stable / experimental / broken' },
+  { field: 'availability', label: 'Availability', placeholder: 'free / service-contract / …' },
+  { field: 'maintainer', label: 'Maintainer' },
+  { field: 'maintainer_email', label: 'Maintainer email' },
+  { field: 'installation_instructions', label: 'Installation instructions', multiline: true },
+];
+
+/**
+ * Appliance metadata section for the template details dialogs, styled after
+ * their collapsible form sections (section header + expand icon, fill form
+ * fields in a two-column grid).
+ *
+ * The server semantics are whole-object replacement (PUT with the field
+ * replaces, without it preserves, null clears), so this component owns the
+ * read-modify-write: every input rebuilds the object from its own form
+ * fields and PRESERVES every key it does not own — the credentials edited
+ * in the General settings section, unknown/future keys the server may have
+ * passed through — they are never shown or stripped here. Empty fields drop
+ * their key; when everything is empty the model becomes null (clear). Null
+ * and absent values behave identically (the server materializes unset keys
+ * as null).
+ *
+ * Two-way bound via [(metadata)] to the parent dialog's signal; the parent
+ * assigns it back onto the template object when saving.
+ */
+@Component({
+  selector: 'app-template-metadata-section',
+  standalone: true,
+  templateUrl: 'template-metadata-section.component.html',
+  styleUrls: ['template-metadata-section.component.scss'],
+  imports: [MatButtonModule, MatFormFieldModule, MatIconModule, MatInputModule, MatTooltipModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class TemplateMetadataSectionComponent {
+  readonly metadata = model<ApplianceMetadata | null>(null);
+
+  readonly fields = FORM_FIELDS;
+  readonly expanded = signal(false);
+  /** Edit-form values keyed by field name, synced from the metadata model. */
+  readonly formValues = signal<{ [field: string]: string }>({});
+
+  private readonly clipboard = inject(Clipboard);
+  private readonly snackBar = inject(MatSnackBar);
+  /** The object our own rebuild last emitted — distinguishes external metadata changes from ours. */
+  private lastEmitted: ApplianceMetadata | null | undefined;
+
+  constructor() {
+    // Sync the form when the parent loads/reloads a template (external metadata set);
+    // our own rebuilds are recognized by reference and don't reset the form.
+    effect(() => {
+      const metadata = this.metadata();
+      if (metadata !== this.lastEmitted) {
+        this.syncForm(metadata);
+      }
+    });
+  }
+
+  toggle() {
+    this.expanded.update((value) => !value);
+  }
+
+  isTruthy(value: unknown): boolean {
+    return value !== undefined && value !== null && value !== '';
+  }
+
+  text(field: KnownField): string {
+    const value = this.metadata()?.[field];
+    return this.isTruthy(value) ? String(value) : '';
+  }
+
+  openLink(field: KnownField) {
+    const url = this.text(field);
+    if (url) {
+      window.open(url, '_blank', 'noopener,noreferrer');
+    }
+  }
+
+  copy(field: KnownField, label: string) {
+    const value = this.text(field);
+    if (!value) return;
+    if (this.clipboard.copy(value)) {
+      this.snackBar.open(`${label} copied to clipboard`, 'Close', { duration: 3000 });
+    } else {
+      this.snackBar.open(`Failed to copy. Please copy the ${label.toLowerCase()} manually.`, 'Close', { duration: 5000 });
+    }
+  }
+
+  onInput(field: string, event: Event) {
+    const value = (event.target as HTMLInputElement | HTMLTextAreaElement).value;
+    this.setField(field, value);
+  }
+
+  setField(field: string, value: string) {
+    this.formValues.update((values) => ({ ...values, [field]: value }));
+    const rebuilt = this.rebuild();
+    this.lastEmitted = rebuilt;
+    this.metadata.set(rebuilt);
+  }
+
+  /** Clears the whole metadata (PUT null semantics) and empties the form. */
+  remove() {
+    this.lastEmitted = null;
+    this.metadata.set(null);
+    this.syncForm(null);
+  }
+
+  /** Rebuild the whole object: non-empty form fields + keys the form does not own, preserved untouched. */
+  private rebuild(): ApplianceMetadata | null {
+    const previous = this.metadata();
+    const next: { [key: string]: unknown } = {};
+    const values = this.formValues();
+    for (const { field } of FORM_FIELDS) {
+      const value = (values[field] || '').trim();
+      if (value !== '') {
+        next[field] = value;
+      }
+    }
+    if (previous) {
+      for (const [key, value] of Object.entries(previous)) {
+        if (key === 'appliance_id') {
+          if (this.isTruthy(value)) next[key] = value;
+        } else if (!FORM_FIELDS.some((entry) => entry.field === key) && this.isTruthy(value)) {
+          next[key] = value; // not owned by this form (credentials from General settings, unknown/future keys) — preserved untouched
+        }
+      }
+    }
+    return Object.keys(next).length > 0 ? (next as ApplianceMetadata) : null;
+  }
+
+  private syncForm(metadata: ApplianceMetadata | null) {
+    const values: { [field: string]: string } = {};
+    for (const { field } of FORM_FIELDS) {
+      const value = metadata?.[field];
+      values[field] = this.isTruthy(value) ? String(value) : '';
+    }
+    this.formValues.set(values);
+  }
+}

--- a/src/app/components/preferences/template-metadata-section/template-metadata-section.component.ts
+++ b/src/app/components/preferences/template-metadata-section/template-metadata-section.component.ts
@@ -47,9 +47,10 @@ const FORM_FIELDS: {
 ];
 
 /**
- * Appliance metadata section for the template details dialogs, styled after
- * their collapsible form sections (section header + expand icon, fill form
- * fields in a two-column grid).
+ * Appliance metadata form for the template details pages' Metadata tab. The
+ * host page provides the __form-card surface and section header, and mounts
+ * this component only while its tab is active; this component renders just
+ * the edit form (fields in a two-column grid).
  *
  * The server semantics are whole-object replacement (PUT with the field
  * replaces, without it preserves, null clears), so this component owns the
@@ -76,7 +77,6 @@ export class TemplateMetadataSectionComponent {
   readonly metadata = model<ApplianceMetadata | null>(null);
 
   readonly fields = FORM_FIELDS;
-  readonly expanded = signal(false);
   /** Edit-form values keyed by field name, synced from the metadata model. */
   readonly formValues = signal<{ [field: string]: string }>({});
 
@@ -94,10 +94,6 @@ export class TemplateMetadataSectionComponent {
         this.syncForm(metadata);
       }
     });
-  }
-
-  toggle() {
-    this.expanded.update((value) => !value);
   }
 
   isTruthy(value: unknown): boolean {

--- a/src/app/components/preferences/vpcs/add-vpcs-template/add-vpcs-template.component.html
+++ b/src/app/components/preferences/vpcs/add-vpcs-template/add-vpcs-template.component.html
@@ -46,6 +46,12 @@
                 <input matInput required formControlName="templateName" type="text" placeholder="Template name" />
               </mat-form-field>
             </form>
+            <app-netmiko-device-type-select
+              [(value)]="netmikoDeviceType"
+              [controller]="controller"
+              appearance="outline"
+              class="vpcs-add__field"
+            />
             <app-template-info-fields [(usage)]="usage" [(symbol)]="symbol"></app-template-info-fields>
           </section>
         </section>

--- a/src/app/components/preferences/vpcs/add-vpcs-template/add-vpcs-template.component.spec.ts
+++ b/src/app/components/preferences/vpcs/add-vpcs-template/add-vpcs-template.component.spec.ts
@@ -6,6 +6,7 @@ import { VpcsService } from '@services/vpcs.service';
 import { ControllerService } from '@services/controller.service';
 import { TemplateMocksService } from '@services/template-mocks.service';
 import { ToasterService } from '@services/toaster.service';
+import { NetmikoDeviceTypesService } from '@services/netmiko-device-types.service';
 import { VpcsTemplate } from '@models/templates/vpcs-template';
 import { Controller } from '@models/controller';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
@@ -92,6 +93,7 @@ describe('AddVpcsTemplateComponent', () => {
         { provide: VpcsService, useValue: mockVpcsService },
         { provide: TemplateMocksService, useValue: mockTemplateMocksService },
         { provide: ToasterService, useValue: mockToasterService },
+        { provide: NetmikoDeviceTypesService, useValue: { getDeviceTypes: vi.fn().mockReturnValue(of({ deviceTypes: null, netmikoVersion: null })) } },
       ],
     }).compileComponents();
 

--- a/src/app/components/preferences/vpcs/add-vpcs-template/add-vpcs-template.component.ts
+++ b/src/app/components/preferences/vpcs/add-vpcs-template/add-vpcs-template.component.ts
@@ -14,10 +14,12 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { v4 as uuid } from 'uuid';
 import { Controller } from '@models/controller';
+import { NetmikoDeviceTypeSelectComponent } from '@components/netmiko-device-type-select/netmiko-device-type-select.component';
 import { VpcsTemplate } from '@models/templates/vpcs-template';
 import { ControllerService } from '@services/controller.service';
 import { TemplateMocksService } from '@services/template-mocks.service';
 import { ToasterService } from '@services/toaster.service';
+import { ValidationService } from '@services/validation';
 import { VpcsService } from '@services/vpcs.service';
 import { TemplateInfoFieldsComponent } from '../../common/template-info-fields/template-info-fields.component';
 
@@ -28,6 +30,7 @@ import { TemplateInfoFieldsComponent } from '../../common/template-info-fields/t
   templateUrl: './add-vpcs-template.component.html',
   styleUrls: ['./add-vpcs-template.component.scss', '../../preferences.component.scss'],
   imports: [
+    NetmikoDeviceTypeSelectComponent,
     ReactiveFormsModule,
     MatIconModule,
     MatButtonModule,
@@ -43,6 +46,7 @@ export class AddVpcsTemplateComponent implements OnInit {
   private vpcsService = inject(VpcsService);
   private router = inject(Router);
   private toasterService = inject(ToasterService);
+  private validationService = inject(ValidationService);
   private templateMocksService = inject(TemplateMocksService);
   private formBuilder = inject(UntypedFormBuilder);
   private cd = inject(ChangeDetectorRef);
@@ -50,6 +54,7 @@ export class AddVpcsTemplateComponent implements OnInit {
   controller?: Controller;
   templateName: string = '';
   templateNameForm: UntypedFormGroup;
+  netmikoDeviceType: string = '';
   isLocalComputerChosen: boolean = true;
   usage = model('');
   symbol = model('vpcs_guest');
@@ -90,12 +95,19 @@ export class AddVpcsTemplateComponent implements OnInit {
     if (!this.templateNameForm.invalid && this.controller) {
       this.templateName = this.templateNameForm.get('templateName').value;
 
+      const netmikoValidation = this.validationService.validateNetmikoDeviceType(this.netmikoDeviceType);
+      if (!netmikoValidation.isValid) {
+        this.toasterService.error(netmikoValidation.errorMessage);
+        return;
+      }
+
       this.templateMocksService.getVpcsTemplate().subscribe({
         next: (template: VpcsTemplate) => {
           const vpcsTemplate = template;
           vpcsTemplate.template_id = uuid();
           vpcsTemplate.name = this.templateName;
           vpcsTemplate.compute_id = 'local';
+          vpcsTemplate.netmiko_device_type = this.netmikoDeviceType.trim() || null;
           vpcsTemplate.usage = this.usage();
           vpcsTemplate.symbol = this.symbol();
 

--- a/src/app/components/preferences/vpcs/vpcs-template-details/vpcs-template-details.component.html
+++ b/src/app/components/preferences/vpcs/vpcs-template-details/vpcs-template-details.component.html
@@ -119,6 +119,35 @@
           </mat-select>
         </mat-form-field>
 
+        <div class="three-column-grid">
+          <app-netmiko-device-type-select
+            [(value)]="netmikoDeviceType"
+            [controller]="controller"
+            appearance="fill"
+            class="vpcs-template-details__field"
+          />
+          <mat-form-field appearance="fill" class="vpcs-template-details__field">
+            <mat-label>Default username</mat-label>
+            <input
+              matInput
+              [value]="defaultUsername()"
+              (input)="onCredentialInput('default_username', $event)"
+              type="text"
+              placeholder="Username to log into this node"
+            />
+          </mat-form-field>
+          <mat-form-field appearance="fill" class="vpcs-template-details__field">
+            <mat-label>Default password</mat-label>
+            <input
+              matInput
+              [value]="defaultPassword()"
+              (input)="onCredentialInput('default_password', $event)"
+              type="text"
+              placeholder="Password to log into this node"
+            />
+          </mat-form-field>
+        </div>
+
         <mat-checkbox [checked]="consoleAutoStart()" (change)="consoleAutoStart.set($event.checked)"
           >Auto start console</mat-checkbox
         >
@@ -135,6 +164,9 @@
       </div>
     </section>
 
+    <section class="vpcs-template-details__form-card">
+      <app-template-metadata-section [(metadata)]="applianceMetadata" />
+    </section>
     <div class="vpcs-template-details__actions">
       <button class="vpcs-template-details__cancel-btn" (click)="goBack()" mat-button>Cancel</button>
       <button mat-raised-button color="primary" class="vpcs-template-details__save-btn" (click)="onSave()">Save</button>

--- a/src/app/components/preferences/vpcs/vpcs-template-details/vpcs-template-details.component.html
+++ b/src/app/components/preferences/vpcs/vpcs-template-details/vpcs-template-details.component.html
@@ -24,6 +24,9 @@
       <button type="button" [class.is-active]="activeSection === 'usage'" (click)="selectSection('usage')">
         Usage
       </button>
+      <button type="button" [class.is-active]="activeSection === 'metadata'" (click)="selectSection('metadata')">
+        Metadata
+      </button>
     </nav>
     <section class="vpcs-template-details__form-card" [class.template-edit-panel-active]="activeSection === 'general'">
       <h3 class="vpcs-template-details__section-title">General settings</h3>
@@ -164,7 +167,8 @@
       </div>
     </section>
 
-    <section class="vpcs-template-details__form-card">
+    <section class="vpcs-template-details__form-card" [class.template-edit-panel-active]="activeSection === 'metadata'">
+      <h3 class="vpcs-template-details__section-title">Appliance metadata</h3>
       <app-template-metadata-section [(metadata)]="applianceMetadata" />
     </section>
     <div class="vpcs-template-details__actions">

--- a/src/app/components/preferences/vpcs/vpcs-template-details/vpcs-template-details.component.scss
+++ b/src/app/components/preferences/vpcs/vpcs-template-details/vpcs-template-details.component.scss
@@ -76,6 +76,13 @@
   display: flex;
   flex-direction: column;
   gap: var(--gns3-density-card-gap);
+
+  .three-column-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 16px;
+    align-items: start;
+  }
 }
 
 .vpcs-template-details__field {

--- a/src/app/components/preferences/vpcs/vpcs-template-details/vpcs-template-details.component.ts
+++ b/src/app/components/preferences/vpcs/vpcs-template-details/vpcs-template-details.component.ts
@@ -73,7 +73,7 @@ export class VpcsTemplateDetailsComponent implements OnInit {
   readonly separatorKeysCodes: number[] = [ENTER, COMMA];
   consoleTypes: string[] = [];
   categories = [];
-  activeSection: 'general' | 'usage' = 'general';
+  activeSection: 'general' | 'usage' | 'metadata' = 'general';
 
   // Model signals for form fields
   templateName = model('');
@@ -237,7 +237,7 @@ export class VpcsTemplateDetailsComponent implements OnInit {
     }
   }
 
-  selectSection(section: 'general' | 'usage'): void {
+  selectSection(section: 'general' | 'usage' | 'metadata'): void {
     this.activeSection = section;
   }
 }

--- a/src/app/components/preferences/vpcs/vpcs-template-details/vpcs-template-details.component.ts
+++ b/src/app/components/preferences/vpcs/vpcs-template-details/vpcs-template-details.component.ts
@@ -1,4 +1,4 @@
-import { Component, ChangeDetectionStrategy, ChangeDetectorRef, OnInit, model, inject } from '@angular/core';
+import { Component, ChangeDetectionStrategy, ChangeDetectorRef, OnInit, model, inject, signal, computed } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
@@ -14,12 +14,21 @@ import { MatDialog } from '@angular/material/dialog';
 import { COMMA, ENTER } from '@angular/cdk/keycodes';
 import { Controller } from '@models/controller';
 import { VpcsTemplate } from '@models/templates/vpcs-template';
+import { ApplianceMetadata } from '@models/appliance-metadata';
+import { NetmikoDeviceTypeSelectComponent } from '@components/netmiko-device-type-select/netmiko-device-type-select.component';
+import {
+  applianceCredentialValue,
+  ApplianceCredentialField,
+  setApplianceCredential,
+} from '../../template-metadata-section/appliance-metadata-field';
 import { ControllerService } from '@services/controller.service';
 import { ToasterService } from '@services/toaster.service';
 import { VpcsConfigurationService } from '@services/vpcs-configuration.service';
 import { VpcsService } from '@services/vpcs.service';
 import { TemplateSymbolDialogComponent } from '@components/project-map/template-symbol-dialog/template-symbol-dialog.component';
+import { TemplateMetadataSectionComponent } from '../../template-metadata-section/template-metadata-section.component';
 import { DialogConfigService } from '@services/dialog-config.service';
+import { ValidationService } from '@services/validation';
 
 @Component({
   standalone: true,
@@ -37,11 +46,13 @@ import { DialogConfigService } from '@services/dialog-config.service';
     RouterModule,
     MatIconModule,
     MatButtonModule,
+    TemplateMetadataSectionComponent,
     MatCardModule,
     MatFormFieldModule,
     MatInputModule,
     MatSelectModule,
     MatCheckboxModule,
+    NetmikoDeviceTypeSelectComponent,
     MatChipsModule,
   ],
 })
@@ -55,6 +66,7 @@ export class VpcsTemplateDetailsComponent implements OnInit {
   private cd = inject(ChangeDetectorRef);
   private dialog = inject(MatDialog);
   private dialogConfig = inject(DialogConfigService);
+  private validationService = inject(ValidationService);
 
   controller: Controller;
   vpcsTemplate: VpcsTemplate;
@@ -71,6 +83,10 @@ export class VpcsTemplateDetailsComponent implements OnInit {
   category = model('');
   consoleType = model('');
   consoleAutoStart = model(false);
+  netmikoDeviceType = model('');
+  readonly applianceMetadata = signal<ApplianceMetadata | null>(null);
+  readonly defaultUsername = computed(() => applianceCredentialValue(this.applianceMetadata(), 'default_username'));
+  readonly defaultPassword = computed(() => applianceCredentialValue(this.applianceMetadata(), 'default_password'));
 
   // Usage & Tags
   tags = model<string[]>([]);
@@ -119,6 +135,8 @@ export class VpcsTemplateDetailsComponent implements OnInit {
     this.consoleAutoStart.set(this.vpcsTemplate.console_auto_start || false);
     this.tags.set(this.vpcsTemplate.tags || []);
     this.usage.set(this.vpcsTemplate.usage || '');
+    this.netmikoDeviceType.set(this.vpcsTemplate.netmiko_device_type || '');
+    this.applianceMetadata.set(this.vpcsTemplate.appliance_metadata ?? null);
   }
 
   getConfiguration() {
@@ -128,6 +146,11 @@ export class VpcsTemplateDetailsComponent implements OnInit {
 
   goBack() {
     this.router.navigate(['/controller', this.controller.id, 'preferences']);
+  }
+
+  onCredentialInput(field: ApplianceCredentialField, event: Event) {
+    const value = (event.target as HTMLInputElement).value;
+    this.applianceMetadata.set(setApplianceCredential(this.applianceMetadata(), field, value));
   }
 
   onSave() {
@@ -141,6 +164,12 @@ export class VpcsTemplateDetailsComponent implements OnInit {
       return;
     }
 
+    const netmikoValidation = this.validationService.validateNetmikoDeviceType(this.netmikoDeviceType());
+    if (!netmikoValidation.isValid) {
+      this.toasterService.error(netmikoValidation.errorMessage);
+      return;
+    }
+
     // Update vpcsTemplate from model signals
     this.vpcsTemplate.name = this.templateName();
     this.vpcsTemplate.default_name_format = this.defaultName();
@@ -151,6 +180,8 @@ export class VpcsTemplateDetailsComponent implements OnInit {
     this.vpcsTemplate.console_auto_start = this.consoleAutoStart();
     this.vpcsTemplate.tags = this.tags();
     this.vpcsTemplate.usage = this.usage();
+    this.vpcsTemplate.netmiko_device_type = this.netmikoDeviceType().trim() || null;
+    this.vpcsTemplate.appliance_metadata = this.applianceMetadata();
 
     this.vpcsService.saveTemplate(this.controller, this.vpcsTemplate).subscribe({
       next: () => {

--- a/src/app/components/project-map/change-hostname-dialog/change-hostname-dialog.component.html
+++ b/src/app/components/project-map/change-hostname-dialog/change-hostname-dialog.component.html
@@ -10,5 +10,11 @@
 
 <div mat-dialog-actions>
   <button mat-button (click)="onCancelClick()" color="accent">Cancel</button>
-  <button mat-raised-button color="primary" (click)="onSaveClick()">Apply</button>
+  <button mat-raised-button color="primary" (click)="onSaveClick()" [disabled]="isApplying()">
+    @if (isApplying()) {
+      <mat-spinner diameter="20"></mat-spinner>
+    } @else {
+      Apply
+    }
+  </button>
 </div>

--- a/src/app/components/project-map/change-hostname-dialog/change-hostname-dialog.component.ts
+++ b/src/app/components/project-map/change-hostname-dialog/change-hostname-dialog.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, inject } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, inject, signal } from '@angular/core';
 import {
   UntypedFormBuilder,
   UntypedFormControl,
@@ -10,6 +10,7 @@ import { MatDialogRef, MatDialogModule } from '@angular/material/dialog';
 import { MatButtonModule } from '@angular/material/button';
 import { MatInputModule } from '@angular/material/input';
 import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { Node } from '../../../cartography/models/node';
 import { Controller } from '@models/controller';
 import { NodeService } from '@services/node.service';
@@ -20,7 +21,7 @@ import { ToasterService } from '@services/toaster.service';
   selector: 'app-change-hostname-dialog-component',
   templateUrl: './change-hostname-dialog.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [MatDialogModule, MatButtonModule, MatInputModule, MatFormFieldModule, ReactiveFormsModule],
+  imports: [MatDialogModule, MatButtonModule, MatInputModule, MatFormFieldModule, MatProgressSpinnerModule, ReactiveFormsModule],
 })
 export class ChangeHostnameDialogComponent implements OnInit {
   public dialogRef = inject(MatDialogRef<ChangeHostnameDialogComponent>);
@@ -33,6 +34,7 @@ export class ChangeHostnameDialogComponent implements OnInit {
   node: Node;
   inputForm: UntypedFormGroup;
   name: string;
+  readonly isApplying = signal(false);
 
   constructor() {
     // Directly use the name from the passed node on initialization
@@ -53,10 +55,13 @@ export class ChangeHostnameDialogComponent implements OnInit {
   }
 
   onSaveClick() {
+    if (this.isApplying()) return;
     if (this.inputForm.valid) {
       // Get the new name from user input in the form
       const newName = this.inputForm.get('name')?.value;
       this.node.name = newName;
+      this.isApplying.set(true);
+      this.dialogRef.disableClose = true;
       this.nodeService.updateNode(this.controller, this.node).subscribe({
         next: () => {
           this.toasterService.success(`Node ${this.node.name} updated.`);
@@ -65,6 +70,8 @@ export class ChangeHostnameDialogComponent implements OnInit {
         error: (err) => {
           const message = err.error?.message || err.message || 'Failed to update node.';
           this.toasterService.error(message);
+          this.isApplying.set(false);
+          this.dialogRef.disableClose = false;
           this.cd.markForCheck();
         },
       });

--- a/src/app/components/project-map/change-symbol-dialog/change-symbol-dialog.component.html
+++ b/src/app/components/project-map/change-symbol-dialog/change-symbol-dialog.component.html
@@ -6,5 +6,11 @@
 
 <div mat-dialog-actions>
   <button mat-button (click)="onCloseClick()" color="accent">Cancel</button>
-  <button mat-button (click)="onSelectClick()" tabindex="2" mat-raised-button color="primary">Apply</button>
+  <button mat-button (click)="onSelectClick()" tabindex="2" mat-raised-button color="primary" [disabled]="isApplying()">
+    @if (isApplying()) {
+      <mat-spinner diameter="20"></mat-spinner>
+    } @else {
+      Apply
+    }
+  </button>
 </div>

--- a/src/app/components/project-map/change-symbol-dialog/change-symbol-dialog.component.ts
+++ b/src/app/components/project-map/change-symbol-dialog/change-symbol-dialog.component.ts
@@ -1,6 +1,7 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, OnInit, inject } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, OnInit, inject, signal } from '@angular/core';
 import { MatDialogRef, MatDialogModule } from '@angular/material/dialog';
 import { MatButtonModule } from '@angular/material/button';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { Node } from '../../../cartography/models/node';
 import { Controller } from '@models/controller';
 import { NodeService } from '@services/node.service';
@@ -13,7 +14,7 @@ import { ToasterService } from '@services/toaster.service';
   templateUrl: './change-symbol-dialog.component.html',
   styleUrls: ['./change-symbol-dialog.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [MatDialogModule, MatButtonModule, SymbolsComponent],
+  imports: [MatDialogModule, MatButtonModule, MatProgressSpinnerModule, SymbolsComponent],
 })
 export class ChangeSymbolDialogComponent implements OnInit {
   public dialogRef = inject(MatDialogRef<ChangeSymbolDialogComponent>);
@@ -24,6 +25,7 @@ export class ChangeSymbolDialogComponent implements OnInit {
   @Input() controller: Controller;
   @Input() node: Node;
   symbol: string;
+  readonly isApplying = signal(false);
 
   ngOnInit() {
     this.symbol = this.node.symbol;
@@ -40,6 +42,9 @@ export class ChangeSymbolDialogComponent implements OnInit {
   }
 
   onSelectClick() {
+    if (this.isApplying()) return;
+    this.isApplying.set(true);
+    this.dialogRef.disableClose = true;
     this.nodeService.updateSymbol(this.controller, this.node, this.symbol).subscribe({
       next: () => {
         this.toasterService.success(`Symbol for node "${this.node.name}" updated.`);
@@ -48,6 +53,8 @@ export class ChangeSymbolDialogComponent implements OnInit {
       error: (err) => {
         const message = err.error?.message || err.message || 'Failed to update symbol';
         this.toasterService.error(message);
+        this.isApplying.set(false);
+        this.dialogRef.disableClose = false;
         this.cd.markForCheck();
       },
     });

--- a/src/app/components/project-map/context-menu/actions/config-action/config-action.component.spec.ts
+++ b/src/app/components/project-map/context-menu/actions/config-action/config-action.component.spec.ts
@@ -55,7 +55,8 @@ describe('ConfigActionComponent', () => {
   const baseDialogConfig = {
     panelClass: ['base-dialog-panel', 'configurator-dialog-panel', 'node-configurator-dialog-panel'],
     autoFocus: false,
-    disableClose: false,
+    // locked while node data loads; configurators unlock it when getNode() completes
+    disableClose: true,
   };
 
   const atmSwitchDialogConfig = {
@@ -66,7 +67,7 @@ describe('ConfigActionComponent', () => {
       'atm-switch-config-panel',
     ],
     autoFocus: false,
-    disableClose: false,
+    disableClose: true,
   };
 
   beforeEach(async () => {

--- a/src/app/components/project-map/context-menu/actions/config-action/config-action.component.ts
+++ b/src/app/components/project-map/context-menu/actions/config-action/config-action.component.ts
@@ -33,7 +33,9 @@ export class ConfigActionComponent {
   private conf = {
     panelClass: ['base-dialog-panel', 'configurator-dialog-panel', 'node-configurator-dialog-panel'],
     autoFocus: false,
-    disableClose: false,
+    // locked while node data loads; each configurator unlocks dialogRef.disableClose
+    // in the getNode() next/error handlers (see isLoading in the configurators)
+    disableClose: true,
   };
   dialogRef;
 

--- a/src/app/components/project-map/context-menu/dialogs/idle-pc-dialog/idle-pc-dialog.component.html
+++ b/src/app/components/project-map/context-menu/dialogs/idle-pc-dialog/idle-pc-dialog.component.html
@@ -25,7 +25,13 @@
   @if (!isComputing) {
   <button mat-button (click)="onCompute()" color="accent">Compute</button>
   } @if (!isComputing) {
-  <button mat-button (click)="onApply()" color="accent">Apply</button>
+  <button mat-button (click)="onApply()" color="accent" [disabled]="isApplying()">
+    @if (isApplying()) {
+      <mat-spinner diameter="20"></mat-spinner>
+    } @else {
+      Apply
+    }
+  </button>
   }
   <button mat-button (click)="onClose()" color="accent">Close</button>
 </div>

--- a/src/app/components/project-map/context-menu/dialogs/idle-pc-dialog/idle-pc-dialog.component.ts
+++ b/src/app/components/project-map/context-menu/dialogs/idle-pc-dialog/idle-pc-dialog.component.ts
@@ -1,4 +1,13 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, OnInit, inject, model } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  Input,
+  OnInit,
+  inject,
+  model,
+  signal,
+} from '@angular/core';
 import { MatDialogRef, MatDialogModule } from '@angular/material/dialog';
 import { MatButtonModule } from '@angular/material/button';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
@@ -31,6 +40,7 @@ export class IdlePCDialogComponent implements OnInit {
   idlepcs = [];
   readonly idlePC = model('');
   isComputing: boolean = false;
+  readonly isApplying = signal(false);
 
   ngOnInit() {
     this.onCompute();
@@ -78,16 +88,23 @@ export class IdlePCDialogComponent implements OnInit {
   }
 
   onApply() {
+    if (this.isApplying()) return;
     if (this.idlePC() && this.idlePC() !== '0x0') {
       this.node.properties.idlepc = this.idlePC();
+      this.isApplying.set(true);
+      this.dialogRef.disableClose = true;
       this.nodeService.updateNode(this.controller, this.node).subscribe({
         next: () => {
           this.toasterService.success(`Node ${this.node.name} updated with idle-PC value ${this.idlePC()}`);
+          this.isApplying.set(false);
+          this.dialogRef.disableClose = false;
           this.cd.markForCheck();
         },
         error: (err) => {
           const message = err.error?.message || err.message || 'Failed to update node with idle-PC value';
           this.toasterService.error(message);
+          this.isApplying.set(false);
+          this.dialogRef.disableClose = false;
           this.cd.markForCheck();
         },
       });

--- a/src/app/components/project-map/drawings-editors/link-style-editor/link-style-editor.component.html
+++ b/src/app/components/project-map/drawings-editors/link-style-editor/link-style-editor.component.html
@@ -60,5 +60,11 @@
 
 <div mat-dialog-actions>
   <button mat-button (click)="onNoClick()" color="accent">Cancel</button>
-  <button mat-button (click)="onYesClick()" tabindex="2" mat-raised-button color="primary">Apply</button>
+  <button mat-button (click)="onYesClick()" tabindex="2" mat-raised-button color="primary" [disabled]="isApplying()">
+    @if (isApplying()) {
+      <mat-spinner diameter="20"></mat-spinner>
+    } @else {
+      Apply
+    }
+  </button>
 </div>

--- a/src/app/components/project-map/drawings-editors/link-style-editor/link-style-editor.component.ts
+++ b/src/app/components/project-map/drawings-editors/link-style-editor/link-style-editor.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, OnInit, inject, ChangeDetectorRef } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit, inject, ChangeDetectorRef, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import {
   FormsModule,
@@ -14,6 +14,7 @@ import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { MatOptionModule } from '@angular/material/core';
 import { MatButtonModule } from '@angular/material/button';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { Link } from '@models/link';
 import { LinkStyle } from '@models/link-style';
 import { Project } from '@models/project';
@@ -41,6 +42,7 @@ import { StyleTranslator } from '../../../../cartography/widgets/links/style-tra
     MatSelectModule,
     MatOptionModule,
     MatButtonModule,
+    MatProgressSpinnerModule,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
@@ -54,6 +56,8 @@ export class LinkStyleEditorDialogComponent implements OnInit {
   private linkToMapLink = inject(LinkToMapLinkConverter);
   private nonNegativeValidator = inject(NonNegativeValidator);
   private cdr = inject(ChangeDetectorRef);
+
+  readonly isApplying = signal(false);
 
   controller: Controller;
   project: Project;
@@ -239,6 +243,7 @@ export class LinkStyleEditorDialogComponent implements OnInit {
   }
 
   onYesClick() {
+    if (this.isApplying()) return;
     if (this.formGroup.valid) {
       if (!this.link.link_style) {
         this.link.link_style = {} as LinkStyle;
@@ -276,6 +281,8 @@ export class LinkStyleEditorDialogComponent implements OnInit {
       const expectedFlowchartRoundness = this.link.link_style.flowchart_roundness;
       const linkTypeChanged = expectedLinkType !== originalLinkType;
 
+      this.isApplying.set(true);
+      this.dialogRef.disableClose = true;
       this.linkService.updateLinkStyle(this.controller, this.link).subscribe({
         next: (link: Link) => {
           if (!link.link_style) {
@@ -333,6 +340,8 @@ export class LinkStyleEditorDialogComponent implements OnInit {
         error: (err) => {
           const message = err.error?.message || err.message || 'Failed to update link style';
           this.toasterService.error(message);
+          this.isApplying.set(false);
+          this.dialogRef.disableClose = false;
           this.cdr.markForCheck();
         },
       });

--- a/src/app/components/project-map/drawings-editors/style-editor/style-editor.component.html
+++ b/src/app/components/project-map/drawings-editors/style-editor/style-editor.component.html
@@ -93,5 +93,11 @@
 
 <div mat-dialog-actions align="end">
   <button mat-button (click)="onNoClick()" color="accent">Cancel</button>
-  <button mat-button (click)="onYesClick()" tabindex="2" mat-raised-button color="primary">Apply</button>
+  <button mat-button (click)="onYesClick()" tabindex="2" mat-raised-button color="primary" [disabled]="isApplying()">
+    @if (isApplying()) {
+      <mat-spinner diameter="20"></mat-spinner>
+    } @else {
+      Apply
+    }
+  </button>
 </div>

--- a/src/app/components/project-map/drawings-editors/style-editor/style-editor.component.ts
+++ b/src/app/components/project-map/drawings-editors/style-editor/style-editor.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, inject } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import {
   ReactiveFormsModule,
@@ -13,6 +13,7 @@ import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { MatOptionModule } from '@angular/material/core';
 import { MatButtonModule } from '@angular/material/button';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { DrawingToMapDrawingConverter } from '../../../../cartography/converters/map/drawing-to-map-drawing-converter';
 import { MapDrawingToSvgConverter } from '../../../../cartography/converters/map/map-drawing-to-svg-converter';
 import { DrawingsDataSource } from '../../../../cartography/datasources/drawings-datasource';
@@ -42,6 +43,7 @@ import { RotationValidator } from '../../../../validators/rotation-validator';
     MatSelectModule,
     MatOptionModule,
     MatButtonModule,
+    MatProgressSpinnerModule,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
@@ -57,6 +59,8 @@ export class StyleEditorDialogComponent implements OnInit {
   private rotationValidator = inject(RotationValidator);
   private qtDasharrayFixer = inject(QtDasharrayFixer);
   private cd = inject(ChangeDetectorRef);
+
+  readonly isApplying = signal(false);
 
   controller: Controller;
   project: Project;
@@ -212,6 +216,7 @@ export class StyleEditorDialogComponent implements OnInit {
   }
 
   onYesClick() {
+    if (this.isApplying()) return;
     if (this.formGroup.valid) {
       if (this.element.stroke_dasharray == '') {
         this.element.stroke_width = 0;
@@ -277,6 +282,8 @@ export class StyleEditorDialogComponent implements OnInit {
 
       this.drawing.svg = this.mapDrawingToSvgConverter.convert(mapDrawing);
 
+      this.isApplying.set(true);
+      this.dialogRef.disableClose = true;
       this.drawingService.update(this.controller, this.drawing).subscribe({
         next: (controllerDrawing: Drawing) => {
           this.drawingsDataSource.update(controllerDrawing);
@@ -286,6 +293,8 @@ export class StyleEditorDialogComponent implements OnInit {
         error: (err) => {
           const message = err.error?.message || err.message || 'Failed to update drawing';
           this.toasterService.error(message);
+          this.isApplying.set(false);
+          this.dialogRef.disableClose = false;
           this.cd.markForCheck();
         },
       });

--- a/src/app/components/project-map/drawings-editors/text-editor/text-editor.component.html
+++ b/src/app/components/project-map/drawings-editors/text-editor/text-editor.component.html
@@ -73,5 +73,11 @@
 
 <div mat-dialog-actions>
   <button mat-button (click)="onNoClick()" color="accent">Cancel</button>
-  <button mat-button (click)="onYesClick()" tabindex="2" mat-raised-button color="primary">Apply</button>
+  <button mat-button (click)="onYesClick()" tabindex="2" mat-raised-button color="primary" [disabled]="isApplying()">
+    @if (isApplying()) {
+      <mat-spinner diameter="20"></mat-spinner>
+    } @else {
+      Apply
+    }
+  </button>
 </div>

--- a/src/app/components/project-map/drawings-editors/text-editor/text-editor.component.ts
+++ b/src/app/components/project-map/drawings-editors/text-editor/text-editor.component.ts
@@ -7,6 +7,7 @@ import {
   inject,
   viewChild,
   ChangeDetectorRef,
+  signal,
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import {
@@ -22,6 +23,7 @@ import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
 import { MatSelectModule } from '@angular/material/select';
 import { MatOptionModule } from '@angular/material/core';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { DrawingToMapDrawingConverter } from '../../../../cartography/converters/map/drawing-to-map-drawing-converter';
 import { MapDrawingToSvgConverter } from '../../../../cartography/converters/map/map-drawing-to-svg-converter';
 import { DrawingsDataSource } from '../../../../cartography/datasources/drawings-datasource';
@@ -56,11 +58,13 @@ import { RotationValidator } from '../../../../validators/rotation-validator';
     MatButtonModule,
     MatSelectModule,
     MatOptionModule,
+    MatProgressSpinnerModule,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TextEditorDialogComponent implements OnInit {
   readonly textArea = viewChild<ElementRef>('textArea');
+  readonly isApplying = signal(false);
 
   private dialogRef = inject(MatDialogRef<TextEditorDialogComponent>);
   private drawingToMapDrawingConverter = inject(DrawingToMapDrawingConverter);
@@ -167,6 +171,7 @@ export class TextEditorDialogComponent implements OnInit {
   }
 
   onYesClick() {
+    if (this.isApplying()) return;
     if (this.formGroup.valid) {
       this.rotation = this.formGroup.get('rotation').value;
 
@@ -174,6 +179,8 @@ export class TextEditorDialogComponent implements OnInit {
         this.node.label.style = this.getStyleFromTextElement();
         this.node.label.rotation = +this.rotation;
 
+        this.isApplying.set(true);
+        this.dialogRef.disableClose = true;
         this.nodeService.updateLabel(this.controller, this.node, this.node.label).subscribe({
           next: (node: Node) => {
             this.nodesDataSource.update(node);
@@ -184,6 +191,8 @@ export class TextEditorDialogComponent implements OnInit {
           error: (err) => {
             const message = err.error?.message || err.message || 'Failed to update node label';
             this.toasterService.error(message);
+            this.isApplying.set(false);
+            this.dialogRef.disableClose = false;
             this.cdr.markForCheck();
           },
         });
@@ -192,6 +201,8 @@ export class TextEditorDialogComponent implements OnInit {
         this.label.rotation = +this.rotation;
         this.label.text = this.element.text;
 
+        this.isApplying.set(true);
+        this.dialogRef.disableClose = true;
         this.linkService.updateLink(this.controller, this.link).subscribe({
           next: (link: Link) => {
             this.linksDataSource.update(link);
@@ -202,6 +213,8 @@ export class TextEditorDialogComponent implements OnInit {
           error: (err) => {
             const message = err.error?.message || err.message || 'Failed to update link';
             this.toasterService.error(message);
+            this.isApplying.set(false);
+            this.dialogRef.disableClose = false;
             this.cdr.markForCheck();
           },
         });
@@ -214,6 +227,8 @@ export class TextEditorDialogComponent implements OnInit {
 
         this.drawing.svg = this.mapDrawingToSvgConverter.convert(mapDrawing);
 
+        this.isApplying.set(true);
+        this.dialogRef.disableClose = true;
         this.drawingService.update(this.controller, this.drawing).subscribe({
           next: (controllerDrawing: Drawing) => {
             this.drawingsDataSource.update(controllerDrawing);
@@ -224,6 +239,8 @@ export class TextEditorDialogComponent implements OnInit {
           error: (err) => {
             const message = err.error?.message || err.message || 'Failed to update drawing';
             this.toasterService.error(message);
+            this.isApplying.set(false);
+            this.dialogRef.disableClose = false;
             this.cdr.markForCheck();
           },
         });

--- a/src/app/components/project-map/marker-manager/marker-form.component.ts
+++ b/src/app/components/project-map/marker-manager/marker-form.component.ts
@@ -16,6 +16,14 @@ export interface MarkerCaptureOption {
 }
 
 /**
+ * Sentinel for "server picks the capture node" in the Capture node dropdown.
+ * mat-select never displays a null-valued option as selected (it clears the
+ * model instead), so "Auto" must be a real string — mapped back to "omit the
+ * field" at the API boundary (see MarkerManagerComponent.submitMarker).
+ */
+export const MARKER_CAPTURE_AUTO = 'auto';
+
+/**
  * Shared create/edit form for per-link markers — the single source of truth for the
  * marker field layout (BPF, Name, Capture node, Direction, Highlight ms, Color).
  *
@@ -75,7 +83,7 @@ export interface MarkerCaptureOption {
         <mat-form-field class="marker-form__field">
           <mat-label>Capture node</mat-label>
           <mat-select formControlName="capture_node_id">
-            <mat-option [value]="null">Auto</mat-option>
+            <mat-option [value]="captureAuto">Auto</mat-option>
             @for (ep of captureOptions(); track ep.id) {
               <mat-option [value]="ep.id">{{ ep.name }}</mat-option>
             }
@@ -152,6 +160,8 @@ export class MarkerFormComponent {
   readonly submitLabel = computed(() => (this.mode() === 'edit' ? 'Save' : 'Add'));
   /** When true, the submit button shows a spinner and the label changes to "Saving…" / "Adding…". */
   readonly submitting = input<boolean>(false);
+  /** Sentinel value of the "Auto" capture-node option (see {@link MARKER_CAPTURE_AUTO}). */
+  readonly captureAuto = MARKER_CAPTURE_AUTO;
   readonly save = output<void>();
   readonly cancel = output<void>();
 }

--- a/src/app/components/project-map/marker-manager/marker-manager.component.html
+++ b/src/app/components/project-map/marker-manager/marker-manager.component.html
@@ -152,14 +152,14 @@
                 >
                   <ng-container
                     [ngTemplateOutlet]="onOffIcon"
-                    [ngTemplateOutletContext]="{ $implicit: togglingDefinition() === row.name, off: row.paused }"
+                    [ngTemplateOutletContext]="{ $implicit: isTogglingDefinition(row.name), off: row.paused }"
                   />
                 </button>
                 <button mat-icon-button (click)="startEditDefinition(row)" matTooltip="Edit">
                   <mat-icon>edit</mat-icon>
                 </button>
                 <button mat-icon-button (click)="deleteDefinition(row)" matTooltip="Delete (clears all copies)">
-                  @if (deletingDefinition() === row.name) {
+                  @if (isDeletingDefinition(row.name)) {
                     <mat-spinner class="marker-manager__toggle-spinner" [diameter]="18" />
                   } @else {
                     <mat-icon>delete</mat-icon>

--- a/src/app/components/project-map/marker-manager/marker-manager.component.spec.ts
+++ b/src/app/components/project-map/marker-manager/marker-manager.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { of, throwError } from 'rxjs';
+import { of, throwError, Subject } from 'rxjs';
 import { MarkerManagerComponent } from './marker-manager.component';
 import { MarkerService } from '@services/marker.service';
 import { LinkService } from '@services/link.service';
@@ -26,6 +26,10 @@ describe('MarkerManagerComponent', () => {
 
   const controller = { id: 1 } as Controller;
   const project = { project_id: 'proj-1' } as Project;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let linksDataSource: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let mapLinksDataSource: any;
 
   beforeEach(async () => {
     markerService = {
@@ -39,15 +43,17 @@ describe('MarkerManagerComponent', () => {
       delete: vi.fn(),
     };
     linkService = { getLink: vi.fn() };
-    registry = { reconcileLink: vi.fn() };
+    registry = { reconcileLink: vi.fn(), rebuildFromAggregate: vi.fn(), removeLink: vi.fn() };
+    linksDataSource = { get: vi.fn(), update: vi.fn(), getItems: vi.fn(() => []) };
+    mapLinksDataSource = { get: vi.fn(), update: vi.fn(), getItems: vi.fn(() => []) };
 
     await TestBed.configureTestingModule({
       imports: [MarkerManagerComponent],
       providers: [
         { provide: MarkerService, useValue: markerService },
         { provide: LinkService, useValue: linkService },
-        { provide: LinksDataSource, useValue: { get: vi.fn(), update: vi.fn(), getItems: vi.fn(() => []) } },
-        { provide: MapLinksDataSource, useValue: { get: vi.fn(), update: vi.fn() } },
+        { provide: LinksDataSource, useValue: linksDataSource },
+        { provide: MapLinksDataSource, useValue: mapLinksDataSource },
         { provide: NodesDataSource, useValue: { get: vi.fn(), getItems: vi.fn(() => []) } },
         { provide: MarkerRegistryService, useValue: registry },
         { provide: ToasterService, useValue: { success: vi.fn(), error: vi.fn() } },
@@ -188,6 +194,36 @@ describe('MarkerManagerComponent', () => {
       expect(linkService.getLink).toHaveBeenCalledWith(controller, 'proj-1', 'l1');
       expect(registry.reconcileLink).toHaveBeenCalled();
       expect(markerService.aggregateList).toHaveBeenCalled();
+    });
+  });
+
+  describe('aggregate race', () => {
+    it('drops a stale aggregate response resolving after a newer one', () => {
+      // Regression: two overlapping aggregate GETs (loadAggregate fires after
+      // every marker CRUD). The older, pre-mutation response must not apply
+      // last — its clearing loop would wipe markers that were just created.
+      const link = { link_id: 'l1', name: 'l1', markers: {} };
+      linksDataSource.get.mockReturnValue(link);
+      linksDataSource.getItems.mockReturnValue([link]);
+      mapLinksDataSource.getItems.mockReturnValue([]);
+
+      const stale = new Subject<any>();
+      const fresh = new Subject<any>();
+      markerService.aggregateList.mockReturnValueOnce(stale.asObservable()).mockReturnValueOnce(fresh.asObservable());
+
+      component.loadAggregate(); // request #1 (older)
+      component.loadAggregate(); // request #2 (newer)
+
+      // Newer response lands first and carries the just-created marker.
+      fresh.next({ 'l1/mymarker': { bpf: 'ip', link_id: 'l1', color: '#ff0000' } });
+      fresh.complete();
+      expect(link.markers).toHaveProperty('mymarker');
+
+      // Older (pre-mutation) response lands last — must be ignored.
+      stale.next({});
+      stale.complete();
+
+      expect(link.markers).toHaveProperty('mymarker');
     });
   });
 });

--- a/src/app/components/project-map/marker-manager/marker-manager.component.ts
+++ b/src/app/components/project-map/marker-manager/marker-manager.component.ts
@@ -8,6 +8,7 @@ import {
   OnDestroy,
   OnInit,
   Output,
+  WritableSignal,
   computed,
   effect,
   inject,
@@ -51,7 +52,7 @@ import { MarkerRegistryService } from '@services/marker-registry.service';
 import { ToasterService } from '@services/toaster.service';
 import { WindowBoundaryService, WindowStyle } from '@services/window-boundary.service';
 import { WindowManagementService } from '@services/window-management.service';
-import { MarkerFormComponent } from './marker-form.component';
+import { MarkerFormComponent, MARKER_CAPTURE_AUTO } from './marker-form.component';
 import { ConfirmationDialogComponent } from '@components/dialogs/confirmation-dialog/confirmation-dialog.component';
 
 interface DefinitionRow {
@@ -132,6 +133,8 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
   private readonly WINDOW_ID = 'marker-manager';
 
   private destroy$ = new Subject<void>();
+  /** Monotonic request id for loadAggregate — stale responses are dropped. */
+  private aggregateRequestSeq = 0;
   readonly controller = input<Controller>();
   readonly project = input<Project>();
   readonly zIndex = input<number>(1000);
@@ -173,16 +176,20 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
   readonly editingMarker = signal<{ linkId: string; name: string } | null>(null);
   /** LinkIds whose marker list is collapsed in the aggregate Links view. */
   readonly collapsedGroups = signal<Set<string>>(new Set());
-  /** Definition name whose pause/resume request is in flight — guards double-fires + drives that row's spinner. */
-  readonly togglingDefinition = signal<string | null>(null);
-  /** `${linkId}/${name}` of the per-marker enable request in flight — guards + drives that row's spinner. */
-  readonly togglingMarker = signal<string | null>(null);
-  /** Definition name whose delete request is in flight — drives that row's spinner. */
-  readonly deletingDefinition = signal<string | null>(null);
+  // In-flight action guards are SETS, not single slots: a single-slot signal is
+  // overwritten by a concurrent action on another row, which makes the first
+  // response clear the second row's spinner and re-enable its double-click
+  // guard while the second request is still pending.
+  /** Definition names with a pause/resume request in flight — guard double-fires + drive those rows' spinners. */
+  readonly togglingDefinition = signal<ReadonlySet<string>>(new Set());
+  /** `${linkId}/${name}` keys of per-marker enable requests in flight — guard + drive those rows' spinners. */
+  readonly togglingMarker = signal<ReadonlySet<string>>(new Set());
+  /** Definition names with a delete request in flight — drive those rows' spinners. */
+  readonly deletingDefinition = signal<ReadonlySet<string>>(new Set());
   /** Whether the definition create/update form is currently submitting. */
   readonly submittingDefinition = signal(false);
-  /** `${linkId}/${name}` of the per-marker delete request in flight — drives that row's spinner. */
-  readonly deletingMarker = signal<string | null>(null);
+  /** `${linkId}/${name}` keys of per-marker delete requests in flight — drive those rows' spinners. */
+  readonly deletingMarker = signal<ReadonlySet<string>>(new Set());
   /** linkId whose per-marker create form is currently submitting. */
   readonly submittingMarker = signal<string | null>(null);
   /** Whether the per-marker edit form is currently submitting. */
@@ -264,7 +271,9 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
     // `null` on Ethernet (picker hidden, backend defaults to DLT_EN10MB); seeded with the
     // first WAN encapsulation when the form opens on a serial link (see toggleAddMarker).
     data_link_type: new UntypedFormControl(null),
-    capture_node_id: new UntypedFormControl(null),
+    // nonNullable so bare markerForm.reset() restores the sentinel instead of
+    // null (which mat-select would render as a blank trigger).
+    capture_node_id: new UntypedFormControl(MARKER_CAPTURE_AUTO, { nonNullable: true }),
   });
 
   readonly markerEditForm = new UntypedFormGroup({
@@ -279,7 +288,7 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
     direction: new UntypedFormControl('both'),
     // Create-only on per-link markers — disabled in edit (recreate to switch encapsulation).
     data_link_type: new UntypedFormControl({ value: 'DLT_EN10MB', disabled: true }),
-    capture_node_id: new UntypedFormControl({ value: null, disabled: true }),
+    capture_node_id: new UntypedFormControl({ value: MARKER_CAPTURE_AUTO, disabled: true }),
   });
 
   /**
@@ -407,14 +416,21 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
     const controller = this.controller();
     const project = this.project();
     if (!controller || !project) return;
+    // loadAggregate fires from many call sites (init + after every marker
+    // CRUD); two overlapping GETs can resolve out of order, and the older
+    // (pre-mutation) response applied last would wipe markers that were just
+    // created. Track the newest request and drop stale responses.
+    const seq = ++this.aggregateRequestSeq;
     this.markerService.aggregateList(controller, project.project_id).pipe(takeUntil(this.destroy$)).subscribe({
       next: (map: AggregateMarkerMap) => {
+        if (seq !== this.aggregateRequestSeq) return; // stale response superseded
         this.linkGroups.set(this.buildGroups(map));
         this.markerRegistryService.rebuildFromAggregate(map);
         this.syncLinkMarkersFromAggregate(map);
         this.cdr.markForCheck();
       },
       error: (err) => {
+        if (seq !== this.aggregateRequestSeq) return;
         this.linkError.set({ linkId: null, message: err.error?.message || err.message || 'Failed to load markers' });
         this.cdr.markForCheck();
       },
@@ -486,11 +502,18 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
       const { link_id: _linkId, node_id: _nodeId, ...marker } = entry;
       mm[name] = marker;
     }
-    for (const [linkId, markers] of byLink) {
-      const link = this.linksDataSource.get(linkId);
-      if (link) link.markers = markers;
-      const mapLink = this.mapLinksDataSource.get(linkId);
-      if (mapLink) mapLink.markers = markers;
+    // One pass per data source replaces AND clears: links present in the
+    // aggregate get the fresh markers, links absent from it had their markers
+    // ALL removed (e.g. their only inherited copy went away with a definition
+    // delete) — clear their stale markers too, or the deleted marker lingers
+    // on the stored link objects until a page reload.
+    for (const link of this.linksDataSource.getItems()) {
+      const markers = byLink.get(link.link_id);
+      link.markers = markers ?? (link.markers ? {} : link.markers);
+    }
+    for (const mapLink of this.mapLinksDataSource.getItems()) {
+      const markers = byLink.get(mapLink.id);
+      mapLink.markers = markers ?? (mapLink.markers ? {} : mapLink.markers);
     }
   }
 
@@ -641,19 +664,19 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
     const project = this.project();
     if (!controller || !project) return;
     // Guard against double-fires while a delete is already in flight.
-    if (this.deletingDefinition() === row.name) return;
+    if (this.isDeletingDefinition(row.name)) return;
     this.defError.set(null);
-    this.deletingDefinition.set(row.name);
+    this.markPending(this.deletingDefinition, row.name);
     this.markerService.deleteDefinition(controller, project.project_id, row.name).pipe(takeUntil(this.destroy$)).subscribe({
       next: () => {
-        this.deletingDefinition.set(null);
+        this.clearPending(this.deletingDefinition, row.name);
         this.toasterService.success(`Marker definition "${row.name}" deleted.`);
         if (this.editingDefinition() === row.name) this.cancelEditDefinition();
         this.loadDefinitions();
         this.loadAggregate();
       },
       error: (err) => {
-        this.deletingDefinition.set(null);
+        this.clearPending(this.deletingDefinition, row.name);
         const message = err.error?.message || err.message || 'Failed to delete definition';
         this.defError.set(message);
         this.toasterService.error(message);
@@ -729,12 +752,36 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
 
   /** Whether a per-marker enable request is in flight for this marker (drives its spinner). */
   isTogglingMarker(linkId: string, name: string): boolean {
-    return this.togglingMarker() === `${linkId}/${name}`;
+    return this.togglingMarker().has(`${linkId}/${name}`);
   }
 
   /** Whether a per-marker delete request is in flight for this marker (drives its spinner). */
   isDeletingMarker(linkId: string, name: string): boolean {
-    return this.deletingMarker() === `${linkId}/${name}`;
+    return this.deletingMarker().has(`${linkId}/${name}`);
+  }
+
+  /** Whether a pause/resume request is in flight for this definition (drives its spinner). */
+  isTogglingDefinition(name: string): boolean {
+    return this.togglingDefinition().has(name);
+  }
+
+  /** Whether a delete request is in flight for this definition (drives its spinner). */
+  isDeletingDefinition(name: string): boolean {
+    return this.deletingDefinition().has(name);
+  }
+
+  /** Stage a key in an in-flight set (new Set ref so OnPush consumers refresh). */
+  private markPending(sig: WritableSignal<ReadonlySet<string>>, key: string) {
+    const next = new Set(sig());
+    next.add(key);
+    sig.set(next);
+  }
+
+  /** Remove a key from an in-flight set (new Set ref so OnPush consumers refresh). */
+  private clearPending(sig: WritableSignal<ReadonlySet<string>>, key: string) {
+    const next = new Set(sig());
+    next.delete(key);
+    sig.set(next);
   }
 
   /**
@@ -806,7 +853,7 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
     if (hd !== null) body.highlight_duration = hd;
     const dir = this.dirToBody(v.direction);
     if (dir) body.direction = dir;
-    if (v.capture_node_id) body.capture_node_id = v.capture_node_id;
+    if (v.capture_node_id && v.capture_node_id !== MARKER_CAPTURE_AUTO) body.capture_node_id = v.capture_node_id;
     if (v.data_link_type) body.data_link_type = v.data_link_type;
 
     this.markerService.create(controller, project.project_id, linkId, body).pipe(takeUntil(this.destroy$)).subscribe({
@@ -835,18 +882,18 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
     const project = this.project();
     if (!controller || !project) return;
     const key = `${linkId}/${name}`;
-    if (this.deletingMarker() === key) return;
+    if (this.isDeletingMarker(linkId, name)) return;
     this.linkError.set(null);
-    this.deletingMarker.set(key);
+    this.markPending(this.deletingMarker, key);
     this.markerService.delete(controller, project.project_id, linkId, name).pipe(takeUntil(this.destroy$)).subscribe({
       next: () => {
-        this.deletingMarker.set(null);
+        this.clearPending(this.deletingMarker, key);
         this.toasterService.success(`Marker "${name}" deleted.`);
         this.refreshLink(linkId);
         this.loadAggregate();
       },
       error: (err) => {
-        this.deletingMarker.set(null);
+        this.clearPending(this.deletingMarker, key);
         const message = err.error?.message || err.message || 'Failed to delete marker';
         this.linkError.set({ linkId, message });
         this.toasterService.error(message);
@@ -869,7 +916,7 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
       highlight_duration: marker.highlight_duration ?? 800,
       direction: this.dirFromMarker(marker.direction),
       data_link_type: marker.data_link_type ?? 'DLT_EN10MB',
-      capture_node_id: marker.capture_node_id ?? null,
+      capture_node_id: marker.capture_node_id ?? MARKER_CAPTURE_AUTO,
     });
     this.markerEditForm.get('name')?.disable();
     // data_link_type is create-only on per-link markers — keep it disabled in edit.
@@ -927,7 +974,7 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
   // ---- per-definition pause/resume (toggles every inherited copy of a rule) ----
 
   toggleDefinitionPaused(row: DefinitionRow) {
-    if (this.togglingDefinition() === row.name) return;
+    if (this.isTogglingDefinition(row.name)) return;
     const controller = this.controller();
     const project = this.project();
     if (!controller || !project) return;
@@ -937,18 +984,18 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
     // call loadDefinitions() here: it sets `loading` and flashes the "Loading…" block /
     // re-renders the whole list. The 204 confirms `paused`, so we set it locally on
     // success; loadAggregate refreshes the Links tab's inherited copies.
-    this.togglingDefinition.set(row.name);
+    this.markPending(this.togglingDefinition, row.name);
     const req$ = wantPaused
       ? this.markerService.pauseDefinition(controller, project.project_id, row.name)
       : this.markerService.resumeDefinition(controller, project.project_id, row.name);
     req$.pipe(takeUntil(this.destroy$)).subscribe({
       next: () => {
-        this.togglingDefinition.set(null);
+        this.clearPending(this.togglingDefinition, row.name);
         this.applyDefinitionPausedLocal(row.name, wantPaused);
         this.loadAggregate();
       },
       error: (err) => {
-        this.togglingDefinition.set(null);
+        this.clearPending(this.togglingDefinition, row.name);
         this.defError.set(err.error?.message || err.message || 'Failed to toggle definition');
         this.cdr.markForCheck();
       },
@@ -977,19 +1024,19 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
     const nextEnabled = marker.enabled === false;
     // Show the row's spinner while in flight; flip the icon only after the server
     // confirms, so the displayed state is always authoritative.
-    this.togglingMarker.set(`${linkId}/${marker.name}`);
+    this.markPending(this.togglingMarker, `${linkId}/${marker.name}`);
     this.markerService
       .setEnabled(controller, project.project_id, linkId, marker.name, nextEnabled)
       .pipe(takeUntil(this.destroy$))
       .subscribe({
         next: () => {
-          this.togglingMarker.set(null);
+          this.clearPending(this.togglingMarker, `${linkId}/${marker.name}`);
           this.applyEnabledLocal(linkId, marker.name, nextEnabled);
           this.refreshLink(linkId);
           this.loadAggregate();
         },
         error: (err) => {
-          this.togglingMarker.set(null);
+          this.clearPending(this.togglingMarker, `${linkId}/${marker.name}`);
           this.toasterService.error(err.error?.message || err.message || 'Failed to toggle marker');
           this.cdr.markForCheck();
         },

--- a/src/app/components/project-map/new-template-dialog/appliance-info-dialog/appliance-info-dialog.component.html
+++ b/src/app/components/project-map/new-template-dialog/appliance-info-dialog/appliance-info-dialog.component.html
@@ -1,13 +1,38 @@
 <div class="title-container">
+  @if (appliance.vendor_logo_url) {
+  <img
+    [src]="appliance.vendor_logo_url"
+    (error)="$event.target.style.display = 'none'"
+    class="appliance-info__vendor-logo"
+    alt=""
+  />
+  }
   <h1 mat-dialog-title>{{ appliance.name }}</h1>
 </div>
 <div mat-dialog-content>
   <div>Vendor: {{ appliance.vendor_name }}</div>
   <div>Status: {{ appliance.status }}</div>
   <div>Maintainer: {{ appliance.maintainer }}</div>
+  <div>Registry version: {{ appliance.registry_version }}</div>
+  @if (appliance.default_username) {
+  <div>Default username: {{ appliance.default_username }}</div>
+  }
+  @if (appliance.default_password) {
+  <div>Default password: {{ appliance.default_password }}</div>
+  }
+  @if (appliance.netmiko_device_type) {
+  <div>Netmiko device type: {{ appliance.netmiko_device_type }}</div>
+  }
   @if (appliance.qemu) {
   <div>Adapters: {{ appliance.qemu.adapters }}</div>
   <div>Console type: {{ appliance.qemu.console_type }}</div>
+  }
+  @if (appliance.docker) {
+  <div>Adapters: {{ appliance.docker.adapters }}</div>
+  <div>Console type: {{ appliance.docker.console_type }}</div>
+  }
+  @if (appliance.installation_instructions) {
+  <div class="appliance-info__instructions">{{ appliance.installation_instructions }}</div>
   }
 </div>
 <div mat-dialog-actions>

--- a/src/app/components/project-map/new-template-dialog/appliance-info-dialog/appliance-info-dialog.component.scss
+++ b/src/app/components/project-map/new-template-dialog/appliance-info-dialog/appliance-info-dialog.component.scss
@@ -1,0 +1,20 @@
+.appliance-info {
+  &__vendor-logo {
+    width: 32px;
+    height: 32px;
+    margin-right: 8px;
+    vertical-align: middle;
+    object-fit: contain;
+    border-radius: 6px;
+  }
+
+  &__instructions {
+    margin-top: 12px;
+    padding: 8px 12px;
+    font-size: 13px;
+    white-space: pre-line;
+    color: var(--mat-sys-on-surface-variant);
+    background: var(--mat-sys-surface-container);
+    border-radius: 8px;
+  }
+}

--- a/src/app/components/project-map/new-template-dialog/appliance-info-dialog/appliance-info-dialog.component.ts
+++ b/src/app/components/project-map/new-template-dialog/appliance-info-dialog/appliance-info-dialog.component.ts
@@ -6,6 +6,7 @@ import { Appliance } from '@models/appliance';
 @Component({
   selector: 'app-appliance-info-dialog',
   templateUrl: 'appliance-info-dialog.component.html',
+  styleUrls: ['appliance-info-dialog.component.scss'],
   imports: [MatDialogModule, MatButtonModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/src/app/components/project-map/new-template-dialog/new-template-dialog.component.ts
+++ b/src/app/components/project-map/new-template-dialog/new-template-dialog.component.ts
@@ -45,6 +45,7 @@ import { IosTemplate } from '@models/templates/ios-template';
 import { IouTemplate } from '@models/templates/iou-template';
 import { QemuTemplate } from '@models/templates/qemu-template';
 import { ApplianceService } from '@services/appliances.service';
+import { getVersionSettingProperties, buildApplianceMetadata, normalizeAppliance } from '@services/appliance-normalizer';
 import { ControllerService } from '@services/controller.service';
 import { DockerService } from '@services/docker.service';
 import { IosService } from '@services/ios.service';
@@ -569,7 +570,9 @@ export class NewTemplateDialogComponent implements OnInit {
     fileReader.onloadend = () => {
       this.isImportingAppliance.set(true);
       try {
-        const appliance = JSON.parse(fileReader.result as string) as Appliance;
+        // normalizeAppliance maps v8 appliance files onto the legacy shape the
+        // template builders below expect (versions/settings/platform fields).
+        const appliance = normalizeAppliance(JSON.parse(fileReader.result as string) as Appliance);
         if (!appliance || typeof appliance !== 'object' || !appliance.name) {
           this.toasterService.error(`'${file.name}' is not a valid appliance file`);
           return;
@@ -920,6 +923,8 @@ export class NewTemplateDialogComponent implements OnInit {
     iouTemplate.template_id = uuid();
     iouTemplate.path = iou_image;
     iouTemplate.template_type = 'iou';
+    iouTemplate.netmiko_device_type = appliance.netmiko_device_type || null;
+    iouTemplate.appliance_metadata = buildApplianceMetadata(appliance);
     iouTemplate.name = name;
     return iouTemplate;
   }
@@ -955,6 +960,8 @@ export class NewTemplateDialogComponent implements OnInit {
     iosTemplate.template_id = uuid();
     iosTemplate.image = ios_image;
     iosTemplate.template_type = 'dynamips';
+    iosTemplate.netmiko_device_type = appliance.netmiko_device_type || null;
+    iosTemplate.appliance_metadata = buildApplianceMetadata(appliance);
     iosTemplate.name = name;
     return iosTemplate;
   }
@@ -986,6 +993,8 @@ export class NewTemplateDialogComponent implements OnInit {
     dockerTemplate.symbol = appliance.symbol;
     dockerTemplate.tags = appliance.tags || [];
     dockerTemplate.usage = appliance.usage;
+    dockerTemplate.netmiko_device_type = appliance.netmiko_device_type || null;
+    dockerTemplate.appliance_metadata = buildApplianceMetadata(appliance);
     dockerTemplate.compute_id = 'local';
     dockerTemplate.template_id = uuid();
     dockerTemplate.name = name;
@@ -1006,22 +1015,26 @@ export class NewTemplateDialogComponent implements OnInit {
 
   private buildQemuTemplate(version: Version, name: string): QemuTemplate {
     const appliance = this.applianceToInstall();
+    // v8 appliances may override the default settings per version
+    const versionProps = getVersionSettingProperties(appliance, version) || {};
+    const qemuProps: any = { ...(appliance.qemu || {}), ...versionProps };
+
     let qemuTemplate: QemuTemplate = new QemuTemplate();
-    qemuTemplate.ram = appliance.qemu.ram;
-    qemuTemplate.adapters = appliance.qemu.adapters;
-    qemuTemplate.adapter_type = appliance.qemu.adapter_type;
-    qemuTemplate.boot_priority = appliance.qemu.boot_priority;
-    qemuTemplate.console_type = appliance.qemu.console_type;
-    qemuTemplate.hda_disk_interface = appliance.qemu.hda_disk_interface;
-    qemuTemplate.hdb_disk_interface = appliance.qemu.hdb_disk_interface;
-    qemuTemplate.hdc_disk_interface = appliance.qemu.hdc_disk_interface;
-    qemuTemplate.hdd_disk_interface = appliance.qemu.hdd_disk_interface;
-    qemuTemplate.category = this.getCategory();
-    qemuTemplate.first_port_name = appliance.first_port_name;
-    qemuTemplate.port_name_format = appliance.port_name_format;
-    qemuTemplate.port_segment_size = appliance.port_segment_size;
+    qemuTemplate.ram = qemuProps.ram;
+    qemuTemplate.adapters = qemuProps.adapters;
+    qemuTemplate.adapter_type = qemuProps.adapter_type;
+    qemuTemplate.boot_priority = qemuProps.boot_priority;
+    qemuTemplate.console_type = qemuProps.console_type;
+    qemuTemplate.hda_disk_interface = qemuProps.hda_disk_interface;
+    qemuTemplate.hdb_disk_interface = qemuProps.hdb_disk_interface;
+    qemuTemplate.hdc_disk_interface = qemuProps.hdc_disk_interface;
+    qemuTemplate.hdd_disk_interface = qemuProps.hdd_disk_interface;
+    qemuTemplate.category = version.category || this.getCategory();
+    qemuTemplate.first_port_name = qemuProps.first_port_name ?? appliance.first_port_name;
+    qemuTemplate.port_name_format = qemuProps.port_name_format ?? appliance.port_name_format;
+    qemuTemplate.port_segment_size = qemuProps.port_segment_size ?? appliance.port_segment_size;
     qemuTemplate.default_name_format = appliance.default_name_format;
-    qemuTemplate.symbol = appliance.symbol;
+    qemuTemplate.symbol = version.symbol || appliance.symbol;
     qemuTemplate.tags = appliance.tags || [];
     qemuTemplate.compute_id = 'local';
     qemuTemplate.template_id = uuid();
@@ -1032,8 +1045,11 @@ export class NewTemplateDialogComponent implements OnInit {
     qemuTemplate.hdd_disk_image = this.findControllerImageName(version.images.hdd_disk_image);
     qemuTemplate.cdrom_image = this.findControllerImageName(version.images.cdrom_image);
     qemuTemplate.template_type = 'qemu';
-    qemuTemplate.usage = appliance.usage;
-    qemuTemplate.platform = appliance.qemu.arch;
+    qemuTemplate.usage = version.usage || appliance.usage;
+    // v8 template_properties carry `platform`; v1-v6 qemu blocks use `arch`
+    qemuTemplate.platform = qemuProps.platform ?? qemuProps.arch;
+    qemuTemplate.netmiko_device_type = qemuProps.netmiko_device_type || appliance.netmiko_device_type || null;
+    qemuTemplate.appliance_metadata = buildApplianceMetadata(appliance, version);
     qemuTemplate.name = name;
     return qemuTemplate;
   }

--- a/src/app/components/project-map/node-editors/config-editor/config-editor.component.html
+++ b/src/app/components/project-map/node-editors/config-editor/config-editor.component.html
@@ -17,5 +17,11 @@
 
 <div mat-dialog-actions>
   <button mat-button (click)="onCancelClick()" color="accent">Cancel</button>
-  <button mat-button (click)="onSaveClick()" tabindex="2" mat-raised-button color="primary">Apply</button>
+  <button mat-button (click)="onSaveClick()" tabindex="2" mat-raised-button color="primary" [disabled]="isApplying()">
+    @if (isApplying()) {
+      <mat-spinner diameter="20"></mat-spinner>
+    } @else {
+      Apply
+    }
+  </button>
 </div>

--- a/src/app/components/project-map/node-editors/config-editor/config-editor.component.ts
+++ b/src/app/components/project-map/node-editors/config-editor/config-editor.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, OnInit, inject, ChangeDetectorRef, model } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit, inject, ChangeDetectorRef, model, signal } from '@angular/core';
 import { MatDialogRef, MatDialogModule } from '@angular/material/dialog';
 import { MatButtonModule } from '@angular/material/button';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
@@ -27,6 +27,7 @@ export class ConfigEditorDialogComponent implements OnInit {
 
   readonly config = model<any>('');
   readonly privateConfig = model<any>('');
+  readonly isApplying = signal(false);
 
   ngOnInit() {
     this.nodeService.getStartupConfiguration(this.controller, this.node).subscribe({
@@ -67,6 +68,9 @@ export class ConfigEditorDialogComponent implements OnInit {
   }
 
   onSaveClick() {
+    if (this.isApplying()) return;
+    this.isApplying.set(true);
+    this.dialogRef.disableClose = true;
     this.nodeService.saveConfiguration(this.controller, this.node, this.config()).subscribe({
       next: (response) => {
         if (this.node.node_type === 'iou' || this.node.node_type === 'dynamips') {
@@ -79,6 +83,8 @@ export class ConfigEditorDialogComponent implements OnInit {
             error: (err) => {
               const message = err.error?.message || err.message || 'Failed to save private configuration';
               this.toasterService.error(message);
+              this.isApplying.set(false);
+              this.dialogRef.disableClose = false;
               this.cdr.markForCheck();
             },
           });
@@ -91,6 +97,8 @@ export class ConfigEditorDialogComponent implements OnInit {
       error: (err) => {
         const message = err.error?.message || err.message || 'Failed to save configuration';
         this.toasterService.error(message);
+        this.isApplying.set(false);
+        this.dialogRef.disableClose = false;
         this.cdr.markForCheck();
       },
     });

--- a/src/app/components/project-map/node-editors/configurator/atm_switch/configurator-atm-switch.component.html
+++ b/src/app/components/project-map/node-editors/configurator/atm_switch/configurator-atm-switch.component.html
@@ -12,6 +12,11 @@
 </div>
 
 <div class="modal-form-container">
+  @if (isLoading()) {
+    <div class="configurator-dialog-loading">
+      <mat-spinner diameter="40"></mat-spinner>
+    </div>
+  } @else {
   <div class="node-config__single-tab" role="tablist" aria-label="Node configuration sections">
     <div role="tab" aria-selected="true">
       <span class="node-config__tab-label"><mat-icon>tune</mat-icon>General</span>
@@ -102,9 +107,16 @@
       </mat-card>
     </div>
   </div>
+  }
 </div>
 
 <div mat-dialog-actions>
   <button mat-button (click)="onCancelClick()" color="accent">Cancel</button>
-  <button mat-raised-button color="primary" (click)="onSaveClick()">Apply</button>
+  <button mat-button (click)="onSaveClick()" tabindex="2" mat-raised-button color="primary" [disabled]="isApplying() || isLoading()">
+    @if (isApplying()) {
+      <mat-spinner diameter="20"></mat-spinner>
+    } @else {
+      Apply
+    }
+  </button>
 </div>

--- a/src/app/components/project-map/node-editors/configurator/atm_switch/configurator-atm-switch.component.ts
+++ b/src/app/components/project-map/node-editors/configurator/atm_switch/configurator-atm-switch.component.ts
@@ -10,6 +10,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatIconModule } from '@angular/material/icon';
 import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { Node } from '../../../../../cartography/models/node';
 import { Controller } from '@models/controller';
 import { NodeService } from '@services/node.service';
@@ -53,6 +54,7 @@ import { AtmSwitchValidationService } from '@services/validation';
     MatCheckboxModule,
     MatIconModule,
     MatTooltipModule,
+    MatProgressSpinnerModule,
   ],
 })
 export class ConfiguratorDialogAtmSwitchComponent implements OnInit {
@@ -84,6 +86,12 @@ export class ConfiguratorDialogAtmSwitchComponent implements OnInit {
   readonly nodeMappingsDataSource = signal<NodeMapping[]>([]);
   readonly displayedColumns = ['portIn', 'portOut', 'actions'] as const;
 
+  // Apply button loading state
+  readonly isApplying = signal(false);
+
+  // Node data loading state
+  readonly isLoading = signal(true);
+
   constructor() {}
 
   ngOnInit() {
@@ -111,11 +119,15 @@ export class ConfiguratorDialogAtmSwitchComponent implements OnInit {
           }))
         );
         // No markForCheck needed - signals trigger automatic update
+        this.isLoading.set(false);
+        this.dialogRef.disableClose = false;
       },
       error: (err) => {
         const message = err.error?.message || err.message || 'Failed to load node';
         this.toasterService.error(message);
         // No markForCheck needed - toasterService triggers update
+        this.isLoading.set(false);
+        this.dialogRef.disableClose = false;
       },
     });
   }
@@ -194,6 +206,8 @@ export class ConfiguratorDialogAtmSwitchComponent implements OnInit {
   }
 
   onSaveClick() {
+    if (this.isApplying()) return;
+
     if (!this.nameSignal()) {
       this.toasterService.error('Fill all required fields.');
       return;
@@ -214,6 +228,8 @@ export class ConfiguratorDialogAtmSwitchComponent implements OnInit {
       {}
     );
 
+    this.isApplying.set(true);
+    this.dialogRef.disableClose = true;
     this.nodeService.updateNode(this.controller, this.node).subscribe({
       next: () => {
         this.toasterService.success(`Node ${this.node.name} updated.`);
@@ -222,6 +238,8 @@ export class ConfiguratorDialogAtmSwitchComponent implements OnInit {
       error: (error: unknown) => {
         const errorMessage = (error as any)?.error?.message || (error as any)?.message || 'Failed to update node';
         this.toasterService.error(errorMessage);
+        this.isApplying.set(false);
+        this.dialogRef.disableClose = false;
         // No markForCheck needed - toasterService triggers update
       },
     });

--- a/src/app/components/project-map/node-editors/configurator/cloud/configurator-cloud.component.html
+++ b/src/app/components/project-map/node-editors/configurator/cloud/configurator-cloud.component.html
@@ -12,6 +12,11 @@
 </div>
 
 <div class="modal-form-container">
+  @if (isLoading()) {
+    <div class="configurator-dialog-loading">
+      <mat-spinner diameter="40"></mat-spinner>
+    </div>
+  } @else {
   <div class="content">
     <div class="default-content">
       <mat-card class="matCard">
@@ -255,9 +260,16 @@
       <div></div>
     </div>
   </div>
-</div>
+  }
 
-<div mat-dialog-actions>
-  <button mat-button (click)="onCancelClick()" color="accent">Cancel</button>
-  <button mat-raised-button color="primary" (click)="onSaveClick()">Apply</button>
+  <div mat-dialog-actions>
+    <button mat-button (click)="onCancelClick()" color="accent">Cancel</button>
+    <button mat-button (click)="onSaveClick()" tabindex="2" mat-raised-button color="primary" [disabled]="isApplying() || isLoading()">
+      @if (isApplying()) {
+        <mat-spinner diameter="20"></mat-spinner>
+      } @else {
+        Apply
+      }
+    </button>
+  </div>
 </div>

--- a/src/app/components/project-map/node-editors/configurator/cloud/configurator-cloud.component.ts
+++ b/src/app/components/project-map/node-editors/configurator/cloud/configurator-cloud.component.ts
@@ -12,6 +12,7 @@ import { MatChipsModule, MatChipInputEvent } from '@angular/material/chips';
 import { MatIconModule } from '@angular/material/icon';
 import { MatTableModule } from '@angular/material/table';
 import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { COMMA, ENTER } from '@angular/cdk/keycodes';
 import { Node } from '../../../../../cartography/models/node';
 import type { HostInterfaceIPAddress, NetworkInterface } from '../../../../../cartography/models/node';
@@ -45,6 +46,7 @@ import { CloudValidationService } from '@services/validation';
     MatIconModule,
     MatTableModule,
     MatTooltipModule,
+    MatProgressSpinnerModule,
     UdpTunnelsComponent,
   ],
 })
@@ -87,6 +89,9 @@ export class ConfiguratorDialogCloudComponent implements OnInit {
 
   readonly udpTunnels = viewChild<UdpTunnelsComponent>('udpTunnels');
 
+  readonly isApplying = signal(false);
+  readonly isLoading = signal(true);
+
   ngOnInit() {
     this.nodeService.getNode(this.controller, this.node).subscribe({
       next: (node: Node) => {
@@ -126,11 +131,15 @@ export class ConfiguratorDialogCloudComponent implements OnInit {
           this.node.properties.ports_mapping.filter((elem) => elem.type === 'udp')
         );
 
+        this.isLoading.set(false);
+        this.dialogRef.disableClose = false;
         this.cd.markForCheck();
       },
       error: (err) => {
         const message = err.error?.message || err.message || 'Failed to load node';
         this.toasterService.error(message);
+        this.isLoading.set(false);
+        this.dialogRef.disableClose = false;
         this.cd.markForCheck();
       },
     });
@@ -225,6 +234,8 @@ export class ConfiguratorDialogCloudComponent implements OnInit {
   }
 
   onSaveClick() {
+    if (this.isApplying()) return;
+
     // Validate required fields
     const nameValidation = this.validationService.validateName(this.nodeName());
     if (!nameValidation.isValid) {
@@ -284,6 +295,8 @@ export class ConfiguratorDialogCloudComponent implements OnInit {
       .concat(this.portsMappingEthernet())
       .concat(this.portsMappingTap());
 
+    this.isApplying.set(true);
+    this.dialogRef.disableClose = true;
     this.nodeService.updateNode(this.controller, this.node).subscribe({
       next: () => {
         this.toasterService.success(`Node ${this.node.name} updated.`);
@@ -292,6 +305,8 @@ export class ConfiguratorDialogCloudComponent implements OnInit {
       error: (error: unknown) => {
         const errorMessage = (error as any)?.error?.message || (error as any)?.message || 'Failed to update node';
         this.toasterService.error(errorMessage);
+        this.isApplying.set(false);
+        this.dialogRef.disableClose = false;
         this.cd.markForCheck();
       },
     });

--- a/src/app/components/project-map/node-editors/configurator/docker/configurator-docker.component.html
+++ b/src/app/components/project-map/node-editors/configurator/docker/configurator-docker.component.html
@@ -12,6 +12,11 @@
 </div>
 
 <div class="modal-form-container">
+  @if (isLoading()) {
+    <div class="configurator-dialog-loading">
+      <mat-spinner diameter="40"></mat-spinner>
+    </div>
+  } @else {
   <div class="content">
     <div class="default-content">
       <mat-card class="matCard">
@@ -127,13 +132,35 @@
                   />
                 </mat-form-field>
 
-                <mat-checkbox
-                  [checked]="consoleAutoStart()"
-                  (change)="consoleAutoStart.set($event.checked)"
-                  class="grid-span-2"
-                >
-                  Auto start console
-                </mat-checkbox>
+                <div class="three-column-grid grid-span-2">
+                  <app-netmiko-device-type-select
+                    [(value)]="netmikoDeviceType"
+                    [controller]="controller"
+                    class="form-field"
+                  />
+                  <mat-form-field class="form-field">
+                    <mat-label>Default username</mat-label>
+                    <input
+                      matInput
+                      [value]="defaultUsername()"
+                      (input)="defaultUsername.set($event.target.value)"
+                      type="text"
+                      [placeholder]="defaultUsernamePlaceholder() || 'Username to log into this node'"
+                    />
+                  </mat-form-field>
+                  <mat-form-field class="form-field">
+                    <mat-label>Default password</mat-label>
+                    <input
+                      matInput
+                      [value]="defaultPassword()"
+                      (input)="defaultPassword.set($event.target.value)"
+                      type="text"
+                      [placeholder]="defaultPasswordPlaceholder() || 'Password to log into this node'"
+                    />
+                  </mat-form-field>
+                </div>
+
+                <mat-checkbox [checked]="consoleAutoStart()" (change)="consoleAutoStart.set($event.checked)" class="grid-span-2"> Auto start console </mat-checkbox>
               </div>
 
               <div class="node-config__secondary-actions">
@@ -293,9 +320,16 @@
       </mat-card>
     </div>
   </div>
+  }
 </div>
 
 <div mat-dialog-actions>
   <button mat-button (click)="onCancelClick()" color="accent">Cancel</button>
-  <button mat-raised-button color="primary" (click)="onSaveClick()">Apply</button>
+  <button mat-button (click)="onSaveClick()" tabindex="2" mat-raised-button color="primary" [disabled]="isApplying() || isLoading()">
+    @if (isApplying()) {
+      <mat-spinner diameter="20"></mat-spinner>
+    } @else {
+      Apply
+    }
+  </button>
 </div>

--- a/src/app/components/project-map/node-editors/configurator/docker/configurator-docker.component.spec.ts
+++ b/src/app/components/project-map/node-editors/configurator/docker/configurator-docker.component.spec.ts
@@ -13,7 +13,9 @@ import { MatCheckboxModule } from '@angular/material/checkbox';
 import { ConfiguratorDialogDockerComponent } from './configurator-docker.component';
 import { DockerConfigurationService } from '@services/docker-configuration.service';
 import { NodeService } from '@services/node.service';
+import { TemplateService } from '@services/template.service';
 import { ToasterService } from '@services/toaster.service';
+import { NetmikoDeviceTypesService } from '@services/netmiko-device-types.service';
 import { DockerValidationService } from '@services/validation';
 import { Node, Properties } from '../../../../../cartography/models/node';
 import { Controller } from '@models/controller';
@@ -130,6 +132,7 @@ describe('ConfiguratorDialogDockerComponent', () => {
       validateConsoleHttpPath: vi.fn().mockReturnValue({ isValid: true }),
       validateEnvironment: vi.fn().mockReturnValue({ isValid: true }),
       validateExtraConfigs: vi.fn().mockReturnValue({ isValid: true }),
+      validateNetmikoDeviceType: vi.fn().mockReturnValue({ isValid: true }),
     };
 
     mockNodeService = {
@@ -166,7 +169,9 @@ describe('ConfiguratorDialogDockerComponent', () => {
         { provide: MatDialogRef, useValue: mockDialogRef },
         { provide: MatDialog, useValue: mockDialog },
         { provide: NodeService, useValue: mockNodeService },
+        { provide: TemplateService, useValue: { list: () => of([]) } },
         { provide: ToasterService, useValue: mockToasterService },
+        { provide: NetmikoDeviceTypesService, useValue: { getDeviceTypes: vi.fn().mockReturnValue(of({ deviceTypes: null, netmikoVersion: null })) } },
         { provide: DockerConfigurationService, useValue: mockDockerConfigurationService },
         { provide: DockerValidationService, useValue: mockDockerValidationService },
         { provide: ChangeDetectorRef, useValue: mockChangeDetectorRef },

--- a/src/app/components/project-map/node-editors/configurator/docker/configurator-docker.component.ts
+++ b/src/app/components/project-map/node-editors/configurator/docker/configurator-docker.component.ts
@@ -11,6 +11,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatChipsModule, MatChipInputEvent } from '@angular/material/chips';
 import { MatIconModule } from '@angular/material/icon';
 import { MatCheckboxModule } from '@angular/material/checkbox';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { CdkTextareaAutosize } from '@angular/cdk/text-field';
 import { COMMA, ENTER } from '@angular/cdk/keycodes';
 import { Node } from '../../../../../cartography/models/node';
@@ -18,10 +19,12 @@ import { Controller } from '@models/controller';
 import { ExtraConfig } from '@models/templates/extra-config';
 import { DockerConfigurationService } from '@services/docker-configuration.service';
 import { NodeService } from '@services/node.service';
+import { TemplateService } from '@services/template.service';
 import { ToasterService } from '@services/toaster.service';
 import { DockerValidationService } from '@services/validation';
 import { ConfigureCustomAdaptersDialogComponent } from './configure-custom-adapters/configure-custom-adapters.component';
 import { EditNetworkConfigurationDialogComponent } from './edit-network-configuration/edit-network-configuration.component';
+import { NetmikoDeviceTypeSelectComponent } from '@components/netmiko-device-type-select/netmiko-device-type-select.component';
 
 @Component({
   standalone: true,
@@ -42,12 +45,15 @@ import { EditNetworkConfigurationDialogComponent } from './edit-network-configur
     MatChipsModule,
     MatIconModule,
     MatCheckboxModule,
+    MatProgressSpinnerModule,
     CdkTextareaAutosize,
+    NetmikoDeviceTypeSelectComponent,
   ],
 })
 export class ConfiguratorDialogDockerComponent implements OnInit {
   private dialogReference = inject(MatDialogRef<ConfiguratorDialogDockerComponent>);
   private nodeService = inject(NodeService);
+  private templateService = inject(TemplateService);
   private toasterService = inject(ToasterService);
   private dockerConfigurationService = inject(DockerConfigurationService);
   private dialog = inject(MatDialog);
@@ -88,6 +94,9 @@ export class ConfiguratorDialogDockerComponent implements OnInit {
   };
   dialogRef;
 
+  readonly isApplying = signal(false);
+  readonly isLoading = signal(true);
+
   // Model signals
   readonly nodeName = model('');
   readonly dockerImage = model('');
@@ -107,6 +116,11 @@ export class ConfiguratorDialogDockerComponent implements OnInit {
   readonly extraVolumes = model('');
   readonly extraConfigs = signal<ExtraConfig[]>([]);
   readonly usage = model('');
+  readonly netmikoDeviceType = model('');
+  readonly defaultUsername = model(''); readonly defaultPassword = model('');
+  // inherited values shown as placeholders when the node fields are empty
+  readonly defaultUsernamePlaceholder = signal('');
+  readonly defaultPasswordPlaceholder = signal('');
 
   ngOnInit() {
     this.nodeService.getNode(this.controller, this.node).subscribe({
@@ -136,17 +150,40 @@ export class ConfiguratorDialogDockerComponent implements OnInit {
           (node.properties.extra_configs || []).map((c) => ({ target: c.target || '', content: c.content ?? '' }))
         );
         this.usage.set(node.properties.usage || '');
+        this.netmikoDeviceType.set(node.netmiko_device_type || '');
+        this.defaultUsername.set(node.default_username || '');
+        this.defaultPassword.set(node.default_password || '');
+        // empty node credentials: show the template appliance metadata as placeholder
+        if ((!node.default_username || !node.default_password) && node.template_id) {
+          this.templateService.list(this.controller).subscribe({
+            next: (templates) => {
+              const metadata = templates.find((tpl) => tpl.template_id === node.template_id)?.appliance_metadata;
+              if (metadata) {
+                this.defaultUsernamePlaceholder.set(node.default_username ? '' : (metadata.default_username as string) || '');
+                this.defaultPasswordPlaceholder.set(node.default_password ? '' : (metadata.default_password as string) || '');
+                this.cd.markForCheck();
+              }
+            },
+            error: () => {
+              // placeholder is informational only — ignore lookup failures
+            },
+          });
+        }
 
         this.getConfiguration();
         if (!this.node.properties.cpus) this.node.properties.cpus = 0.0;
         if (!this.node.tags) {
           this.node.tags = [];
         }
+        this.isLoading.set(false);
+        this.dialogReference.disableClose = false;
         this.cd.markForCheck();
       },
       error: (err) => {
         const message = err.error?.message || err.message || 'Failed to load node';
         this.toasterService.error(message);
+        this.isLoading.set(false);
+        this.dialogReference.disableClose = false;
         this.cd.markForCheck();
       },
     });
@@ -204,6 +241,8 @@ export class ConfiguratorDialogDockerComponent implements OnInit {
   }
 
   onSaveClick() {
+    if (this.isApplying()) return;
+
     // Validate name (required)
     const nameValidation = this.validationService.validateName(this.nodeName());
     if (!nameValidation.isValid) {
@@ -266,6 +305,13 @@ export class ConfiguratorDialogDockerComponent implements OnInit {
       return;
     }
 
+    // Validate netmiko device type format if provided
+    const netmikoValidation = this.validationService.validateNetmikoDeviceType(this.netmikoDeviceType());
+    if (!netmikoValidation.isValid) {
+      this.toasterService.error(netmikoValidation.errorMessage);
+      return;
+    }
+
     // Merge signal values back into node
     this.node.name = this.nodeName();
     this.node.properties.image = this.dockerImage();
@@ -289,7 +335,12 @@ export class ConfiguratorDialogDockerComponent implements OnInit {
     this.node.properties.extra_configs = extraConfigs;
     this.extraConfigs.set(extraConfigs); // drop blank rows so the editor matches what was saved
     this.node.properties.usage = this.usage();
+    this.node.netmiko_device_type = this.netmikoDeviceType().trim() || null;
+    this.node.default_username = this.defaultUsername().trim() || null;
+    this.node.default_password = this.defaultPassword().trim() || null;
 
+    this.isApplying.set(true);
+    this.dialogReference.disableClose = true;
     this.nodeService.updateNode(this.controller, this.node).subscribe({
       next: () => {
         this.toasterService.success(`Node ${this.node.name} updated.`);
@@ -298,6 +349,8 @@ export class ConfiguratorDialogDockerComponent implements OnInit {
       error: (error: unknown) => {
         const errorMessage = (error as any)?.error?.message || (error as any)?.message || 'Failed to update node';
         this.toasterService.error(errorMessage);
+        this.isApplying.set(false);
+        this.dialogReference.disableClose = false;
         this.cd.markForCheck();
       },
     });

--- a/src/app/components/project-map/node-editors/configurator/docker/configure-custom-adapters/configure-custom-adapters.component.html
+++ b/src/app/components/project-map/node-editors/configurator/docker/configure-custom-adapters/configure-custom-adapters.component.html
@@ -50,5 +50,11 @@
 </div>
 <div mat-dialog-actions align="end">
   <button mat-button (click)="onCancelClick()">Cancel</button>
-  <button mat-raised-button color="primary" (click)="onSaveClick()">Apply</button>
+  <button mat-raised-button color="primary" (click)="onSaveClick()" [disabled]="isApplying()">
+    @if (isApplying()) {
+      <mat-spinner diameter="20"></mat-spinner>
+    } @else {
+      Apply
+    }
+  </button>
 </div>

--- a/src/app/components/project-map/node-editors/configurator/docker/configure-custom-adapters/configure-custom-adapters.component.ts
+++ b/src/app/components/project-map/node-editors/configurator/docker/configure-custom-adapters/configure-custom-adapters.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, inject, model } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, inject, model, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MatDialogRef, MatDialogModule, MatDialogContent } from '@angular/material/dialog';
 import { MatButtonModule } from '@angular/material/button';
@@ -6,6 +6,7 @@ import { MatIconModule } from '@angular/material/icon';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatInputModule } from '@angular/material/input';
 import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { Node } from '../../../../../../cartography/models/node';
 import { Controller } from '@models/controller';
 import { DockerConfigurationService } from '@services/docker-configuration.service';
@@ -17,7 +18,7 @@ import { ValidationService } from '@services/validation';
   selector: 'app-configure-custom-adapters',
   templateUrl: './configure-custom-adapters.component.html',
   styleUrl: './configure-custom-adapters.component.scss',
-  imports: [CommonModule, MatDialogModule, MatButtonModule, MatIconModule, MatTooltipModule, MatInputModule, MatFormFieldModule],
+  imports: [CommonModule, MatDialogModule, MatButtonModule, MatIconModule, MatTooltipModule, MatInputModule, MatFormFieldModule, MatProgressSpinnerModule],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ConfigureCustomAdaptersDialogComponent implements OnInit {
@@ -34,6 +35,7 @@ export class ConfigureCustomAdaptersDialogComponent implements OnInit {
   saveHandler: (adapters: any[]) => void;
 
   readonly adapters = model<any[]>([]);
+  readonly isApplying = signal(false);
 
   constructor() {}
 
@@ -100,6 +102,7 @@ export class ConfigureCustomAdaptersDialogComponent implements OnInit {
   }
 
   onSaveClick() {
+    if (this.isApplying()) return;
     if (this.hasInvalidMac()) {
       this.toasterService.error('One or more MAC addresses are invalid (expected XX:XX:XX:XX:XX:XX)');
       return;
@@ -112,6 +115,8 @@ export class ConfigureCustomAdaptersDialogComponent implements OnInit {
         ...a,
         mac_address: a.mac_address || null,
       }));
+      this.isApplying.set(true);
+      this.dialogRef.disableClose = true;
       this.nodeService.updateNodeWithCustomAdapters(this.controller, this.node).subscribe({
         next: () => {
           this.onCancelClick();
@@ -121,6 +126,8 @@ export class ConfigureCustomAdaptersDialogComponent implements OnInit {
         error: (err) => {
           const message = err.error?.message || err.message || 'Failed to update node with custom adapters';
           this.toasterService.error(message);
+          this.isApplying.set(false);
+          this.dialogRef.disableClose = false;
           this.cdr.markForCheck();
         },
       });

--- a/src/app/components/project-map/node-editors/configurator/docker/edit-network-configuration/edit-network-configuration.component.html
+++ b/src/app/components/project-map/node-editors/configurator/docker/edit-network-configuration/edit-network-configuration.component.html
@@ -292,12 +292,18 @@
 <div mat-dialog-actions>
   <button mat-button color="accent" type="button" [disabled]="saving()" (click)="onCancelClick()">Cancel</button>
   <button
+    mat-button
+    (click)="onSaveClick()"
+    tabindex="2"
     mat-raised-button
     color="primary"
     type="button"
     [disabled]="loading() || loadFailed() || saving()"
-    (click)="onSaveClick()"
   >
-    {{ saving() ? 'Applying…' : 'Apply' }}
+    @if (saving()) {
+      <mat-spinner diameter="20"></mat-spinner>
+    } @else {
+      Apply
+    }
   </button>
 </div>

--- a/src/app/components/project-map/node-editors/configurator/docker/edit-network-configuration/edit-network-configuration.component.ts
+++ b/src/app/components/project-map/node-editors/configurator/docker/edit-network-configuration/edit-network-configuration.component.ts
@@ -192,15 +192,18 @@ export class EditNetworkConfigurationDialogComponent implements OnInit {
 
     const serializedConfiguration = this.configurationPreview();
     this.saving.set(true);
+    this.dialogRef.disableClose = true;
     this.nodeService.saveNetworkConfiguration(this.controller, this.node, serializedConfiguration).subscribe({
       next: () => {
         this.saving.set(false);
+        this.dialogRef.disableClose = false;
         this.dialogRef.close();
         this.toasterService.success(`Configuration for node ${this.node.name} saved.`);
         this.cdr.markForCheck();
       },
       error: (err) => {
         this.saving.set(false);
+        this.dialogRef.disableClose = false;
         const message = err.error?.message || err.message || 'Failed to save network configuration';
         this.toasterService.error(message);
         this.cdr.markForCheck();

--- a/src/app/components/project-map/node-editors/configurator/ethernet-switch/configurator-ethernet-switch.component.html
+++ b/src/app/components/project-map/node-editors/configurator/ethernet-switch/configurator-ethernet-switch.component.html
@@ -12,6 +12,11 @@
 </div>
 
 <div class="modal-form-container">
+  @if (isLoading()) {
+    <div class="configurator-dialog-loading">
+      <mat-spinner diameter="40"></mat-spinner>
+    </div>
+  } @else {
   <div class="node-config__single-tab" role="tablist" aria-label="Node configuration sections">
     <div role="tab" aria-selected="true">
       <span class="node-config__tab-label"><mat-icon>tune</mat-icon>General</span>
@@ -68,9 +73,16 @@
     </div>
     }
   </div>
+  }
 </div>
 
 <div mat-dialog-actions>
   <button mat-button (click)="onCancelClick()" color="accent">Cancel</button>
-  <button mat-raised-button color="primary" (click)="onSaveClick()">Apply</button>
+  <button mat-button (click)="onSaveClick()" tabindex="2" mat-raised-button color="primary" [disabled]="isApplying() || isLoading()">
+    @if (isApplying()) {
+      <mat-spinner diameter="20"></mat-spinner>
+    } @else {
+      Apply
+    }
+  </button>
 </div>

--- a/src/app/components/project-map/node-editors/configurator/ethernet-switch/configurator-ethernet-switch.component.ts
+++ b/src/app/components/project-map/node-editors/configurator/ethernet-switch/configurator-ethernet-switch.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, inject, model } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, inject, model, signal } from '@angular/core';
 import { MatDialogRef, MatDialogModule } from '@angular/material/dialog';
 import { MatCardModule } from '@angular/material/card';
 import { MatFormFieldModule } from '@angular/material/form-field';
@@ -7,6 +7,7 @@ import { MatSelectModule } from '@angular/material/select';
 import { MatButtonModule } from '@angular/material/button';
 import { MatChipsModule, MatChipInputEvent } from '@angular/material/chips';
 import { MatIconModule } from '@angular/material/icon';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { COMMA, ENTER } from '@angular/cdk/keycodes';
 import { Node } from '../../../../../cartography/models/node';
 import { PortsComponent } from '@components/preferences/common/ports/ports.component';
@@ -31,6 +32,7 @@ import { ValidationService } from '@services/validation';
     MatButtonModule,
     MatChipsModule,
     MatIconModule,
+    MatProgressSpinnerModule,
     PortsComponent,
   ],
 })
@@ -52,6 +54,12 @@ export class ConfiguratorDialogEthernetSwitchComponent implements OnInit {
   readonly nodeName = model('');
   readonly consoleType = model('');
 
+  // Apply button loading state
+  readonly isApplying = signal(false);
+
+  // Node data loading state
+  readonly isLoading = signal(true);
+
   ngOnInit() {
     this.nodeService.getNode(this.controller, this.node).subscribe({
       next: (node: Node) => {
@@ -67,11 +75,15 @@ export class ConfiguratorDialogEthernetSwitchComponent implements OnInit {
           this.node.tags = [];
         }
         this.cd.markForCheck();
+        this.isLoading.set(false);
+        this.dialogRef.disableClose = false;
       },
       error: (err) => {
         const message = err.error?.message || err.message || 'Failed to load node';
         this.toasterService.error(message);
         this.cd.markForCheck();
+        this.isLoading.set(false);
+        this.dialogRef.disableClose = false;
       },
     });
   }
@@ -81,6 +93,8 @@ export class ConfiguratorDialogEthernetSwitchComponent implements OnInit {
   }
 
   onSaveClick() {
+    if (this.isApplying()) return;
+
     // Validate name (required)
     const nameValidation = this.validationService.required(this.nodeName(), 'Name');
     if (!nameValidation.isValid) {
@@ -92,6 +106,8 @@ export class ConfiguratorDialogEthernetSwitchComponent implements OnInit {
     this.node.name = this.nodeName();
     this.node.console_type = this.consoleType();
 
+    this.isApplying.set(true);
+    this.dialogRef.disableClose = true;
     this.nodeService.updateNode(this.controller, this.node).subscribe({
       next: () => {
         this.toasterService.success(`Node ${this.node.name} updated.`);
@@ -100,6 +116,8 @@ export class ConfiguratorDialogEthernetSwitchComponent implements OnInit {
       error: (error: unknown) => {
         const errorMessage = (error as any)?.error?.message || (error as any)?.message || 'Failed to update node';
         this.toasterService.error(errorMessage);
+        this.isApplying.set(false);
+        this.dialogRef.disableClose = false;
         this.cd.markForCheck();
       },
     });

--- a/src/app/components/project-map/node-editors/configurator/ethernet_hub/configurator-ethernet-hub.component.html
+++ b/src/app/components/project-map/node-editors/configurator/ethernet_hub/configurator-ethernet-hub.component.html
@@ -12,6 +12,11 @@
 </div>
 
 <div class="modal-form-container">
+  @if (isLoading()) {
+    <div class="configurator-dialog-loading">
+      <mat-spinner diameter="40"></mat-spinner>
+    </div>
+  } @else {
   <div class="node-config__single-tab" role="tablist" aria-label="Node configuration sections">
     <div role="tab" aria-selected="true">
       <span class="node-config__tab-label"><mat-icon>tune</mat-icon>General</span>
@@ -59,9 +64,16 @@
       </mat-card>
     </div>
   </div>
+  }
 </div>
 
 <div mat-dialog-actions>
   <button mat-button (click)="onCancelClick()" color="accent">Cancel</button>
-  <button mat-raised-button color="primary" (click)="onSaveClick()">Apply</button>
+  <button mat-button (click)="onSaveClick()" tabindex="2" mat-raised-button color="primary" [disabled]="isApplying() || isLoading()">
+    @if (isApplying()) {
+      <mat-spinner diameter="20"></mat-spinner>
+    } @else {
+      Apply
+    }
+  </button>
 </div>

--- a/src/app/components/project-map/node-editors/configurator/ethernet_hub/configurator-ethernet-hub.component.ts
+++ b/src/app/components/project-map/node-editors/configurator/ethernet_hub/configurator-ethernet-hub.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, inject, model } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, inject, model, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { MatDialogRef, MatDialogModule } from '@angular/material/dialog';
@@ -8,6 +8,7 @@ import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
 import { MatChipsModule, MatChipInputEvent } from '@angular/material/chips';
 import { MatIconModule } from '@angular/material/icon';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { COMMA, ENTER } from '@angular/cdk/keycodes';
 import { Node } from '../../../../../cartography/models/node';
 import { Controller } from '@models/controller';
@@ -32,6 +33,7 @@ import { ValidationService } from '@services/validation';
     MatButtonModule,
     MatChipsModule,
     MatIconModule,
+    MatProgressSpinnerModule,
   ],
 })
 export class ConfiguratorDialogEthernetHubComponent implements OnInit {
@@ -54,6 +56,12 @@ export class ConfiguratorDialogEthernetHubComponent implements OnInit {
   readonly nodeName = model('');
   readonly nodeNumberOfPorts = model('');
 
+  // Apply button loading state
+  readonly isApplying = signal(false);
+
+  // Node data loading state
+  readonly isLoading = signal(true);
+
   ngOnInit() {
     this.nodeService.getNode(this.controller, this.node).subscribe({
       next: (node: Node) => {
@@ -70,11 +78,15 @@ export class ConfiguratorDialogEthernetHubComponent implements OnInit {
           this.node.tags = [];
         }
         this.cd.markForCheck();
+        this.isLoading.set(false);
+        this.dialogRef.disableClose = false;
       },
       error: (err) => {
         const message = err.error?.message || err.message || 'Failed to load node';
         this.toasterService.error(message);
         this.cd.markForCheck();
+        this.isLoading.set(false);
+        this.dialogRef.disableClose = false;
       },
     });
   }
@@ -85,6 +97,8 @@ export class ConfiguratorDialogEthernetHubComponent implements OnInit {
   }
 
   onSaveClick() {
+    if (this.isApplying()) return;
+
     // Validate name (required)
     const nameValidation = this.validationService.required(this.nodeName(), 'Name');
     if (!nameValidation.isValid) {
@@ -116,6 +130,8 @@ export class ConfiguratorDialogEthernetHubComponent implements OnInit {
       });
     }
 
+    this.isApplying.set(true);
+    this.dialogRef.disableClose = true;
     this.nodeService.updateNode(this.controller, this.node).subscribe({
       next: () => {
         this.toasterService.success(`Node ${this.node.name} updated.`);
@@ -124,6 +140,8 @@ export class ConfiguratorDialogEthernetHubComponent implements OnInit {
       error: (error: unknown) => {
         const errorMessage = (error as any)?.error?.message || (error as any)?.message || 'Failed to update node';
         this.toasterService.error(errorMessage);
+        this.isApplying.set(false);
+        this.dialogRef.disableClose = false;
         this.cd.markForCheck();
       },
     });

--- a/src/app/components/project-map/node-editors/configurator/ios/configurator-ios.component.html
+++ b/src/app/components/project-map/node-editors/configurator/ios/configurator-ios.component.html
@@ -12,6 +12,11 @@
 </div>
 
 <div class="modal-form-container">
+  @if (isLoading()) {
+    <div class="configurator-dialog-loading">
+      <mat-spinner diameter="40"></mat-spinner>
+    </div>
+  } @else {
   <div class="content">
     <div class="default-content">
       <mat-card class="matCard">
@@ -91,11 +96,34 @@
                     }
                   </mat-select>
                 </mat-form-field>
-                <mat-checkbox
-                  class="form-grid__full"
-                  [checked]="consoleAutoStart()"
-                  (change)="consoleAutoStart.set($event.checked)"
-                >
+                <div class="three-column-grid form-grid__full">
+                  <app-netmiko-device-type-select
+                    [(value)]="netmikoDeviceType"
+                    [controller]="controller"
+                    class="form-field"
+                  />
+                  <mat-form-field class="form-field">
+                    <mat-label>Default username</mat-label>
+                    <input
+                      matInput
+                      [value]="defaultUsername()"
+                      (input)="defaultUsername.set($event.target.value)"
+                      type="text"
+                      [placeholder]="defaultUsernamePlaceholder() || 'Username to log into this node'"
+                    />
+                  </mat-form-field>
+                  <mat-form-field class="form-field">
+                    <mat-label>Default password</mat-label>
+                    <input
+                      matInput
+                      [value]="defaultPassword()"
+                      (input)="defaultPassword.set($event.target.value)"
+                      type="text"
+                      [placeholder]="defaultPasswordPlaceholder() || 'Password to log into this node'"
+                    />
+                  </mat-form-field>
+                </div>
+                <mat-checkbox class="form-grid__full" [checked]="consoleAutoStart()" (change)="consoleAutoStart.set($event.checked)">
                   Auto start console
                 </mat-checkbox>
               </div>
@@ -293,9 +321,16 @@
       </mat-card>
     </div>
   </div>
+  }
 </div>
 
 <div mat-dialog-actions>
   <button mat-button (click)="onCancelClick()" color="accent">Cancel</button>
-  <button mat-raised-button color="primary" (click)="onSaveClick()">Apply</button>
+  <button mat-button (click)="onSaveClick()" tabindex="2" mat-raised-button color="primary" [disabled]="isApplying() || isLoading()">
+    @if (isApplying()) {
+      <mat-spinner diameter="20"></mat-spinner>
+    } @else {
+      Apply
+    }
+  </button>
 </div>

--- a/src/app/components/project-map/node-editors/configurator/ios/configurator-ios.component.spec.ts
+++ b/src/app/components/project-map/node-editors/configurator/ios/configurator-ios.component.spec.ts
@@ -4,7 +4,9 @@ import { of, Subject, throwError } from 'rxjs';
 import { ConfiguratorDialogIosComponent } from './configurator-ios.component';
 import { IosConfigurationService } from '@services/ios-configuration.service';
 import { NodeService } from '@services/node.service';
+import { TemplateService } from '@services/template.service';
 import { ToasterService } from '@services/toaster.service';
+import { NetmikoDeviceTypesService } from '@services/netmiko-device-types.service';
 import { IosValidationService } from '@services/validation';
 import { Node, Properties } from '../../../../../cartography/models/node';
 import { Controller } from '@models/controller';
@@ -127,6 +129,7 @@ describe('ConfiguratorDialogIosComponent', () => {
       validateRamForPlatform: vi.fn().mockReturnValue({ isValid: true }),
       validateNvramForPlatform: vi.fn().mockReturnValue({ isValid: true }),
       validateIomem: vi.fn().mockReturnValue({ isValid: true }),
+      validateNetmikoDeviceType: vi.fn().mockReturnValue({ isValid: true }),
     };
 
     mockConfigurationService = {
@@ -208,7 +211,9 @@ describe('ConfiguratorDialogIosComponent', () => {
       providers: [
         { provide: MatDialogRef, useValue: mockDialogRef },
         { provide: NodeService, useValue: mockNodeService },
+        { provide: TemplateService, useValue: { list: () => of([]) } },
         { provide: ToasterService, useValue: mockToasterService },
+        { provide: NetmikoDeviceTypesService, useValue: { getDeviceTypes: vi.fn().mockReturnValue(of({ deviceTypes: null, netmikoVersion: null })) } },
         { provide: IosConfigurationService, useValue: mockConfigurationService },
         { provide: IosValidationService, useValue: mockValidationService },
         { provide: ChangeDetectorRef, useValue: mockChangeDetectorRef },

--- a/src/app/components/project-map/node-editors/configurator/ios/configurator-ios.component.ts
+++ b/src/app/components/project-map/node-editors/configurator/ios/configurator-ios.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, inject, model } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, inject, model, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { MatDialogRef, MatDialogModule } from '@angular/material/dialog';
@@ -11,13 +11,16 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatChipsModule, MatChipInputEvent } from '@angular/material/chips';
 import { MatIconModule } from '@angular/material/icon';
 import { MatCheckboxModule } from '@angular/material/checkbox';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { COMMA, ENTER } from '@angular/cdk/keycodes';
 import { Node } from '../../../../../cartography/models/node';
 import { Controller } from '@models/controller';
 import { IosConfigurationService } from '@services/ios-configuration.service';
 import { NodeService } from '@services/node.service';
+import { TemplateService } from '@services/template.service';
 import { ToasterService } from '@services/toaster.service';
 import { IosValidationService } from '@services/validation';
+import { NetmikoDeviceTypeSelectComponent } from '@components/netmiko-device-type-select/netmiko-device-type-select.component';
 
 @Component({
   standalone: true,
@@ -38,11 +41,14 @@ import { IosValidationService } from '@services/validation';
     MatChipsModule,
     MatIconModule,
     MatCheckboxModule,
+    MatProgressSpinnerModule,
+    NetmikoDeviceTypeSelectComponent,
   ],
 })
 export class ConfiguratorDialogIosComponent implements OnInit {
   private dialogRef = inject(MatDialogRef<ConfiguratorDialogIosComponent>);
   private nodeService = inject(NodeService);
+  private templateService = inject(TemplateService);
   private toasterService = inject(ToasterService);
   private configurationService = inject(IosConfigurationService);
   private cd = inject(ChangeDetectorRef);
@@ -57,6 +63,9 @@ export class ConfiguratorDialogIosComponent implements OnInit {
   adapterMatrix = {};
   wicMatrix = {};
   readonly separatorKeysCodes: number[] = [ENTER, COMMA];
+
+  readonly isApplying = signal(false);
+  readonly isLoading = signal(true);
 
   // Model signals
   readonly nodeName = model('');
@@ -89,6 +98,11 @@ export class ConfiguratorDialogIosComponent implements OnInit {
   readonly mmap = model(false);
   readonly sparsemem = model(false);
   readonly usage = model('');
+  readonly netmikoDeviceType = model('');
+  readonly defaultUsername = model(''); readonly defaultPassword = model('');
+  // inherited values shown as placeholders when the node fields are empty
+  readonly defaultUsernamePlaceholder = signal('');
+  readonly defaultPasswordPlaceholder = signal('');
 
   ngOnInit() {
     this.nodeService.getNode(this.controller, this.node).subscribe({
@@ -125,6 +139,25 @@ export class ConfiguratorDialogIosComponent implements OnInit {
         this.mmap.set(node.properties.mmap || false);
         this.sparsemem.set(node.properties.sparsemem || false);
         this.usage.set(node.properties.usage || '');
+        this.netmikoDeviceType.set(node.netmiko_device_type || '');
+        this.defaultUsername.set(node.default_username || '');
+        this.defaultPassword.set(node.default_password || '');
+        // empty node credentials: show the template appliance metadata as placeholder
+        if ((!node.default_username || !node.default_password) && node.template_id) {
+          this.templateService.list(this.controller).subscribe({
+            next: (templates) => {
+              const metadata = templates.find((tpl) => tpl.template_id === node.template_id)?.appliance_metadata;
+              if (metadata) {
+                this.defaultUsernamePlaceholder.set(node.default_username ? '' : (metadata.default_username as string) || '');
+                this.defaultPasswordPlaceholder.set(node.default_password ? '' : (metadata.default_password as string) || '');
+                this.cd.markForCheck();
+              }
+            },
+            error: () => {
+              // placeholder is informational only — ignore lookup failures
+            },
+          });
+        }
 
         if (!this.node.tags) {
           this.node.tags = [];
@@ -132,11 +165,15 @@ export class ConfiguratorDialogIosComponent implements OnInit {
         this.getConfiguration();
         this.fillSlotsData();
         this.cd.markForCheck();
+        this.isLoading.set(false);
+        this.dialogRef.disableClose = false;
       },
       error: (err) => {
         const message = err.error?.message || err.message || 'Failed to load node';
         this.toasterService.error(message);
         this.cd.markForCheck();
+        this.isLoading.set(false);
+        this.dialogRef.disableClose = false;
       },
     });
   }
@@ -194,6 +231,8 @@ export class ConfiguratorDialogIosComponent implements OnInit {
   }
 
   onSaveClick() {
+    if (this.isApplying()) return;
+
     // Validate required fields
     const nameValidation = this.validationService.validateName(this.nodeName());
     if (!nameValidation.isValid) { this.toasterService.error(nameValidation.errorMessage); return; }
@@ -209,6 +248,8 @@ export class ConfiguratorDialogIosComponent implements OnInit {
     if (!macValidation.isValid) { this.toasterService.error(macValidation.errorMessage); return; }
     const idlepcValidation = this.validationService.validateIdlepc(this.idlepc());
     if (!idlepcValidation.isValid) { this.toasterService.error(idlepcValidation.errorMessage); return; }
+    const netmikoValidation = this.validationService.validateNetmikoDeviceType(this.netmikoDeviceType());
+    if (!netmikoValidation.isValid) { this.toasterService.error(netmikoValidation.errorMessage); return; }
     if (this.iomem()) {
       const iomemValidation = this.validationService.validateIomem(this.iomem());
       if (!iomemValidation.isValid) { this.toasterService.error(iomemValidation.errorMessage); return; }
@@ -252,8 +293,13 @@ export class ConfiguratorDialogIosComponent implements OnInit {
     this.node.properties.mmap = this.mmap();
     this.node.properties.sparsemem = this.sparsemem();
     this.node.properties.usage = this.usage();
+    this.node.netmiko_device_type = this.netmikoDeviceType().trim() || null;
+    this.node.default_username = this.defaultUsername().trim() || null;
+    this.node.default_password = this.defaultPassword().trim() || null;
 
     this.saveSlotsData();
+    this.isApplying.set(true);
+    this.dialogRef.disableClose = true;
     this.nodeService.updateNode(this.controller, this.node).subscribe({
       next: () => {
         this.toasterService.success(`Node ${this.node.name} updated.`);
@@ -262,6 +308,8 @@ export class ConfiguratorDialogIosComponent implements OnInit {
       error: (error: unknown) => {
         const errorMessage = (error as any)?.error?.message || (error as any)?.message || 'Failed to update node';
         this.toasterService.error(errorMessage);
+        this.isApplying.set(false);
+        this.dialogRef.disableClose = false;
         this.cd.markForCheck();
       },
     });

--- a/src/app/components/project-map/node-editors/configurator/iou/configurator-iou.component.html
+++ b/src/app/components/project-map/node-editors/configurator/iou/configurator-iou.component.html
@@ -12,6 +12,11 @@
 </div>
 
 <div class="modal-form-container">
+  @if (isLoading()) {
+    <div class="configurator-dialog-loading">
+      <mat-spinner diameter="40"></mat-spinner>
+    </div>
+  } @else {
   <div class="content">
     <div class="default-content">
       <mat-card class="matCard">
@@ -56,9 +61,31 @@
                 </mat-select>
               </mat-form-field>
 
-              <mat-checkbox [checked]="consoleAutoStart()" (change)="consoleAutoStart.set($event.checked)">
-                Auto start console
-              </mat-checkbox>
+              <div class="three-column-grid">
+                <app-netmiko-device-type-select [(value)]="netmikoDeviceType" [controller]="controller" class="form-field" />
+                <mat-form-field class="form-field">
+                  <mat-label>Default username</mat-label>
+                  <input
+                    matInput
+                    [value]="defaultUsername()"
+                    (input)="defaultUsername.set($event.target.value)"
+                    type="text"
+                    [placeholder]="defaultUsernamePlaceholder() || 'Username to log into this node'"
+                  />
+                </mat-form-field>
+                <mat-form-field class="form-field">
+                  <mat-label>Default password</mat-label>
+                  <input
+                    matInput
+                    [value]="defaultPassword()"
+                    (input)="defaultPassword.set($event.target.value)"
+                    type="text"
+                    [placeholder]="defaultPasswordPlaceholder() || 'Password to log into this node'"
+                  />
+                </mat-form-field>
+              </div>
+
+              <mat-checkbox [checked]="consoleAutoStart()" (change)="consoleAutoStart.set($event.checked)"> Auto start console </mat-checkbox>
 
               <mat-checkbox [checked]="l1Keepalives()" (change)="l1Keepalives.set($event.checked)">
                 Enable Layer 1 keepalive messages
@@ -133,9 +160,16 @@
       </mat-card>
     </div>
   </div>
+  }
 </div>
 
 <div mat-dialog-actions>
   <button mat-button (click)="onCancelClick()" color="accent">Cancel</button>
-  <button mat-raised-button color="primary" (click)="onSaveClick()">Apply</button>
+  <button mat-button (click)="onSaveClick()" tabindex="2" mat-raised-button color="primary" [disabled]="isApplying() || isLoading()">
+    @if (isApplying()) {
+      <mat-spinner diameter="20"></mat-spinner>
+    } @else {
+      Apply
+    }
+  </button>
 </div>

--- a/src/app/components/project-map/node-editors/configurator/iou/configurator-iou.component.spec.ts
+++ b/src/app/components/project-map/node-editors/configurator/iou/configurator-iou.component.spec.ts
@@ -8,7 +8,9 @@ import { COMMA, ENTER } from '@angular/cdk/keycodes';
 import { ConfiguratorDialogIouComponent } from './configurator-iou.component';
 import { IouConfigurationService } from '@services/iou-configuration.service';
 import { NodeService } from '@services/node.service';
+import { TemplateService } from '@services/template.service';
 import { ToasterService } from '@services/toaster.service';
+import { NetmikoDeviceTypesService } from '@services/netmiko-device-types.service';
 import { IouValidationService } from '@services/validation';
 import { Node } from '../../../../../cartography/models/node';
 import { Controller } from '@models/controller';
@@ -142,6 +144,7 @@ describe('ConfiguratorDialogIouComponent', () => {
       validatePath: vi.fn().mockReturnValue({ isValid: true }),
       validateEthernetAdapters: vi.fn().mockReturnValue({ isValid: true }),
       validateSerialAdapters: vi.fn().mockReturnValue({ isValid: true }),
+      validateNetmikoDeviceType: vi.fn().mockReturnValue({ isValid: true }),
     };
 
     mockChangeDetectorRef = {
@@ -160,7 +163,9 @@ describe('ConfiguratorDialogIouComponent', () => {
       providers: [
         { provide: MatDialogRef, useValue: mockDialogRef },
         { provide: NodeService, useValue: mockNodeService },
+        { provide: TemplateService, useValue: { list: () => of([]) } },
         { provide: ToasterService, useValue: mockToasterService },
+        { provide: NetmikoDeviceTypesService, useValue: { getDeviceTypes: vi.fn().mockReturnValue(of({ deviceTypes: null, netmikoVersion: null })) } },
         { provide: IouConfigurationService, useValue: mockConfigurationService },
         { provide: IouValidationService, useValue: mockValidationService },
         { provide: ChangeDetectorRef, useValue: mockChangeDetectorRef },
@@ -212,7 +217,9 @@ describe('ConfiguratorDialogIouComponent', () => {
         providers: [
           { provide: MatDialogRef, useValue: mockDialogRef },
           { provide: NodeService, useValue: mockNodeService },
+          { provide: TemplateService, useValue: { list: () => of([]) } },
           { provide: ToasterService, useValue: mockToasterService },
+          { provide: NetmikoDeviceTypesService, useValue: { getDeviceTypes: vi.fn().mockReturnValue(of({ deviceTypes: null, netmikoVersion: null })) } },
           { provide: IouConfigurationService, useValue: mockConfigurationService },
           
         ],
@@ -245,7 +252,9 @@ describe('ConfiguratorDialogIouComponent', () => {
         providers: [
           { provide: MatDialogRef, useValue: mockDialogRef },
           { provide: NodeService, useValue: mockNodeService },
+          { provide: TemplateService, useValue: { list: () => of([]) } },
           { provide: ToasterService, useValue: mockToasterService },
+          { provide: NetmikoDeviceTypesService, useValue: { getDeviceTypes: vi.fn().mockReturnValue(of({ deviceTypes: null, netmikoVersion: null })) } },
           { provide: IouConfigurationService, useValue: mockConfigurationService },
           
         ],
@@ -296,7 +305,9 @@ describe('ConfiguratorDialogIouComponent', () => {
         providers: [
           { provide: MatDialogRef, useValue: mockDialogRef },
           { provide: NodeService, useValue: mockNodeService },
+          { provide: TemplateService, useValue: { list: () => of([]) } },
           { provide: ToasterService, useValue: mockToasterService },
+          { provide: NetmikoDeviceTypesService, useValue: { getDeviceTypes: vi.fn().mockReturnValue(of({ deviceTypes: null, netmikoVersion: null })) } },
           { provide: IouConfigurationService, useValue: mockConfigurationService },
           
         ],
@@ -355,7 +366,9 @@ describe('ConfiguratorDialogIouComponent', () => {
         providers: [
           { provide: MatDialogRef, useValue: mockDialogRef },
           { provide: NodeService, useValue: mockNodeService },
+          { provide: TemplateService, useValue: { list: () => of([]) } },
           { provide: ToasterService, useValue: mockToasterService },
+          { provide: NetmikoDeviceTypesService, useValue: { getDeviceTypes: vi.fn().mockReturnValue(of({ deviceTypes: null, netmikoVersion: null })) } },
           { provide: IouConfigurationService, useValue: mockConfigurationService },
           
         ],

--- a/src/app/components/project-map/node-editors/configurator/iou/configurator-iou.component.ts
+++ b/src/app/components/project-map/node-editors/configurator/iou/configurator-iou.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, inject, model } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, inject, model, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { MatDialogRef, MatDialogModule } from '@angular/material/dialog';
@@ -11,13 +11,16 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatChipsModule, MatChipInputEvent } from '@angular/material/chips';
 import { MatIconModule } from '@angular/material/icon';
 import { MatCheckboxModule } from '@angular/material/checkbox';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { COMMA, ENTER } from '@angular/cdk/keycodes';
 import { Node } from '../../../../../cartography/models/node';
 import { Controller } from '@models/controller';
 import { IouConfigurationService } from '@services/iou-configuration.service';
 import { NodeService } from '@services/node.service';
+import { TemplateService } from '@services/template.service';
 import { ToasterService } from '@services/toaster.service';
 import { IouValidationService } from '@services/validation';
+import { NetmikoDeviceTypeSelectComponent } from '@components/netmiko-device-type-select/netmiko-device-type-select.component';
 
 @Component({
   standalone: true,
@@ -38,11 +41,14 @@ import { IouValidationService } from '@services/validation';
     MatChipsModule,
     MatIconModule,
     MatCheckboxModule,
+    MatProgressSpinnerModule,
+    NetmikoDeviceTypeSelectComponent,
   ],
 })
 export class ConfiguratorDialogIouComponent implements OnInit {
   private dialogRef = inject(MatDialogRef<ConfiguratorDialogIouComponent>);
   private nodeService = inject(NodeService);
+  private templateService = inject(TemplateService);
   private toasterService = inject(ToasterService);
   private configurationService = inject(IouConfigurationService);
   private cd = inject(ChangeDetectorRef);
@@ -53,6 +59,9 @@ export class ConfiguratorDialogIouComponent implements OnInit {
   name: string;
   readonly separatorKeysCodes: number[] = [ENTER, COMMA];
   consoleTypes: string[] = [];
+
+  readonly isApplying = signal(false);
+  readonly isLoading = signal(true);
 
   // Model signals
   readonly nodeName = model('');
@@ -65,6 +74,11 @@ export class ConfiguratorDialogIouComponent implements OnInit {
   readonly ethernetAdapters = model('');
   readonly serialAdapters = model('');
   readonly usage = model('');
+  readonly netmikoDeviceType = model('');
+  readonly defaultUsername = model(''); readonly defaultPassword = model('');
+  // inherited values shown as placeholders when the node fields are empty
+  readonly defaultUsernamePlaceholder = signal('');
+  readonly defaultPasswordPlaceholder = signal('');
 
   ngOnInit() {
     this.nodeService.getNode(this.controller, this.node).subscribe({
@@ -84,17 +98,40 @@ export class ConfiguratorDialogIouComponent implements OnInit {
         this.ethernetAdapters.set(node.properties.ethernet_adapters?.toString() || '');
         this.serialAdapters.set(node.properties.serial_adapters?.toString() || '');
         this.usage.set(node.properties.usage || '');
+        this.netmikoDeviceType.set(node.netmiko_device_type || '');
+        this.defaultUsername.set(node.default_username || '');
+        this.defaultPassword.set(node.default_password || '');
+        // empty node credentials: show the template appliance metadata as placeholder
+        if ((!node.default_username || !node.default_password) && node.template_id) {
+          this.templateService.list(this.controller).subscribe({
+            next: (templates) => {
+              const metadata = templates.find((tpl) => tpl.template_id === node.template_id)?.appliance_metadata;
+              if (metadata) {
+                this.defaultUsernamePlaceholder.set(node.default_username ? '' : (metadata.default_username as string) || '');
+                this.defaultPasswordPlaceholder.set(node.default_password ? '' : (metadata.default_password as string) || '');
+                this.cd.markForCheck();
+              }
+            },
+            error: () => {
+              // placeholder is informational only — ignore lookup failures
+            },
+          });
+        }
 
         this.getConfiguration();
         if (!this.node.tags) {
           this.node.tags = [];
         }
         this.cd.markForCheck();
+        this.isLoading.set(false);
+        this.dialogRef.disableClose = false;
       },
       error: (err) => {
         const message = err.error?.message || err.message || 'Failed to load node';
         this.toasterService.error(message);
         this.cd.markForCheck();
+        this.isLoading.set(false);
+        this.dialogRef.disableClose = false;
       },
     });
   }
@@ -104,6 +141,8 @@ export class ConfiguratorDialogIouComponent implements OnInit {
   }
 
   onSaveClick() {
+    if (this.isApplying()) return;
+
     // Validate required fields
     const nameValidation = this.validationService.validateName(this.nodeName());
     if (!nameValidation.isValid) { this.toasterService.error(nameValidation.errorMessage); return; }
@@ -111,6 +150,8 @@ export class ConfiguratorDialogIouComponent implements OnInit {
     if (!ethValidation.isValid) { this.toasterService.error(ethValidation.errorMessage); return; }
     const serialValidation = this.validationService.validateSerialAdapters(this.serialAdapters());
     if (!serialValidation.isValid) { this.toasterService.error(serialValidation.errorMessage); return; }
+    const netmikoValidation = this.validationService.validateNetmikoDeviceType(this.netmikoDeviceType());
+    if (!netmikoValidation.isValid) { this.toasterService.error(netmikoValidation.errorMessage); return; }
 
     this.node.name = this.nodeName();
     this.node.console_type = this.consoleType();
@@ -120,9 +161,14 @@ export class ConfiguratorDialogIouComponent implements OnInit {
     this.node.properties.ram = parseInt(this.ram(), 10) || 0;
     this.node.properties.nvram = parseInt(this.nvram(), 10) || 0;
     this.node.properties.usage = this.usage();
+    this.node.netmiko_device_type = this.netmikoDeviceType().trim() || null;
+    this.node.default_username = this.defaultUsername().trim() || null;
+    this.node.default_password = this.defaultPassword().trim() || null;
     this.node.properties.ethernet_adapters = parseInt(this.ethernetAdapters(), 10) || 0;
     this.node.properties.serial_adapters = parseInt(this.serialAdapters(), 10) || 0;
 
+    this.isApplying.set(true);
+    this.dialogRef.disableClose = true;
     this.nodeService.updateNode(this.controller, this.node).subscribe({
       next: () => {
         this.toasterService.success(`Node ${this.node.name} updated.`);
@@ -131,6 +177,8 @@ export class ConfiguratorDialogIouComponent implements OnInit {
       error: (error: unknown) => {
         const errorMessage = (error as any)?.error?.message || (error as any)?.message || 'Failed to update node';
         this.toasterService.error(errorMessage);
+        this.isApplying.set(false);
+        this.dialogRef.disableClose = false;
         this.cd.markForCheck();
       },
     });

--- a/src/app/components/project-map/node-editors/configurator/nat/configurator-nat.component.html
+++ b/src/app/components/project-map/node-editors/configurator/nat/configurator-nat.component.html
@@ -12,6 +12,11 @@
 </div>
 
 <div class="modal-form-container">
+  @if (isLoading()) {
+    <div class="configurator-dialog-loading">
+      <mat-spinner diameter="40"></mat-spinner>
+    </div>
+  } @else {
   <div class="node-config__single-tab" role="tablist" aria-label="Node configuration sections">
     <div role="tab" aria-selected="true">
       <span class="node-config__tab-label"><mat-icon>tune</mat-icon>General</span>
@@ -92,9 +97,16 @@
       </mat-card>
     </div>
   </div>
+  }
 </div>
 
 <div mat-dialog-actions>
   <button mat-button (click)="onCancelClick()" color="accent">Cancel</button>
-  <button mat-raised-button color="primary" (click)="onSaveClick()">Apply</button>
+  <button mat-button (click)="onSaveClick()" tabindex="2" mat-raised-button color="primary" [disabled]="isApplying() || isLoading()">
+    @if (isApplying()) {
+      <mat-spinner diameter="20"></mat-spinner>
+    } @else {
+      Apply
+    }
+  </button>
 </div>

--- a/src/app/components/project-map/node-editors/configurator/nat/configurator-nat.component.ts
+++ b/src/app/components/project-map/node-editors/configurator/nat/configurator-nat.component.ts
@@ -9,6 +9,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatTableModule } from '@angular/material/table';
 import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { COMMA, ENTER } from '@angular/cdk/keycodes';
 import { MatChipInputEvent, MatChipsModule } from '@angular/material/chips';
 import { Node } from '../../../../../cartography/models/node';
@@ -38,6 +39,7 @@ import { formatFlags, formatIpAddress, formatIpAddresses, formatInterfaceMeta } 
     MatIconModule,
     MatTableModule,
     MatTooltipModule,
+    MatProgressSpinnerModule,
   ],
 })
 export class ConfiguratorDialogNatComponent implements OnInit {
@@ -54,6 +56,9 @@ export class ConfiguratorDialogNatComponent implements OnInit {
 
   portsMappingEthernet = signal<PortsMappingEntity[]>([]);
   ethernetDisplayColumns: string[] = ['name', 'ipAddresses'];
+
+  readonly isApplying = signal(false);
+  readonly isLoading = signal(true);
 
   // Model signals
   readonly nodeName = model('');
@@ -80,11 +85,15 @@ export class ConfiguratorDialogNatComponent implements OnInit {
           this.node.properties.ports_mapping.filter((elem) => elem.type === 'ethernet')
         );
 
+        this.isLoading.set(false);
+        this.dialogRef.disableClose = false;
         this.cd.markForCheck();
       },
       error: (err) => {
         const message = err.error?.message || err.message || 'Failed to load node';
         this.toasterService.error(message);
+        this.isLoading.set(false);
+        this.dialogRef.disableClose = false;
         this.cd.markForCheck();
       },
     });
@@ -101,6 +110,8 @@ export class ConfiguratorDialogNatComponent implements OnInit {
   }
 
   onSaveClick() {
+    if (this.isApplying()) return;
+
     const nameValidation = this.validationService.required(this.nodeName(), 'Name');
     if (!nameValidation.isValid) {
       this.toasterService.error(nameValidation.errorMessage || 'Name is required');
@@ -111,6 +122,8 @@ export class ConfiguratorDialogNatComponent implements OnInit {
 
     this.node.properties.ports_mapping = this.portsMappingEthernet();
 
+    this.isApplying.set(true);
+    this.dialogRef.disableClose = true;
     this.nodeService.updateNode(this.controller, this.node).subscribe({
       next: () => {
         this.toasterService.success(`Node ${this.node.name} updated.`);
@@ -119,6 +132,8 @@ export class ConfiguratorDialogNatComponent implements OnInit {
       error: (error: unknown) => {
         const errorMessage = (error as any)?.error?.message || (error as any)?.message || 'Failed to update node';
         this.toasterService.error(errorMessage);
+        this.isApplying.set(false);
+        this.dialogRef.disableClose = false;
         this.cd.markForCheck();
       },
     });

--- a/src/app/components/project-map/node-editors/configurator/qemu/configurator-qemu.component.html
+++ b/src/app/components/project-map/node-editors/configurator/qemu/configurator-qemu.component.html
@@ -12,6 +12,11 @@
 </div>
 
 <div class="modal-form-container">
+  @if (isLoading()) {
+    <div class="configurator-dialog-loading">
+      <mat-spinner diameter="40"></mat-spinner>
+    </div>
+  } @else {
   <div class="content">
     <div class="default-content">
       <mat-card class="matCard">
@@ -112,6 +117,30 @@
                     <mat-option [value]="type">{{ type }}</mat-option>
                     }
                   </mat-select>
+                </mat-form-field>
+              </div>
+
+              <div class="three-column-grid">
+                <app-netmiko-device-type-select [(value)]="netmikoDeviceType" [controller]="controller" class="form-field" />
+                <mat-form-field class="form-field">
+                  <mat-label>Default username</mat-label>
+                  <input
+                    matInput
+                    [value]="defaultUsername()"
+                    (input)="defaultUsername.set($event.target.value)"
+                    type="text"
+                    [placeholder]="defaultUsernamePlaceholder() || 'Username to log into this node'"
+                  />
+                </mat-form-field>
+                <mat-form-field class="form-field">
+                  <mat-label>Default password</mat-label>
+                  <input
+                    matInput
+                    [value]="defaultPassword()"
+                    (input)="defaultPassword.set($event.target.value)"
+                    type="text"
+                    [placeholder]="defaultPasswordPlaceholder() || 'Password to log into this node'"
+                  />
                 </mat-form-field>
               </div>
 
@@ -717,9 +746,16 @@
       </mat-card>
     </div>
   </div>
+  }
 </div>
 
 <div mat-dialog-actions>
   <button mat-button (click)="onCancelClick()" color="accent">Cancel</button>
-  <button mat-raised-button color="primary" (click)="onSaveClick()">Apply</button>
+  <button mat-button (click)="onSaveClick()" tabindex="2" mat-raised-button color="primary" [disabled]="isApplying() || isLoading()">
+    @if (isApplying()) {
+      <mat-spinner diameter="20"></mat-spinner>
+    } @else {
+      Apply
+    }
+  </button>
 </div>

--- a/src/app/components/project-map/node-editors/configurator/qemu/configurator-qemu.component.spec.ts
+++ b/src/app/components/project-map/node-editors/configurator/qemu/configurator-qemu.component.spec.ts
@@ -6,7 +6,9 @@ import { ConfiguratorDialogQemuComponent } from './configurator-qemu.component';
 import { QemuConfigurationService } from '@services/qemu-configuration.service';
 import { QemuService } from '@services/qemu.service';
 import { NodeService } from '@services/node.service';
+import { TemplateService } from '@services/template.service';
 import { ToasterService } from '@services/toaster.service';
+import { NetmikoDeviceTypesService } from '@services/netmiko-device-types.service';
 import { ValidationService } from '@services/validation';
 import { ImageManagerService } from '@services/image-manager.service';
 import { Node } from '../../../../../cartography/models/node';
@@ -204,6 +206,7 @@ describe('ConfiguratorDialogQemuComponent', () => {
 
     mockValidationService = {
       required: vi.fn().mockReturnValue({ isValid: true, errorMessage: '' }),
+      validateNetmikoDeviceType: vi.fn().mockReturnValue({ isValid: true }),
     };
 
     mockImageManagerService = {
@@ -227,9 +230,11 @@ describe('ConfiguratorDialogQemuComponent', () => {
       providers: [
         { provide: MatDialogRef, useValue: mockDialogRef },
         { provide: NodeService, useValue: mockNodeService },
+        { provide: TemplateService, useValue: { list: () => of([]) } },
         { provide: QemuService, useValue: mockQemuService },
         { provide: QemuConfigurationService, useValue: mockQemuConfigurationService },
         { provide: ToasterService, useValue: mockToasterService },
+        { provide: NetmikoDeviceTypesService, useValue: { getDeviceTypes: vi.fn().mockReturnValue(of({ deviceTypes: null, netmikoVersion: null })) } },
         { provide: ValidationService, useValue: mockValidationService },
         { provide: ImageManagerService, useValue: mockImageManagerService },
         { provide: ChangeDetectorRef, useValue: mockCd },

--- a/src/app/components/project-map/node-editors/configurator/qemu/configurator-qemu.component.ts
+++ b/src/app/components/project-map/node-editors/configurator/qemu/configurator-qemu.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, inject, model } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, inject, model, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { MatDialog, MatDialogRef, MatDialogModule } from '@angular/material/dialog';
@@ -12,6 +12,7 @@ import { MatChipsModule, MatChipInputEvent } from '@angular/material/chips';
 import { MatIconModule } from '@angular/material/icon';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatAutocompleteModule } from '@angular/material/autocomplete';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { COMMA, ENTER } from '@angular/cdk/keycodes';
 import { Node } from '../../../../../cartography/models/node';
 import { CustomAdapter } from '@models/qemu/qemu-custom-adapter';
@@ -19,6 +20,7 @@ import { QemuBinary } from '@models/qemu/qemu-binary';
 import { QemuImage } from '@models/qemu/qemu-image';
 import { Controller } from '@models/controller';
 import { NodeService } from '@services/node.service';
+import { TemplateService } from '@services/template.service';
 import { QemuConfigurationService } from '@services/qemu-configuration.service';
 import { QemuService } from '@services/qemu.service';
 import { ToasterService } from '@services/toaster.service';
@@ -30,6 +32,7 @@ import {
   CustomAdaptersDialogResult,
 } from '@components/preferences/common/custom-adapters/custom-adapters.component';
 import { QemuImageCreatorComponent } from './qemu-image-creator/qemu-image-creator.component';
+import { NetmikoDeviceTypeSelectComponent } from '@components/netmiko-device-type-select/netmiko-device-type-select.component';
 
 @Component({
   standalone: true,
@@ -51,12 +54,15 @@ import { QemuImageCreatorComponent } from './qemu-image-creator/qemu-image-creat
     MatIconModule,
     MatCheckboxModule,
     MatAutocompleteModule,
+    MatProgressSpinnerModule,
+    NetmikoDeviceTypeSelectComponent,
   ],
 })
 export class ConfiguratorDialogQemuComponent implements OnInit {
   private dialog = inject(MatDialog);
   private dialogRef = inject(MatDialogRef<ConfiguratorDialogQemuComponent>);
   private nodeService = inject(NodeService);
+  private templateService = inject(TemplateService);
   private toasterService = inject(ToasterService);
   private qemuService = inject(QemuService);
   private qemuConfigurationService = inject(QemuConfigurationService);
@@ -96,6 +102,9 @@ export class ConfiguratorDialogQemuComponent implements OnInit {
   };
   dialogRefQemuImageCreator;
 
+  readonly isApplying = signal(false);
+  readonly isLoading = signal(true);
+
   // Model signals
   readonly nodeName = model('');
   readonly ram = model('');
@@ -122,6 +131,11 @@ export class ConfiguratorDialogQemuComponent implements OnInit {
   readonly options = model(''); readonly tpm = model(false);
   readonly uefi = model(false);
   readonly usage = model('');
+  readonly netmikoDeviceType = model('');
+  readonly defaultUsername = model(''); readonly defaultPassword = model('');
+  // inherited values shown as placeholders when the node fields are empty
+  readonly defaultUsernamePlaceholder = signal('');
+  readonly defaultPasswordPlaceholder = signal('');
   readonly linkedClone = model(false);
   readonly maxcpus = model('');
   readonly createConfigDisk = model(false);
@@ -166,6 +180,25 @@ export class ConfiguratorDialogQemuComponent implements OnInit {
         this.tpm.set(node.properties.tpm || false);
         this.uefi.set(node.properties.uefi || false);
         this.usage.set(node.properties.usage || '');
+        this.netmikoDeviceType.set(node.netmiko_device_type || '');
+        this.defaultUsername.set(node.default_username || '');
+        this.defaultPassword.set(node.default_password || '');
+        // empty node credentials: show the template appliance metadata as placeholder
+        if ((!node.default_username || !node.default_password) && node.template_id) {
+          this.templateService.list(this.controller).subscribe({
+            next: (templates) => {
+              const metadata = templates.find((tpl) => tpl.template_id === node.template_id)?.appliance_metadata;
+              if (metadata) {
+                this.defaultUsernamePlaceholder.set(node.default_username ? '' : (metadata.default_username as string) || '');
+                this.defaultPasswordPlaceholder.set(node.default_password ? '' : (metadata.default_password as string) || '');
+                this.cd.markForCheck();
+              }
+            },
+            error: () => {
+              // placeholder is informational only — ignore lookup failures
+            },
+          });
+        }
         this.linkedClone.set(node.properties.linked_clone ?? true);
         this.maxcpus.set(node.properties.maxcpus?.toString() || '');
         this.createConfigDisk.set(node.properties.create_config_disk ?? false);
@@ -212,11 +245,15 @@ export class ConfiguratorDialogQemuComponent implements OnInit {
         // allGlobalFiles is already loaded by qemuService.getImages() above
         this.getConfiguration();
         this.cd.markForCheck();
+        this.isLoading.set(false);
+        this.dialogRef.disableClose = false;
       },
       error: (err) => {
         const message = err.error?.message || err.message || 'Failed to load node';
         this.toasterService.error(message);
         this.cd.markForCheck();
+        this.isLoading.set(false);
+        this.dialogRef.disableClose = false;
       },
     });
 
@@ -481,11 +518,15 @@ export class ConfiguratorDialogQemuComponent implements OnInit {
   }
 
   onSaveClick() {
+    if (this.isApplying()) return;
+
     // Validate required fields
     const nameValidation = this.validationService.required(this.nodeName(), 'Name');
     if (!nameValidation.isValid) { this.toasterService.error(nameValidation.errorMessage); return; }
     const ramValidation = this.validationService.required(this.ram(), 'RAM');
     if (!ramValidation.isValid) { this.toasterService.error(ramValidation.errorMessage); return; }
+    const netmikoValidation = this.validationService.validateNetmikoDeviceType(this.netmikoDeviceType());
+    if (!netmikoValidation.isValid) { this.toasterService.error(netmikoValidation.errorMessage); return; }
 
     // Merge signal values back into node
     this.node.name = this.nodeName();
@@ -517,6 +558,9 @@ export class ConfiguratorDialogQemuComponent implements OnInit {
     this.node.properties.tpm = this.tpm();
     this.node.properties.uefi = this.uefi();
     this.node.properties.usage = this.usage();
+    this.node.netmiko_device_type = this.netmikoDeviceType().trim() || null;
+    this.node.default_username = this.defaultUsername().trim() || null;
+    this.node.default_password = this.defaultPassword().trim() || null;
     this.node.properties.linked_clone = this.linkedClone();
     this.node.properties.maxcpus = parseInt(this.maxcpus(), 10) || undefined;
     this.node.properties.create_config_disk = this.createConfigDisk();
@@ -525,6 +569,8 @@ export class ConfiguratorDialogQemuComponent implements OnInit {
     this.node.properties.adapter_type = this.adapterType();
     this.node.properties.replicate_network_connection_state = this.replicateNetworkState();
 
+    this.isApplying.set(true);
+    this.dialogRef.disableClose = true;
     this.nodeService.updateNodeWithCustomAdapters(this.controller, this.node).subscribe({
       next: () => {
         this.toasterService.success(`Node ${this.node.name} updated.`);
@@ -533,6 +579,8 @@ export class ConfiguratorDialogQemuComponent implements OnInit {
       error: (error) => {
         const errorMessage = error.error?.message || error.message || 'Failed to update node';
         this.toasterService.error(errorMessage);
+        this.isApplying.set(false);
+        this.dialogRef.disableClose = false;
       },
     });
   }

--- a/src/app/components/project-map/node-editors/configurator/qemu/qemu-image-creator/qemu-image-creator.component.html
+++ b/src/app/components/project-map/node-editors/configurator/qemu/qemu-image-creator/qemu-image-creator.component.html
@@ -147,5 +147,11 @@
 
 <div mat-dialog-actions>
   <button mat-button (click)="onCancelClick()" color="accent">Cancel</button>
-  <button mat-raised-button color="primary" (click)="onSaveClick()">Apply</button>
+  <button mat-button (click)="onSaveClick()" tabindex="2" mat-raised-button color="primary" [disabled]="isApplying()">
+    @if (isApplying()) {
+      <mat-spinner diameter="20"></mat-spinner>
+    } @else {
+      Apply
+    }
+  </button>
 </div>

--- a/src/app/components/project-map/node-editors/configurator/qemu/qemu-image-creator/qemu-image-creator.component.ts
+++ b/src/app/components/project-map/node-editors/configurator/qemu/qemu-image-creator/qemu-image-creator.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, inject, model } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject, model, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { MatDialogRef, MatDialogModule } from '@angular/material/dialog';
@@ -8,6 +8,7 @@ import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { MatOptionModule } from '@angular/material/core';
 import { MatCardModule } from '@angular/material/card';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { Controller } from '@models/controller';
 import { NodeService } from '@services/node.service';
 import { QemuService, QemuDiskImageOptions } from '@services/qemu.service';
@@ -28,6 +29,7 @@ import { ValidationService } from '@services/validation';
     MatSelectModule,
     MatOptionModule,
     MatCardModule,
+    MatProgressSpinnerModule,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
@@ -59,6 +61,8 @@ export class QemuImageCreatorComponent {
   readonly adapterType = model('');
   readonly zeroedGrain = model('');
 
+  readonly isApplying = signal(false);
+
   readonly mountPointOptions = ['hda', 'hdb', 'hdc', 'hdd'];
 
   // Format-specific options
@@ -69,6 +73,7 @@ export class QemuImageCreatorComponent {
   readonly adapterTypeOptions = ['ide', 'lsilogic', 'buslogic', 'legacyESX'];
 
   onSaveClick() {
+    if (this.isApplying()) return;
     // Validate mount point
     const mountValidation = this.validationService.required(this.mountPoint(), 'Mount point');
     if (!mountValidation.isValid) { this.toasterService.error(mountValidation.errorMessage); return; }
@@ -105,6 +110,8 @@ export class QemuImageCreatorComponent {
     if (this.adapterType()) options.adapter_type = this.adapterType();
     if (this.zeroedGrain()) options.zeroed_grain = this.zeroedGrain();
 
+    this.isApplying.set(true);
+    this.dialogRef.disableClose = true;
     this.qemuService.createDiskImage(this.controller, this.projectId, this.nodeId, this.diskName(), options).subscribe({
       next: () => {
         this.toasterService.success(`Disk image "${this.diskName()}" created.`);
@@ -113,6 +120,8 @@ export class QemuImageCreatorComponent {
       error: (error) => {
         const errorMessage = error.error?.detail || error.message || 'Failed to create image';
         this.toasterService.error(errorMessage);
+        this.isApplying.set(false);
+        this.dialogRef.disableClose = false;
       },
     });
   }

--- a/src/app/components/project-map/node-editors/configurator/switch/configurator-switch.component.html
+++ b/src/app/components/project-map/node-editors/configurator/switch/configurator-switch.component.html
@@ -12,6 +12,11 @@
 </div>
 
 <div class="modal-form-container">
+  @if (isLoading()) {
+    <div class="configurator-dialog-loading">
+      <mat-spinner diameter="40"></mat-spinner>
+    </div>
+  } @else {
   <div class="node-config__single-tab" role="tablist" aria-label="Node configuration sections">
     <div role="tab" aria-selected="true">
       <span class="node-config__tab-label"><mat-icon>tune</mat-icon>General</span>
@@ -92,9 +97,16 @@
       </mat-card>
     </div>
   </div>
+  }
 </div>
 
 <div mat-dialog-actions>
   <button mat-button (click)="onCancelClick()" color="accent">Cancel</button>
-  <button mat-raised-button color="primary" (click)="onSaveClick()">Apply</button>
+  <button mat-button (click)="onSaveClick()" tabindex="2" mat-raised-button color="primary" [disabled]="isApplying() || isLoading()">
+    @if (isApplying()) {
+      <mat-spinner diameter="20"></mat-spinner>
+    } @else {
+      Apply
+    }
+  </button>
 </div>

--- a/src/app/components/project-map/node-editors/configurator/switch/configurator-switch.component.ts
+++ b/src/app/components/project-map/node-editors/configurator/switch/configurator-switch.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, inject, model } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, inject, model, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { MatDialogRef, MatDialogModule } from '@angular/material/dialog';
@@ -9,6 +9,7 @@ import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { Node } from '../../../../../cartography/models/node';
 import { Controller } from '@models/controller';
 import { NodeService } from '@services/node.service';
@@ -51,6 +52,7 @@ import { ValidationService } from '@services/validation';
     MatButtonModule,
     MatIconModule,
     MatTooltipModule,
+    MatProgressSpinnerModule,
   ],
 })
 export class ConfiguratorDialogSwitchComponent implements OnInit {
@@ -77,6 +79,12 @@ export class ConfiguratorDialogSwitchComponent implements OnInit {
   readonly destinationPort = model('');
   readonly destinationDlci = model('');
 
+  // Apply button loading state
+  readonly isApplying = signal(false);
+
+  // Node data loading state
+  readonly isLoading = signal(true);
+
   ngOnInit() {
     this.nodeService.getNode(this.controller, this.node).subscribe({
       next: (node: Node) => {
@@ -94,11 +102,15 @@ export class ConfiguratorDialogSwitchComponent implements OnInit {
           portOut: value,
         }));
         this.cd.markForCheck();
+        this.isLoading.set(false);
+        this.dialogRef.disableClose = false;
       },
       error: (err) => {
         const message = err.error?.message || err.message || 'Failed to load node';
         this.toasterService.error(message);
         this.cd.markForCheck();
+        this.isLoading.set(false);
+        this.dialogRef.disableClose = false;
       },
     });
   }
@@ -180,6 +192,8 @@ export class ConfiguratorDialogSwitchComponent implements OnInit {
   }
 
   onSaveClick() {
+    if (this.isApplying()) return;
+
     // Validate name (required)
     const nameValidation = this.validationService.required(this.nodeName(), 'Name');
     if (!nameValidation.isValid) {
@@ -198,6 +212,8 @@ export class ConfiguratorDialogSwitchComponent implements OnInit {
       {}
     );
 
+    this.isApplying.set(true);
+    this.dialogRef.disableClose = true;
     this.nodeService.updateNode(this.controller, this.node).subscribe({
       next: () => {
         this.toasterService.success(`Node ${this.node.name} updated.`);
@@ -206,6 +222,8 @@ export class ConfiguratorDialogSwitchComponent implements OnInit {
       error: (error: unknown) => {
         const errorMessage = (error as any)?.error?.message || (error as any)?.message || 'Failed to update node';
         this.toasterService.error(errorMessage);
+        this.isApplying.set(false);
+        this.dialogRef.disableClose = false;
       },
     });
   }

--- a/src/app/components/project-map/node-editors/configurator/virtualbox/configurator-virtualbox.component.html
+++ b/src/app/components/project-map/node-editors/configurator/virtualbox/configurator-virtualbox.component.html
@@ -113,5 +113,11 @@
 
 <div mat-dialog-actions>
   <button mat-button (click)="onCancelClick()" color="accent">Cancel</button>
-  <button mat-raised-button color="primary" (click)="onSaveClick()">Apply</button>
+  <button mat-button (click)="onSaveClick()" tabindex="2" mat-raised-button color="primary" [disabled]="isApplying()">
+    @if (isApplying()) {
+      <mat-spinner diameter="20"></mat-spinner>
+    } @else {
+      Apply
+    }
+  </button>
 </div>

--- a/src/app/components/project-map/node-editors/configurator/virtualbox/configurator-virtualbox.component.ts
+++ b/src/app/components/project-map/node-editors/configurator/virtualbox/configurator-virtualbox.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, inject } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import {
   FormsModule,
@@ -18,6 +18,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatChipsModule, MatChipInputEvent } from '@angular/material/chips';
 import { MatIconModule } from '@angular/material/icon';
 import { MatCheckboxModule } from '@angular/material/checkbox';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { COMMA, ENTER } from '@angular/cdk/keycodes';
 import { Node } from '../../../../../cartography/models/node';
 import { CustomAdapter } from '@models/qemu/qemu-custom-adapter';
@@ -58,6 +59,7 @@ import {
     MatChipsModule,
     MatIconModule,
     MatCheckboxModule,
+    MatProgressSpinnerModule,
   ],
 })
 export class ConfiguratorDialogVirtualBoxComponent implements OnInit {
@@ -78,6 +80,8 @@ export class ConfiguratorDialogVirtualBoxComponent implements OnInit {
   readonly separatorKeysCodes: number[] = [ENTER, COMMA];
 
   networkTypes = [];
+
+  readonly isApplying = signal(false);
 
   constructor() {
     this.generalSettingsForm = this.formBuilder.group({
@@ -192,6 +196,8 @@ export class ConfiguratorDialogVirtualBoxComponent implements OnInit {
   }
 
   onSaveClick() {
+    if (this.isApplying()) return;
+
     if (this.generalSettingsForm.valid) {
       // Merge form values back into node
       const formValues = this.generalSettingsForm.value;
@@ -205,6 +211,7 @@ export class ConfiguratorDialogVirtualBoxComponent implements OnInit {
       this.node.properties.use_any_adapter = formValues.use_any_adapter;
       this.node.properties.usage = formValues.usage;
 
+      this.isApplying.set(true);
       this.nodeService.updateNodeWithCustomAdapters(this.controller, this.node).subscribe({
         next: () => {
           this.toasterService.success(`Node ${this.node.name} updated.`);
@@ -213,6 +220,7 @@ export class ConfiguratorDialogVirtualBoxComponent implements OnInit {
         error: (error: unknown) => {
           const errorMessage = (error as any)?.error?.message || (error as any)?.message || 'Failed to update node';
           this.toasterService.error(errorMessage);
+          this.isApplying.set(false);
           this.cd.markForCheck();
         },
       });

--- a/src/app/components/project-map/node-editors/configurator/vmware/configurator-vmware.component.html
+++ b/src/app/components/project-map/node-editors/configurator/vmware/configurator-vmware.component.html
@@ -108,5 +108,11 @@
 
 <div mat-dialog-actions>
   <button mat-button (click)="onCancelClick()" color="accent">Cancel</button>
-  <button mat-raised-button color="primary" (click)="onSaveClick()">Apply</button>
+  <button mat-button (click)="onSaveClick()" tabindex="2" mat-raised-button color="primary" [disabled]="isApplying()">
+    @if (isApplying()) {
+      <mat-spinner diameter="20"></mat-spinner>
+    } @else {
+      Apply
+    }
+  </button>
 </div>

--- a/src/app/components/project-map/node-editors/configurator/vmware/configurator-vmware.component.ts
+++ b/src/app/components/project-map/node-editors/configurator/vmware/configurator-vmware.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, inject } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import {
   FormsModule,
@@ -18,6 +18,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatChipsModule, MatChipInputEvent } from '@angular/material/chips';
 import { MatIconModule } from '@angular/material/icon';
 import { MatCheckboxModule } from '@angular/material/checkbox';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { COMMA, ENTER } from '@angular/cdk/keycodes';
 import { Node } from '../../../../../cartography/models/node';
 import { CustomAdapter } from '@models/qemu/qemu-custom-adapter';
@@ -58,6 +59,7 @@ import {
     MatChipsModule,
     MatIconModule,
     MatCheckboxModule,
+    MatProgressSpinnerModule,
   ],
 })
 export class ConfiguratorDialogVmwareComponent implements OnInit {
@@ -78,6 +80,8 @@ export class ConfiguratorDialogVmwareComponent implements OnInit {
   onCloseOptions = [];
 
   networkTypes = [];
+
+  readonly isApplying = signal(false);
 
   constructor() {
     this.generalSettingsForm = this.formBuilder.group({
@@ -192,6 +196,8 @@ export class ConfiguratorDialogVmwareComponent implements OnInit {
   }
 
   onSaveClick() {
+    if (this.isApplying()) return;
+
     if (this.generalSettingsForm.valid) {
       // Merge form values back into node
       const formValues = this.generalSettingsForm.value;
@@ -205,6 +211,7 @@ export class ConfiguratorDialogVmwareComponent implements OnInit {
       this.node.properties.use_any_adapter = formValues.use_any_adapter;
       this.node.properties.usage = formValues.usage;
 
+      this.isApplying.set(true);
       this.nodeService.updateNodeWithCustomAdapters(this.controller, this.node).subscribe({
         next: () => {
           this.toasterService.success(`Node ${this.node.name} updated.`);
@@ -213,6 +220,7 @@ export class ConfiguratorDialogVmwareComponent implements OnInit {
         error: (error: unknown) => {
           const errorMessage = (error as any)?.error?.message || (error as any)?.message || 'Failed to update node';
           this.toasterService.error(errorMessage);
+          this.isApplying.set(false);
         },
       });
     } else {

--- a/src/app/components/project-map/node-editors/configurator/vpcs/configurator-vpcs.component.html
+++ b/src/app/components/project-map/node-editors/configurator/vpcs/configurator-vpcs.component.html
@@ -12,6 +12,11 @@
 </div>
 
 <div class="modal-form-container">
+  @if (isLoading()) {
+    <div class="configurator-dialog-loading">
+      <mat-spinner diameter="40"></mat-spinner>
+    </div>
+  } @else {
   <div class="node-config__single-tab" role="tablist" aria-label="Node configuration sections">
     <div role="tab" aria-selected="true">
       <span class="node-config__tab-label"><mat-icon>tune</mat-icon>General</span>
@@ -60,16 +65,45 @@
             </mat-select>
           </mat-form-field>
 
-          <mat-checkbox [checked]="consoleAutoStart()" (change)="consoleAutoStart.set($event.checked)">
-            Auto start console
-          </mat-checkbox>
+          <div class="three-column-grid">
+            <app-netmiko-device-type-select [(value)]="netmikoDeviceType" [controller]="controller" class="form-field" />
+            <mat-form-field class="form-field">
+              <mat-label>Default username</mat-label>
+              <input
+                matInput
+                [value]="defaultUsername()"
+                (input)="defaultUsername.set($event.target.value)"
+                type="text"
+                [placeholder]="defaultUsernamePlaceholder() || 'Username to log into this node'"
+              />
+            </mat-form-field>
+            <mat-form-field class="form-field">
+              <mat-label>Default password</mat-label>
+              <input
+                matInput
+                [value]="defaultPassword()"
+                (input)="defaultPassword.set($event.target.value)"
+                type="text"
+                [placeholder]="defaultPasswordPlaceholder() || 'Password to log into this node'"
+              />
+            </mat-form-field>
+          </div>
+
+          <mat-checkbox [checked]="consoleAutoStart()" (change)="consoleAutoStart.set($event.checked)"> Auto start console </mat-checkbox>
         </div>
       </mat-card>
     </div>
   </div>
+  }
 </div>
 
 <div mat-dialog-actions>
   <button mat-button (click)="onCancelClick()" color="accent">Cancel</button>
-  <button mat-raised-button color="primary" (click)="onSaveClick()">Apply</button>
+  <button mat-button (click)="onSaveClick()" tabindex="2" mat-raised-button color="primary" [disabled]="isApplying() || isLoading()">
+    @if (isApplying()) {
+      <mat-spinner diameter="20"></mat-spinner>
+    } @else {
+      Apply
+    }
+  </button>
 </div>

--- a/src/app/components/project-map/node-editors/configurator/vpcs/configurator-vpcs.component.spec.ts
+++ b/src/app/components/project-map/node-editors/configurator/vpcs/configurator-vpcs.component.spec.ts
@@ -4,7 +4,9 @@ import { MatDialogRef } from '@angular/material/dialog';
 import { MatChipsModule } from '@angular/material/chips';
 import { ConfiguratorDialogVpcsComponent } from './configurator-vpcs.component';
 import { NodeService } from '@services/node.service';
+import { TemplateService } from '@services/template.service';
 import { ToasterService } from '@services/toaster.service';
+import { NetmikoDeviceTypesService } from '@services/netmiko-device-types.service';
 import { VpcsConfigurationService } from '@services/vpcs-configuration.service';
 import { ValidationService } from '@services/validation';
 import { Node } from '../../../../../cartography/models/node';
@@ -52,6 +54,7 @@ describe('ConfiguratorDialogVpcsComponent', () => {
 
     mockValidationService = {
       required: vi.fn().mockReturnValue({ isValid: true }),
+      validateNetmikoDeviceType: vi.fn().mockReturnValue({ isValid: true }),
     };
 
     mockChangeDetectorRef = {
@@ -63,7 +66,9 @@ describe('ConfiguratorDialogVpcsComponent', () => {
       providers: [
         { provide: MatDialogRef, useValue: mockDialogRef },
         { provide: NodeService, useValue: mockNodeService },
+        { provide: TemplateService, useValue: { list: () => of([]) } },
         { provide: ToasterService, useValue: mockToasterService },
+        { provide: NetmikoDeviceTypesService, useValue: { getDeviceTypes: vi.fn().mockReturnValue(of({ deviceTypes: null, netmikoVersion: null })) } },
         { provide: VpcsConfigurationService, useValue: mockVpcsConfigurationService },
         { provide: ValidationService, useValue: mockValidationService },
         { provide: ChangeDetectorRef, useValue: mockChangeDetectorRef },

--- a/src/app/components/project-map/node-editors/configurator/vpcs/configurator-vpcs.component.ts
+++ b/src/app/components/project-map/node-editors/configurator/vpcs/configurator-vpcs.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, inject, model } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, inject, model, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { MatDialogRef, MatDialogModule } from '@angular/material/dialog';
@@ -10,13 +10,16 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatChipsModule, MatChipInputEvent } from '@angular/material/chips';
 import { MatIconModule } from '@angular/material/icon';
 import { MatCheckboxModule } from '@angular/material/checkbox';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { COMMA, ENTER } from '@angular/cdk/keycodes';
 import { Node } from '../../../../../cartography/models/node';
 import { Controller } from '@models/controller';
 import { NodeService } from '@services/node.service';
+import { TemplateService } from '@services/template.service';
 import { ToasterService } from '@services/toaster.service';
 import { VpcsConfigurationService } from '@services/vpcs-configuration.service';
 import { ValidationService } from '@services/validation';
+import { NetmikoDeviceTypeSelectComponent } from '@components/netmiko-device-type-select/netmiko-device-type-select.component';
 
 @Component({
   standalone: true,
@@ -36,11 +39,14 @@ import { ValidationService } from '@services/validation';
     MatChipsModule,
     MatIconModule,
     MatCheckboxModule,
+    MatProgressSpinnerModule,
+    NetmikoDeviceTypeSelectComponent,
   ],
 })
 export class ConfiguratorDialogVpcsComponent implements OnInit {
   private dialogRef = inject(MatDialogRef<ConfiguratorDialogVpcsComponent>);
   private nodeService = inject(NodeService);
+  private templateService = inject(TemplateService);
   private toasterService = inject(ToasterService);
   private vpcsConfigurationService = inject(VpcsConfigurationService);
   private cd = inject(ChangeDetectorRef);
@@ -56,6 +62,17 @@ export class ConfiguratorDialogVpcsComponent implements OnInit {
   readonly nodeName = model('');
   readonly consoleType = model('');
   readonly consoleAutoStart = model(false);
+  readonly netmikoDeviceType = model('');
+  readonly defaultUsername = model(''); readonly defaultPassword = model('');
+  // inherited values shown as placeholders when the node fields are empty
+  readonly defaultUsernamePlaceholder = signal('');
+  readonly defaultPasswordPlaceholder = signal('');
+
+  // Apply button loading state
+  readonly isApplying = signal(false);
+
+  // Node data loading state
+  readonly isLoading = signal(true);
 
   ngOnInit() {
     this.nodeService.getNode(this.controller, this.node).subscribe({
@@ -67,17 +84,40 @@ export class ConfiguratorDialogVpcsComponent implements OnInit {
         this.nodeName.set(node.name || '');
         this.consoleType.set(node.console_type || '');
         this.consoleAutoStart.set(node.console_auto_start || false);
+        this.netmikoDeviceType.set(node.netmiko_device_type || '');
+        this.defaultUsername.set(node.default_username || '');
+        this.defaultPassword.set(node.default_password || '');
+        // empty node credentials: show the template appliance metadata as placeholder
+        if ((!node.default_username || !node.default_password) && node.template_id) {
+          this.templateService.list(this.controller).subscribe({
+            next: (templates) => {
+              const metadata = templates.find((tpl) => tpl.template_id === node.template_id)?.appliance_metadata;
+              if (metadata) {
+                this.defaultUsernamePlaceholder.set(node.default_username ? '' : (metadata.default_username as string) || '');
+                this.defaultPasswordPlaceholder.set(node.default_password ? '' : (metadata.default_password as string) || '');
+                this.cd.markForCheck();
+              }
+            },
+            error: () => {
+              // placeholder is informational only — ignore lookup failures
+            },
+          });
+        }
 
         this.getConfiguration();
         if (!this.node.tags) {
           this.node.tags = [];
         }
         this.cd.markForCheck();
+        this.isLoading.set(false);
+        this.dialogRef.disableClose = false;
       },
       error: (err) => {
         const message = err.error?.message || err.message || 'Failed to load node';
         this.toasterService.error(message);
         this.cd.markForCheck();
+        this.isLoading.set(false);
+        this.dialogRef.disableClose = false;
       },
     });
   }
@@ -87,6 +127,8 @@ export class ConfiguratorDialogVpcsComponent implements OnInit {
   }
 
   onSaveClick() {
+    if (this.isApplying()) return;
+
     // Validate name (required)
     const nameValidation = this.validationService.required(this.nodeName(), 'Name');
     if (!nameValidation.isValid) {
@@ -94,10 +136,21 @@ export class ConfiguratorDialogVpcsComponent implements OnInit {
       return;
     }
 
+    const netmikoValidation = this.validationService.validateNetmikoDeviceType(this.netmikoDeviceType());
+    if (!netmikoValidation.isValid) {
+      this.toasterService.error(netmikoValidation.errorMessage);
+      return;
+    }
+
     this.node.name = this.nodeName();
     this.node.console_type = this.consoleType();
     this.node.console_auto_start = this.consoleAutoStart();
+    this.node.netmiko_device_type = this.netmikoDeviceType().trim() || null;
+    this.node.default_username = this.defaultUsername().trim() || null;
+    this.node.default_password = this.defaultPassword().trim() || null;
 
+    this.isApplying.set(true);
+    this.dialogRef.disableClose = true;
     this.nodeService.updateNode(this.controller, this.node).subscribe({
       next: () => {
         this.toasterService.success(`Node ${this.node.name} updated.`);
@@ -106,6 +159,8 @@ export class ConfiguratorDialogVpcsComponent implements OnInit {
       error: (error: unknown) => {
         const errorMessage = (error as any)?.error?.message || (error as any)?.message || 'Failed to update node';
         this.toasterService.error(errorMessage);
+        this.isApplying.set(false);
+        this.dialogRef.disableClose = false;
         this.cd.markForCheck();
       },
     });

--- a/src/app/components/project-map/packet-capturing/packet-filters/packet-filters.component.html
+++ b/src/app/components/project-map/packet-capturing/packet-filters/packet-filters.component.html
@@ -50,6 +50,12 @@ tcp dst port 443 and src portrange 1024-65535" [value]="filters.bpf[0]" (input)=
 <div mat-dialog-actions align="end">
   <button mat-button (click)="onNoClick()" color="accent">Cancel</button>
   <button mat-button (click)="onResetClick()" color="accent">Reset</button>
-  <button mat-button (click)="onYesClick()" tabindex="2" mat-raised-button color="primary">Apply</button>
+  <button mat-button (click)="onYesClick()" tabindex="2" mat-raised-button color="primary" [disabled]="isApplying()">
+    @if (isApplying()) {
+      <mat-spinner diameter="20"></mat-spinner>
+    } @else {
+      Apply
+    }
+  </button>
   <button mat-button (click)="onHelpClick()" color="accent">Help</button>
 </div>

--- a/src/app/components/project-map/packet-capturing/packet-filters/packet-filters.component.ts
+++ b/src/app/components/project-map/packet-capturing/packet-filters/packet-filters.component.ts
@@ -1,9 +1,10 @@
-import { ChangeDetectionStrategy, Component, OnInit, inject, ChangeDetectorRef } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit, inject, ChangeDetectorRef, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MatDialogModule, MatDialog, MatDialogRef } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { Filter } from '@models/filter';
 import { FilterDescription } from '@models/filter-description';
 import { Link } from '@models/link';
@@ -25,6 +26,7 @@ import { ToasterService } from '@services/toaster.service';
     MatFormFieldModule,
     MatInputModule,
     MatButtonModule,
+    MatProgressSpinnerModule,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
@@ -35,6 +37,8 @@ export class PacketFiltersDialogComponent implements OnInit {
   private dialogConfig = inject(DialogConfigService);
   private cdr = inject(ChangeDetectorRef);
   private toasterService = inject(ToasterService);
+
+  readonly isApplying = signal(false);
 
   controller: Controller;
   project: Project;
@@ -143,7 +147,10 @@ export class PacketFiltersDialogComponent implements OnInit {
   }
 
   onYesClick() {
+    if (this.isApplying()) return;
     this.link.filters = this.filters;
+    this.isApplying.set(true);
+    this.dialogRef.disableClose = true;
     this.linkService.updateLink(this.controller, this.link).subscribe({
       next: (link: Link) => {
         this.toasterService.success('Packet filters applied.');
@@ -153,6 +160,8 @@ export class PacketFiltersDialogComponent implements OnInit {
       error: (err) => {
         const message = err.error?.message || err.message || 'Failed to apply filters';
         this.toasterService.error(message);
+        this.isApplying.set(false);
+        this.dialogRef.disableClose = false;
         this.cdr.markForCheck();
       },
     });

--- a/src/app/components/project-map/project-map.component.spec.ts
+++ b/src/app/components/project-map/project-map.component.spec.ts
@@ -708,8 +708,8 @@ describe('ProjectMapComponent', () => {
     mockInterfaceStatusWidget = { };
     mockLabel = { };
     mockNodesWidget = { };
-    mockMarkerFlashService = { };
-    mockMarkerRegistryService = { };
+    mockMarkerFlashService = { reset: () => {} };
+    mockMarkerRegistryService = { reset: () => {} };
 
     // Configure TestBed with cartography module and all required mocks
     // Note: CartographyModule provides 67+ services that are used by child components
@@ -1148,6 +1148,14 @@ describe('ProjectMapComponent', () => {
 
         expect(mockMapScaleService.setScale).toHaveBeenCalledWith(1.1);
       });
+
+      it('should clamp at MAX_SCALE (5, matching wheel zoom)', () => {
+        mockMapScaleService.getScale.mockReturnValue(5);
+
+        component.zoomIn();
+
+        expect(mockMapScaleService.setScale).not.toHaveBeenCalled();
+      });
     });
 
     describe('zoomOut', () => {
@@ -1159,8 +1167,16 @@ describe('ProjectMapComponent', () => {
         expect(mockMapScaleService.setScale).toHaveBeenCalledWith(0.9);
       });
 
-      it('should not decrease scale below 0.1', () => {
+      it('should clamp at MIN_SCALE (0.01, matching wheel zoom)', () => {
         mockMapScaleService.getScale.mockReturnValue(0.05);
+
+        component.zoomOut();
+
+        expect(mockMapScaleService.setScale).toHaveBeenCalledWith(0.01);
+      });
+
+      it('should not call setScale at the zoom-out floor', () => {
+        mockMapScaleService.getScale.mockReturnValue(0.01);
 
         component.zoomOut();
 

--- a/src/app/components/project-map/project-map.component.ts
+++ b/src/app/components/project-map/project-map.component.ts
@@ -1739,14 +1739,18 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
   }
 
   zoomIn() {
-    this.mapScaleService.setScale(this.mapScaleService.getScale() + 0.1);
+    const currentScale = this.mapScaleService.getScale();
+    const nextScale = Math.min(MapScaleService.MAX_SCALE, currentScale + 0.1);
+    if (nextScale !== currentScale) {
+      this.mapScaleService.setScale(nextScale);
+    }
   }
 
   zoomOut() {
-    let currentScale = this.mapScaleService.getScale();
-
-    if (currentScale - 0.1 > 0) {
-      this.mapScaleService.setScale(currentScale - 0.1);
+    const currentScale = this.mapScaleService.getScale();
+    const nextScale = Math.max(MapScaleService.MIN_SCALE, currentScale - 0.1);
+    if (nextScale !== currentScale) {
+      this.mapScaleService.setScale(nextScale);
     }
   }
 
@@ -1980,6 +1984,12 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
     this.drawingsDataSource.clear();
     this.nodesDataSource.clear();
     this.linksDataSource.clear();
+
+    // Marker services are app-lifetime singletons that outlive this component:
+    // clear the legend registry (stale pills until the next project's links
+    // fetch) and all flash timers / staged states / geometry cache entries.
+    this.markerRegistryService.reset();
+    this.markerFlashService.reset();
 
     // Stop the project WS auto-reconnect loop during teardown: set the flag so
     // the onclose handler (fired by close() below) does not schedule a reconnect.

--- a/src/app/components/project-map/web-console/web-console.component.spec.ts
+++ b/src/app/components/project-map/web-console/web-console.component.spec.ts
@@ -59,6 +59,7 @@ describe('WebConsoleComponent', () => {
     setNumberOfColumns: vi.fn(),
     setNumberOfRows: vi.fn(),
     closeConsoleForNode: vi.fn(),
+    sendTerminalSize: vi.fn(),
   };
 
   const mockThemeService = {
@@ -236,6 +237,22 @@ describe('WebConsoleComponent', () => {
     it('should create WebSocket connection', () => {
       fixture.detectChanges();
       expect(mockNodeConsoleService.getUrl).toHaveBeenCalledWith(mockController, mockNode);
+    });
+
+    it('should send initial terminal size when socket opens', () => {
+      fixture.detectChanges();
+      const WebSocketConstructor = vi.mocked(WebSocket);
+      const wsInstance = WebSocketConstructor.mock.results[0]?.value;
+      wsInstance.onopen();
+      expect(mockNodeConsoleService.sendTerminalSize).toHaveBeenCalledWith(wsInstance, component.term.cols, component.term.rows);
+    });
+
+    it('should forward resize geometry via sendTerminalSize', () => {
+      fixture.detectChanges();
+      const WebSocketConstructor = vi.mocked(WebSocket);
+      const wsInstance = WebSocketConstructor.mock.results[0]?.value;
+      component.term.resize(120, 40);
+      expect(mockNodeConsoleService.sendTerminalSize).toHaveBeenCalledWith(wsInstance, 120, 40);
     });
 
     it('should initialize terminal with fitAddon', () => {

--- a/src/app/components/project-map/web-console/web-console.component.ts
+++ b/src/app/components/project-map/web-console/web-console.component.ts
@@ -107,6 +107,14 @@ export class WebConsoleComponent implements OnInit, AfterViewInit, OnDestroy {
       }
     };
 
+    this.socket.onopen = () => {
+      this.consoleService.sendTerminalSize(this.socket, this.term.cols, this.term.rows);
+    };
+    // fires whenever FitAddon.fit()/term.resize() changes the geometry
+    this.term.onResize(({ cols, rows }) => {
+      this.consoleService.sendTerminalSize(this.socket, cols, rows);
+    });
+
     const attachAddon = new AttachAddon(this.socket);
     this.term.loadAddon(attachAddon);
     this.xtermService.initTerminal(this.term, this.fitAddon);

--- a/src/app/components/template/template-list-dialog/template-list-dialog.component.html
+++ b/src/app/components/template/template-list-dialog/template-list-dialog.component.html
@@ -11,17 +11,18 @@
     <span>Add nodes</span>
   </span>
   <span class="dialog-title__actions">
-    <button
+    <a
       mat-button
       class="dialog-title__preferences"
       color="accent"
       aria-label="Template preferences"
-      (click)="onNoClick()"
-      routerLink="/controller/{{ controller?.id }}/preferences"
+      [routerLink]="['/controller', controller?.id, 'preferences']"
+      target="_blank"
+      rel="noopener"
     >
       <mat-icon>tune</mat-icon>
       <span>Template preferences</span>
-    </button>
+    </a>
     <button mat-icon-button aria-label="Close add nodes" (click)="onNoClick()">
       <mat-icon>close</mat-icon>
     </button>

--- a/src/app/components/template/template-list-dialog/template-list-dialog.component.scss
+++ b/src/app/components/template/template-list-dialog/template-list-dialog.component.scss
@@ -74,7 +74,7 @@
 
 .template-gallery {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(108px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(96px, 1fr));
   gap: var(--gns3-density-space-2);
   max-height: calc(var(--gns3-density-form-field-height) * 5);
   padding: var(--gns3-density-space-2);
@@ -89,9 +89,9 @@
 .template-card {
   position: relative;
   display: grid;
-  grid-template-rows: calc(var(--gns3-density-form-field-height) * 1.5) minmax(2.5em, auto);
+  grid-template-rows: calc(var(--gns3-density-form-field-height) * 1) minmax(2.5em, auto);
   min-width: 0;
-  min-height: calc(var(--gns3-density-form-field-height) * 2.75);
+  min-height: calc(var(--gns3-density-form-field-height) * 2);
   box-sizing: border-box;
   place-items: center;
   align-content: start;
@@ -129,8 +129,8 @@
 
 .template-card__image-wrap {
   display: grid;
-  width: calc(var(--gns3-density-form-field-height) * 1.5);
-  height: calc(var(--gns3-density-form-field-height) * 1.5);
+  width: calc(var(--gns3-density-form-field-height) * 1);
+  height: calc(var(--gns3-density-form-field-height) * 1);
   min-width: 0;
   min-height: 0;
   overflow: hidden;
@@ -147,10 +147,10 @@
 }
 
 .template-card__fallback-icon {
-  width: 32px;
-  height: 32px;
+  width: 24px;
+  height: 24px;
   color: var(--mat-sys-on-surface-variant);
-  font-size: 32px;
+  font-size: 24px;
 }
 
 .template-card__name {

--- a/src/app/components/topology-summary/topology-summary.component.scss
+++ b/src/app/components/topology-summary/topology-summary.component.scss
@@ -272,6 +272,7 @@
   min-height: 0;
   flex: 1 1 auto;
   overflow: auto;
+  overflow-x: hidden;
 }
 
 .node-row {
@@ -416,7 +417,6 @@
 }
 
 .compute-list {
-  overflow-x: hidden;
   border: 1px solid var(--mat-sys-outline-variant);
   border-radius: var(--gns3-density-radius-sm);
   background: var(--mat-sys-surface-container-lowest);

--- a/src/app/components/topology-summary/topology-summary.component.spec.ts
+++ b/src/app/components/topology-summary/topology-summary.component.spec.ts
@@ -389,6 +389,27 @@ describe('TopologySummaryComponent', () => {
       expect(component.computes).toEqual(mockComputes);
     });
 
+    it('should fetch computes even when the notification cache already has data', async () => {
+      // Regression guard: the cache only contains computes that happened to
+      // emit a WS event, so it must never replace the authoritative HTTP list
+      // (otherwise the local compute never shows up).
+      mockNotificationService.hasCachedData.mockReturnValue(true);
+      mockNotificationService.getCachedComputes.mockReturnValue([
+        { compute_id: 'remote', name: 'Remote' } as Compute,
+      ]);
+      const mockComputes = [
+        { compute_id: 'local', name: 'Local' } as Compute,
+        { compute_id: 'remote', name: 'Remote' } as Compute,
+      ];
+      mockComputeService.getComputes.mockReturnValue(of(mockComputes));
+
+      component.ngOnInit();
+      await vi.runAllTimersAsync();
+
+      expect(mockComputeService.getComputes).toHaveBeenCalledWith(mockController);
+      expect(component.computes).toEqual(mockComputes);
+    });
+
     it('should call revertPosition on init', async () => {
       const revertPositionSpy = vi.spyOn(component, 'revertPosition');
 

--- a/src/app/components/topology-summary/topology-summary.component.ts
+++ b/src/app/components/topology-summary/topology-summary.component.ts
@@ -122,25 +122,25 @@ export class TopologySummaryComponent implements OnInit, OnDestroy {
       })
     );
 
-    if (this.notificationService.hasCachedData()) {
-      this.computes = this.notificationService.getCachedComputes();
-      this.cd.markForCheck();
-    } else {
-      this.subscriptions.push(
-        this.computeService.getComputes(this.controller).subscribe({
-          next: (computes) => {
-            this.computes = computes;
-            this.notificationService.setInitialComputes(computes);
-            this.cd.markForCheck();
-          },
-          error: (err) => {
-            const message = err.error?.message || err.message || 'Failed to load computes';
-            this.toasterService.error(message);
-            this.cd.markForCheck();
-          },
-        })
-      );
-    }
+    // The notification cache only holds computes that happened to emit a WS
+    // event (e.g. a remote compute reconnecting), so it is not guaranteed to
+    // contain the full list (the local compute rarely emits events). Always
+    // fetch the authoritative list via HTTP; the cache stream provides live
+    // updates on top of it.
+    this.subscriptions.push(
+      this.computeService.getComputes(this.controller).subscribe({
+        next: (computes) => {
+          this.computes = computes;
+          this.notificationService.setInitialComputes(computes);
+          this.cd.markForCheck();
+        },
+        error: (err) => {
+          const message = err.error?.message || err.message || 'Failed to load computes';
+          this.toasterService.error(message);
+          this.cd.markForCheck();
+        },
+      })
+    );
   }
 
   private normalizeConsoleHost(node: Node): Node {

--- a/src/app/components/web-console-full-window/web-console-full-window.component.spec.ts
+++ b/src/app/components/web-console-full-window/web-console-full-window.component.spec.ts
@@ -15,6 +15,9 @@ const createMockTermInstance = () => ({
   focus: vi.fn(),
   write: vi.fn(),
   attachCustomKeyEventHandler: vi.fn().mockReturnValue(true),
+  onResize: vi.fn(),
+  cols: 100,
+  rows: 32,
   options: { theme: {} },
 });
 
@@ -93,6 +96,7 @@ describe('WebConsoleFullWindowComponent', () => {
   const mockNodeConsoleService = {
     consoleResized: new Subject<ConsoleResizedEvent>(),
     getUrl: vi.fn().mockReturnValue('ws://localhost:3080/test'),
+    sendTerminalSize: vi.fn(),
   };
 
   const mockControllerService = {
@@ -196,6 +200,8 @@ describe('WebConsoleFullWindowComponent', () => {
       mockTermInstance.focus.mockClear();
       mockTermInstance.write.mockClear();
       mockTermInstance.attachCustomKeyEventHandler.mockClear();
+      mockTermInstance.onResize.mockClear();
+      mockNodeConsoleService.sendTerminalSize.mockClear();
       mockTermInstance.options.theme = {};
     }
     if (mockFitAddonInstance) {
@@ -355,6 +361,28 @@ describe('WebConsoleFullWindowComponent', () => {
       fixture.detectChanges();
       await vi.runAllTimersAsync();
       expect(mockTermInstance.open).toHaveBeenCalled();
+    });
+
+    it('should send initial terminal size when socket opens', async () => {
+      fixture.detectChanges();
+      await vi.runAllTimersAsync();
+
+      const socket = (component as any).socket;
+      socket.onopen();
+
+      expect(mockNodeConsoleService.sendTerminalSize).toHaveBeenCalledWith(socket, mockTermInstance.cols, mockTermInstance.rows);
+    });
+
+    it('should subscribe to term resize and forward new geometry', async () => {
+      fixture.detectChanges();
+      await vi.runAllTimersAsync();
+
+      expect(mockTermInstance.onResize).toHaveBeenCalled();
+      const onResizeCallback = mockTermInstance.onResize.mock.calls[0][0];
+      const socket = (component as any).socket;
+      onResizeCallback({ cols: 120, rows: 40 });
+
+      expect(mockNodeConsoleService.sendTerminalSize).toHaveBeenCalledWith(socket, 120, 40);
     });
 
     it('should load attach addon to terminal', async () => {

--- a/src/app/components/web-console-full-window/web-console-full-window.component.ts
+++ b/src/app/components/web-console-full-window/web-console-full-window.component.ts
@@ -134,6 +134,14 @@ export class WebConsoleFullWindowComponent implements OnInit, OnDestroy {
         this.term.write('\r\n\x1b[33mConnection closed.\x1b[0m\r\n');
       };
 
+      this.socket.onopen = () => {
+        this.consoleService.sendTerminalSize(this.socket, this.term.cols, this.term.rows);
+      };
+      // fires whenever FitAddon.fit()/term.resize() changes the geometry
+      this.term.onResize(({ cols, rows }) => {
+        this.consoleService.sendTerminalSize(this.socket, cols, rows);
+      });
+
       const attachAddon = new AttachAddon(this.socket);
       this.term.loadAddon(attachAddon);
       this.xtermService.initTerminal(this.term, this.fitAddon);

--- a/src/app/handlers/project-web-service-handler.spec.ts
+++ b/src/app/handlers/project-web-service-handler.spec.ts
@@ -52,6 +52,7 @@ describe('ProjectWebServiceHandler', () => {
 
     mockMarkerFlashService = {
       flash: vi.fn(),
+      evictLink: vi.fn(),
     };
 
     mockMarkerRegistryService = {

--- a/src/app/handlers/project-web-service-handler.ts
+++ b/src/app/handlers/project-web-service-handler.ts
@@ -61,6 +61,9 @@ export class ProjectWebServiceHandler {
       const link = message.event as Link;
       this.linksDataSource.remove(link);
       this.markerRegistryService.removeLink(link.link_id);
+      // The link (and its path element) is gone — its geometry cache entry
+      // would never be used again and never evicted (app-singleton service).
+      this.markerFlashService.evictLink(link.link_id);
       this.linkNotificationEmitter.emit(message);
     }
     if (message.action === 'marker.match') {

--- a/src/app/layouts/default-layout/default-layout.component.scss
+++ b/src/app/layouts/default-layout/default-layout.component.scss
@@ -5,13 +5,18 @@
 
 :host {
   --layout-header-height: 64px;
+
+  /* App shell: lock the layout to the viewport height so the sidebar and
+     toolbar stay fixed while only the main content scrolls. */
+  display: block;
+  height: 100vh;
 }
 
 /* =============================================
 // Layout Container (Drawer)
 // ============================================= */
 .layout-container {
-  min-height: 100vh;
+  height: 100%;
   background: linear-gradient(135deg, var(--mat-sys-primary-container) 0%, var(--mat-sys-background) 100%);
 }
 
@@ -124,7 +129,10 @@
 .layout-content {
   display: flex;
   flex-direction: column;
-  min-height: 100vh;
+  height: 100%;
+  /* Material defaults .mat-drawer-content to overflow: auto; keep the layout
+     itself static so .main-content is the single scroll container. */
+  overflow: hidden;
 }
 
 /* =============================================
@@ -287,6 +295,9 @@
   overflow-y: auto;
   background: transparent;
   flex: 1;
+  /* Allow the flex child to shrink below its content height so it,
+     not the document, becomes the scroll container. */
+  min-height: 0;
 }
 
 /* =============================================

--- a/src/app/layouts/default-layout/default-layout.component.ts
+++ b/src/app/layouts/default-layout/default-layout.component.ts
@@ -95,8 +95,14 @@ export class DefaultLayoutComponent implements OnInit, OnDestroy {
       .subscribe(() => {
         this.notificationCenter.closePanel();
         // Recursively traverse the route tree to find controller_id
-        this.controllerId = this.getParamFromRoute(this.route, 'controller_id');
-        this.getData();
+        const controllerId = this.getParamFromRoute(this.route, 'controller_id');
+        // Only refetch (and reset controller/admin state) when the controller
+        // actually changed; otherwise the sidebar @if blocks collapse and
+        // re-expand on every navigation, making the Support section flicker.
+        if (controllerId !== this.controllerId) {
+          this.controllerId = controllerId;
+          this.getData();
+        }
         this.cd.markForCheck();
       });
 

--- a/src/app/models/appliance-metadata.ts
+++ b/src/app/models/appliance-metadata.ts
@@ -1,0 +1,29 @@
+/**
+ * Metadata persisted on a template describing the appliance it was installed
+ * from (server: appliance_to_template._build_appliance_metadata — a snapshot
+ * taken at install time; later registry updates do not affect it).
+ *
+ * All fields are optional and may be null or absent (the server materializes
+ * the known keys as null in responses — treat null like missing). The server
+ * model is extra="allow" and passes unknown keys through, so read-modify-write
+ * edits must preserve keys it does not know about.
+ */
+export interface ApplianceMetadata {
+  appliance_id?: string | null;
+  description?: string | null;
+  vendor_name?: string | null;
+  vendor_url?: string | null;
+  vendor_logo_url?: string | null;
+  documentation_url?: string | null;
+  product_name?: string | null;
+  product_url?: string | null;
+  status?: string | null;
+  availability?: string | null;
+  maintainer?: string | null;
+  maintainer_email?: string | null;
+  installation_instructions?: string | null;
+  default_username?: string | null;
+  default_password?: string | null;
+  // Unknown/future registry keys — preserved on read-modify-write.
+  [key: string]: unknown;
+}

--- a/src/app/models/appliance.ts
+++ b/src/app/models/appliance.ts
@@ -24,6 +24,7 @@ export interface Qemu {
   hdd_disk_interface: string;
   kvm: string;
   ram: number;
+  options?: string;
 }
 
 export interface Docker {
@@ -57,6 +58,9 @@ export interface Dynamips {
   slot6: string;
   slot7: string;
   startup_config: string;
+  wic0?: string;
+  wic1?: string;
+  wic2?: string;
 }
 
 export interface Iou {
@@ -65,6 +69,10 @@ export interface Iou {
   ram: number;
   serial_adapters: number;
   startup_config: string;
+  console_type?: string;
+  console_auto_start?: boolean;
+  l1_keepalives?: boolean;
+  use_default_iou_values?: boolean;
 }
 
 export interface Images {
@@ -79,9 +87,35 @@ export interface Images {
 export interface Version {
   images: Images;
   name: string;
+  // v8: name of the settings group used by this version (server sends a single
+  // string, e.g. vyos "1.5 x86_64"), plus version-level overrides
+  settings?: string | string[];
+  category?: string;
+  usage?: string;
+  symbol?: string;
+  installation_instructions?: string;
+  default_username?: string;
+  default_password?: string;
+}
+
+/**
+ * v8 appliance setting group: named emulator configuration block.
+ * `template_properties` holds the same keys the v1-v6 format keeps in
+ * top-level qemu/docker/iou/dynamips blocks.
+ */
+export interface ApplianceSetting {
+  name: string;
+  default?: boolean;
+  // server default: true — merge the default group's properties under this one
+  inherit_default_properties?: boolean;
+  template_type: string;
+  template_properties: {
+    [key: string]: any;
+  };
 }
 
 export interface Appliance {
+  appliance_id?: string;
   availability: string;
   builtin: boolean;
   category: string;
@@ -107,10 +141,18 @@ export interface Appliance {
   tags: string[];
   custom_adapters?: CustomAdapter[];
 
-  docker: Docker;
-  dynamips: Dynamips;
-  iou: Iou;
-  qemu: Qemu;
+  docker?: Docker;
+  dynamips?: Dynamips;
+  iou?: Iou;
+  qemu?: Qemu;
+
+  // v8 fields
+  settings?: ApplianceSetting[];
+  vendor_logo_url?: string;
+  default_username?: string;
+  default_password?: string;
+  installation_instructions?: string;
+  netmiko_device_type?: string;
 
   emulator?: string;
 }

--- a/src/app/models/netmiko-device-type.ts
+++ b/src/app/models/netmiko-device-type.ts
@@ -1,0 +1,23 @@
+/**
+ * GET /v3/netmiko/device_types — the device types supported by the netmiko
+ * installed on the server. The list changes with the server's netmiko
+ * version (plus gns3_-prefixed custom drivers), so it must be fetched,
+ * never hardcoded.
+ *
+ * The server answers 501 (error body key `message`, not `detail`) when
+ * netmiko is missing — the field itself still works, callers fall back to
+ * free text.
+ */
+export interface NetmikoDeviceType {
+  /** Value written to netmiko_device_type. */
+  name: string;
+  /** Telnet-based variant (_telnet) — most GNS3 consoles are Telnet. */
+  telnet: boolean;
+  /** GNS3 custom driver (gns3_ prefix), not built into netmiko. */
+  custom: boolean;
+}
+
+export interface NetmikoDeviceTypesResponse {
+  netmiko_version: string;
+  device_types: NetmikoDeviceType[];
+}

--- a/src/app/models/template.ts
+++ b/src/app/models/template.ts
@@ -1,3 +1,5 @@
+import { ApplianceMetadata } from './appliance-metadata';
+
 export class Template {
   template_id: string;
   builtin: boolean;
@@ -9,4 +11,6 @@ export class Template {
   symbol: string;
   template_type: string;
   tags?: string[];
+  netmiko_device_type?: string | null;
+  appliance_metadata?: ApplianceMetadata | null;
 }

--- a/src/app/models/templates/docker-template.ts
+++ b/src/app/models/templates/docker-template.ts
@@ -1,3 +1,4 @@
+import { ApplianceMetadata } from '../appliance-metadata';
 import { CustomAdapter } from '../qemu/qemu-custom-adapter';
 import { ExtraConfig } from './extra-config';
 
@@ -29,4 +30,6 @@ export class DockerTemplate {
   template_type: string;
   usage: string;
   tags: string[];
+  netmiko_device_type?: string | null;
+  appliance_metadata?: ApplianceMetadata | null;
 }

--- a/src/app/models/templates/ios-template.ts
+++ b/src/app/models/templates/ios-template.ts
@@ -1,3 +1,4 @@
+import { ApplianceMetadata } from '../appliance-metadata';
 export class IosTemplate {
   auto_delete_disks: boolean;
   builtin: boolean;
@@ -42,4 +43,6 @@ export class IosTemplate {
   wic1?: string;
   wic2?: string;
   tags: string[];
+  netmiko_device_type?: string | null;
+  appliance_metadata?: ApplianceMetadata | null;
 }

--- a/src/app/models/templates/iou-template.ts
+++ b/src/app/models/templates/iou-template.ts
@@ -1,3 +1,4 @@
+import { ApplianceMetadata } from '../appliance-metadata';
 export class IouTemplate {
   builtin: boolean;
   category: string;
@@ -20,4 +21,6 @@ export class IouTemplate {
   usage: string;
   use_default_iou_values: boolean;
   tags: string[];
+  netmiko_device_type?: string | null;
+  appliance_metadata?: ApplianceMetadata | null;
 }

--- a/src/app/models/templates/qemu-template.ts
+++ b/src/app/models/templates/qemu-template.ts
@@ -1,3 +1,4 @@
+import { ApplianceMetadata } from '../appliance-metadata';
 import { CustomAdapter } from '../qemu/qemu-custom-adapter';
 
 export class QemuTemplate {
@@ -49,4 +50,6 @@ export class QemuTemplate {
   tpm: boolean;
   uefi: boolean;
   tags: string[];
+  netmiko_device_type?: string | null;
+  appliance_metadata?: ApplianceMetadata | null;
 }

--- a/src/app/models/templates/vpcs-template.ts
+++ b/src/app/models/templates/vpcs-template.ts
@@ -1,3 +1,4 @@
+import { ApplianceMetadata } from '../appliance-metadata';
 export interface VpcsTemplate {
   base_script_file: string;
   builtin: boolean;
@@ -12,4 +13,6 @@ export interface VpcsTemplate {
   template_type: string;
   tags?: string[];
   usage?: string;
+  netmiko_device_type?: string | null;
+  appliance_metadata?: ApplianceMetadata | null;
 }

--- a/src/app/services/appliance-normalizer.spec.ts
+++ b/src/app/services/appliance-normalizer.spec.ts
@@ -1,0 +1,265 @@
+import { describe, it, expect } from 'vitest';
+import { Appliance } from '@models/appliance';
+import { normalizeAppliance, getDefaultSetting, getVersionSettingProperties, buildApplianceMetadata } from './appliance-normalizer';
+
+function createV8Appliance(): Appliance {
+  return {
+    name: 'v8 appliance',
+    category: 'router',
+    registry_version: 8,
+    vendor_name: 'Vendor',
+    status: 'stable',
+    versions: [
+      {
+        name: '1.0',
+        images: { hda_disk_image: 'v8-1.0.qcow2' },
+        settings: ['small'],
+        category: 'guest',
+        usage: 'version usage',
+        symbol: ':/symbols/custom.svg',
+      },
+      {
+        name: '2.0',
+        images: { hda_disk_image: 'v8-2.0.qcow2' },
+      },
+    ],
+    settings: [
+      {
+        name: 'default',
+        default: true,
+        template_type: 'qemu',
+        template_properties: {
+          ram: 4096,
+          adapters: 8,
+          console_type: 'telnet',
+          arch: 'x86_64',
+          first_port_name: 'eth1',
+          port_name_format: 'eth{0}',
+          port_segment_size: 3,
+        },
+      },
+      {
+        name: 'small',
+        template_type: 'qemu',
+        template_properties: {
+          ram: 2048,
+          adapters: 4,
+        },
+      },
+    ],
+  } as unknown as Appliance;
+}
+
+describe('appliance-normalizer', () => {
+  describe('normalizeAppliance', () => {
+    it('should return v6 appliance untouched', () => {
+      const appliance = {
+        name: 'v6 appliance',
+        registry_version: 6,
+        qemu: { ram: 1024, adapters: 2, console_type: 'telnet' },
+      } as unknown as Appliance;
+
+      const result = normalizeAppliance(appliance);
+
+      expect(result).toBe(appliance);
+      expect(result.qemu.ram).toBe(1024);
+    });
+
+    it('should fill qemu block from default settings group', () => {
+      const appliance = createV8Appliance();
+
+      const result = normalizeAppliance(appliance);
+
+      expect(result.qemu).toBeDefined();
+      expect(result.qemu.ram).toBe(4096);
+      expect(result.qemu.adapters).toBe(8);
+      expect(result.qemu.console_type).toBe('telnet');
+    });
+
+    it('should lift port naming fields from template_properties', () => {
+      const appliance = createV8Appliance();
+
+      const result = normalizeAppliance(appliance);
+
+      expect(result.first_port_name).toBe('eth1');
+      expect(result.port_name_format).toBe('eth{0}');
+      expect(result.port_segment_size).toBe(3);
+    });
+
+    it('should keep top-level port naming fields when already set', () => {
+      const appliance = createV8Appliance();
+      appliance.first_port_name = 'Gi1';
+
+      const result = normalizeAppliance(appliance);
+
+      expect(result.first_port_name).toBe('Gi1');
+    });
+
+    it('should map docker memory to mem_limit', () => {
+      const appliance = createV8Appliance();
+      appliance.settings = [
+        {
+          name: 'default',
+          default: true,
+          template_type: 'docker',
+          template_properties: {
+            adapters: 16,
+            console_type: 'docker_exec',
+            image: 'vendor/router:latest',
+            memory: 4096,
+          },
+        },
+      ];
+
+      const result = normalizeAppliance(appliance);
+
+      expect(result.docker).toBeDefined();
+      expect(result.docker.mem_limit).toBe(4096);
+      expect(result.docker.image).toBe('vendor/router:latest');
+    });
+
+    it('should use first settings group when no group is marked default', () => {
+      const appliance = createV8Appliance();
+      appliance.settings[0].default = undefined;
+
+      const result = normalizeAppliance(appliance);
+
+      expect(result.qemu.ram).toBe(4096);
+    });
+
+    it('should carry netmiko_device_type from template_properties', () => {
+      const appliance = createV8Appliance();
+      appliance.settings[0].template_properties.netmiko_device_type = 'cisco_xr';
+
+      const result = normalizeAppliance(appliance);
+
+      expect(result.netmiko_device_type).toBe('cisco_xr');
+    });
+  });
+
+  describe('getDefaultSetting', () => {
+    it('should return undefined for v6 appliance without settings', () => {
+      expect(getDefaultSetting({ registry_version: 6 } as unknown as Appliance)).toBeUndefined();
+    });
+
+    it('should return the group marked default', () => {
+      const appliance = createV8Appliance();
+
+      expect(getDefaultSetting(appliance)?.name).toBe('default');
+    });
+  });
+
+  describe('getVersionSettingProperties', () => {
+    it('should return null when version has no settings', () => {
+      const appliance = createV8Appliance();
+
+      expect(getVersionSettingProperties(appliance, appliance.versions[1])).toBeNull();
+    });
+
+    it('should resolve a settings group referenced by name as a string', () => {
+      const appliance = createV8Appliance();
+      // real server data (e.g. vyos.gns3a) references a group by name as a single string
+      appliance.versions[0].settings = 'small';
+
+      const props = getVersionSettingProperties(appliance, appliance.versions[0]);
+
+      expect(props).not.toBeNull();
+      expect(props['ram']).toBe(2048);
+      expect(props['adapters']).toBe(4);
+    });
+
+    it('should merge version setting group over default properties', () => {
+      const appliance = createV8Appliance();
+
+      const props = getVersionSettingProperties(appliance, appliance.versions[0]);
+
+      expect(props).not.toBeNull();
+      expect(props['ram']).toBe(2048); // overridden by 'small' group
+      expect(props['adapters']).toBe(4); // overridden by 'small' group
+      expect(props['console_type']).toBe('telnet'); // kept from default group
+    });
+
+    it('should not inherit default properties when inherit_default_properties is false', () => {
+      const appliance = createV8Appliance();
+      appliance.settings[1].inherit_default_properties = false;
+
+      const props = getVersionSettingProperties(appliance, appliance.versions[0]);
+
+      expect(props).not.toBeNull();
+      expect(props['ram']).toBe(2048);
+      expect(props['console_type']).toBeUndefined(); // default group not merged
+    });
+
+    it('should return null for unknown group name (caller falls back to default block)', () => {
+      const appliance = createV8Appliance();
+      appliance.versions[0].settings = 'missing-group';
+
+      expect(getVersionSettingProperties(appliance, appliance.versions[0])).toBeNull();
+    });
+
+    it('should return null for v6 appliance without settings', () => {
+      const appliance = { registry_version: 6 } as unknown as Appliance;
+
+      expect(getVersionSettingProperties(appliance, { name: '1.0', images: {} } as any)).toBeNull();
+    });
+  });
+
+  describe('buildApplianceMetadata', () => {
+    it('should snapshot appliance-level fields and appliance_id', () => {
+      const appliance = createV8Appliance();
+      appliance.appliance_id = 'f82b74c4-0f30-456f-a582-63daca528502';
+      appliance.default_username = 'vyos';
+      appliance.default_password = 'vyos';
+      appliance.installation_instructions = 'Import the qcow2 image.';
+
+      const metadata = buildApplianceMetadata(appliance)!;
+
+      expect(metadata['default_username']).toBe('vyos');
+      expect(metadata['default_password']).toBe('vyos');
+      expect(metadata['installation_instructions']).toBe('Import the qcow2 image.');
+      expect(metadata['vendor_name']).toBe('Vendor');
+      expect(metadata['status']).toBe('stable');
+      expect(metadata['appliance_id']).toBe('f82b74c4-0f30-456f-a582-63daca528502');
+    });
+
+    it('should let version-level values override appliance-level ones', () => {
+      const appliance = createV8Appliance();
+      appliance.default_username = 'appliance-user';
+      appliance.versions[0].default_username = 'version-user';
+      appliance.versions[0].installation_instructions = 'version-specific instructions';
+
+      const metadata = buildApplianceMetadata(appliance, appliance.versions[0])!;
+
+      expect(metadata['default_username']).toBe('version-user');
+      expect(metadata['installation_instructions']).toBe('version-specific instructions');
+    });
+
+    it('should fall back to the appliance level when the version does not define a field', () => {
+      const appliance = createV8Appliance();
+      appliance.default_username = 'appliance-user';
+
+      const metadata = buildApplianceMetadata(appliance, appliance.versions[0])!;
+
+      expect(metadata['default_username']).toBe('appliance-user');
+    });
+
+    it('should omit unset, null and empty-string fields', () => {
+      const appliance = createV8Appliance();
+
+      const metadata = buildApplianceMetadata(appliance)!;
+
+      expect(metadata['default_username']).toBeUndefined();
+      expect(metadata['documentation_url']).toBeUndefined();
+      expect(metadata['maintainer_email']).toBeUndefined();
+      // only the fields the fixture actually defines are present
+      expect(Object.keys(metadata).sort()).toEqual(['status', 'vendor_name']);
+    });
+
+    it('should return null when nothing is set', () => {
+      const appliance = { name: 'bare', registry_version: 8 } as unknown as Appliance;
+
+      expect(buildApplianceMetadata(appliance)).toBeNull();
+      expect(buildApplianceMetadata(appliance, { name: '1.0', images: {} } as any)).toBeNull();
+    });
+  });
+});

--- a/src/app/services/appliance-normalizer.ts
+++ b/src/app/services/appliance-normalizer.ts
@@ -1,0 +1,151 @@
+import { Appliance, ApplianceSetting, Version } from '@models/appliance';
+import { ApplianceMetadata } from '@models/appliance-metadata';
+
+/**
+ * Normalizes v8 appliance format (registry_version 8) into the v1-v6 shape
+ * the UI consumes: the default settings group is flattened onto the top-level
+ * qemu/docker/iou/dynamips blocks and port-naming fields, so existing install
+ * flows work unchanged. v1-v6 appliances pass through untouched.
+ *
+ * v8 shape:
+ *   settings: [{name, default, template_type, template_properties}]
+ *   versions[].settings: name of the setting group used by that version
+ */
+export function normalizeAppliance(appliance: Appliance): Appliance {
+  if (!appliance || !Array.isArray(appliance.settings) || appliance.settings.length === 0) {
+    return appliance;
+  }
+
+  const defaultSetting = getDefaultSetting(appliance);
+  if (!defaultSetting) {
+    return appliance;
+  }
+
+  const props = defaultSetting.template_properties || {};
+  const templateType = defaultSetting.template_type;
+
+  // Fill the emulator block the UI reads (qemu/docker/iou/dynamips)
+  if (templateType && !(appliance as any)[templateType]) {
+    const block: any = { ...props };
+    // v6 docker block uses mem_limit for the memory limit
+    if (templateType === 'docker' && block.mem_limit === undefined && block.memory !== undefined) {
+      block.mem_limit = block.memory;
+    }
+    (appliance as any)[templateType] = block;
+  }
+
+  // Lift port naming and shared fields out of template_properties (v6 keeps them top-level)
+  if (appliance.first_port_name === undefined || appliance.first_port_name === null) {
+    appliance.first_port_name = props.first_port_name;
+  }
+  if (appliance.port_name_format === undefined || appliance.port_name_format === null) {
+    appliance.port_name_format = props.port_name_format;
+  }
+  if (appliance.port_segment_size === undefined || appliance.port_segment_size === null) {
+    appliance.port_segment_size = props.port_segment_size;
+  }
+  if (!appliance.custom_adapters && props.custom_adapters) {
+    appliance.custom_adapters = props.custom_adapters;
+  }
+  if (!appliance.usage && props.usage) {
+    appliance.usage = props.usage;
+  }
+  if (!appliance.netmiko_device_type && props.netmiko_device_type) {
+    appliance.netmiko_device_type = props.netmiko_device_type;
+  }
+
+  return appliance;
+}
+
+export function getDefaultSetting(appliance: Appliance): ApplianceSetting | undefined {
+  if (!Array.isArray(appliance.settings) || appliance.settings.length === 0) {
+    return undefined;
+  }
+  return appliance.settings.find((s) => s.default) || appliance.settings[0];
+}
+
+/**
+ * Descriptive appliance fields the server copies onto an installed template.
+ * Mirrors _APPLIANCE_METADATA_FIELDS in gns3server/controller/appliance_to_template.py.
+ */
+const APPLIANCE_METADATA_FIELDS = [
+  'description',
+  'vendor_name',
+  'vendor_url',
+  'vendor_logo_url',
+  'documentation_url',
+  'product_name',
+  'product_url',
+  'status',
+  'availability',
+  'maintainer',
+  'maintainer_email',
+  'installation_instructions',
+  'default_username',
+  'default_password',
+] as const;
+
+/**
+ * Builds the appliance_metadata snapshot to attach to a template created
+ * client-side from an appliance: version-level values (e.g. credentials
+ * specific to the installed version) override appliance-level ones, unset
+ * fields are omitted, and appliance_id identifies the source appliance.
+ * Mirrors the server's _build_appliance_metadata so templates installed via
+ * the web UI carry the same metadata as server-side installs.
+ */
+export function buildApplianceMetadata(appliance: Appliance, version?: Version | null): ApplianceMetadata | null {
+  const metadata: { [key: string]: unknown } = {};
+  const versionFields = version as unknown as { [key: string]: unknown } | null | undefined;
+  const applianceFields = appliance as unknown as { [key: string]: unknown };
+  for (const field of APPLIANCE_METADATA_FIELDS) {
+    const value = versionFields?.[field] ?? applianceFields[field];
+    if (value !== undefined && value !== null && value !== '') {
+      metadata[field] = value;
+    }
+  }
+  if (applianceFields.appliance_id) {
+    metadata.appliance_id = applianceFields.appliance_id;
+  }
+  return Object.keys(metadata).length > 0 ? (metadata as ApplianceMetadata) : null;
+}
+
+/**
+ * Returns the effective template properties for a version: the default
+ * setting group's properties overridden by the setting group(s) the version
+ * references (v8 only; returns null for v1-v6 appliances).
+ *
+ * Mirrors the server's _select_v8_settings + _merge_v8_properties
+ * (gns3server/controller/appliance_to_template.py): versions reference a
+ * settings group by name as a single string, and a non-default group inherits
+ * the default group's properties unless inherit_default_properties is false.
+ */
+export function getVersionSettingProperties(appliance: Appliance, version: Version): { [key: string]: any } | null {
+  const defaultSetting = getDefaultSetting(appliance);
+  if (!defaultSetting) {
+    return null;
+  }
+
+  const settingsRef = version?.settings;
+  const groupNames = typeof settingsRef === 'string' ? [settingsRef] : Array.isArray(settingsRef) ? settingsRef : [];
+  if (groupNames.length === 0) {
+    return null;
+  }
+
+  const groups = groupNames
+    .map((name) => appliance.settings.find((s) => s.name === name))
+    .filter((s): s is ApplianceSetting => !!s);
+  if (groups.length === 0) {
+    // The server raises here; fall back to the default group at the caller so
+    // the install still produces a usable template instead of a broken one.
+    return null;
+  }
+
+  const merged: { [key: string]: any } = {};
+  if (groups.every((group) => group.inherit_default_properties !== false)) {
+    Object.assign(merged, defaultSetting.template_properties || {});
+  }
+  for (const group of groups) {
+    Object.assign(merged, group.template_properties || {});
+  }
+  return merged;
+}

--- a/src/app/services/appliances.service.ts
+++ b/src/app/services/appliances.service.ts
@@ -1,20 +1,26 @@
 import { Injectable } from '@angular/core';
 import { environment } from 'environments/environment';
 import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
 import { Appliance } from '@models/appliance';
 import { Controller } from '@models/controller';
 import { HttpController } from './http-controller.service';
+import { normalizeAppliance } from './appliance-normalizer';
 
 @Injectable()
 export class ApplianceService {
   constructor(private httpController: HttpController) {}
 
   getAppliances(controller: Controller): Observable<Appliance[]> {
-    return this.httpController.get<Appliance[]>(controller, '/appliances') as Observable<Appliance[]>;
+    return (this.httpController.get<Appliance[]>(controller, '/appliances') as Observable<Appliance[]>).pipe(
+      map((appliances) => (appliances || []).map((appliance) => normalizeAppliance(appliance)))
+    );
   }
 
   getAppliance(controller: Controller, url): Observable<Appliance> {
-    return this.httpController.get<Appliance>(controller, url) as Observable<Appliance>;
+    return (this.httpController.get<Appliance>(controller, url) as Observable<Appliance>).pipe(
+      map((appliance) => normalizeAppliance(appliance))
+    );
   }
 
   getUploadPath(controller: Controller, filename: string) {

--- a/src/app/services/mapScale.service.spec.ts
+++ b/src/app/services/mapScale.service.spec.ts
@@ -106,6 +106,41 @@ describe('MapScaleService', () => {
       service.resetToDefault();
       expect(emitSpy).toHaveBeenCalledWith(1);
     });
+
+    it('should reset pan (transformation.x/y) along with the scale', () => {
+      // Regression: resetting only k left the view offset at the panned
+      // location — "reset zoom" snapped the scale while the content stayed
+      // off to the side.
+      mockContext.transformation.x = 150;
+      mockContext.transformation.y = -80;
+      service.setScale(2.5);
+
+      service.resetToDefault();
+
+      expect(mockContext.transformation.x).toBe(0);
+      expect(mockContext.transformation.y).toBe(0);
+      expect(mockContext.transformation.k).toBe(1);
+      expect(service.currentScale).toBe(1);
+    });
+  });
+
+  describe('resetScaleState', () => {
+    it('should reset the tracked scale without touching the transformation or emitting', () => {
+      // Used by createGraph on project open: the transformation is reset
+      // directly, and emitting would trigger the map's scale-change apply.
+      const emitSpy = vi.spyOn(service.scaleChangeEmitter, 'emit');
+      service.setScale(2.4);
+      mockContext.transformation.k = 1;
+      mockContext.transformation.x = 0;
+      mockContext.transformation.y = 0;
+      emitSpy.mockClear();
+
+      service.resetScaleState();
+
+      expect(service.getScale()).toBe(1);
+      expect(mockContext.transformation.k).toBe(1);
+      expect(emitSpy).not.toHaveBeenCalled();
+    });
   });
 
   describe('Scale Range', () => {

--- a/src/app/services/mapScale.service.ts
+++ b/src/app/services/mapScale.service.ts
@@ -3,6 +3,10 @@ import { Context } from '../cartography/models/context';
 
 @Injectable()
 export class MapScaleService {
+  /** Shared zoom bounds — wheel zoom and the toolbar/keyboard buttons must agree. */
+  public static readonly MIN_SCALE = 0.01;
+  public static readonly MAX_SCALE = 5;
+
   public currentScale: number;
   public scaleChangeEmitter = new EventEmitter();
 
@@ -21,8 +25,23 @@ export class MapScaleService {
   }
 
   resetToDefault() {
+    // Reset to the default view: scale 1 AND pan back to the origin. Pan lives
+    // in transformation.x/y — leaving it set made "reset zoom" snap the scale
+    // while the view stayed offset at the panned location.
     this.currentScale = 1;
+    this.context.transformation.x = 0;
+    this.context.transformation.y = 0;
     this.context.transformation.k = this.currentScale;
     this.scaleChangeEmitter.emit(this.currentScale);
+  }
+
+  /**
+   * Sync the tracked scale with an externally reset transformation WITHOUT
+   * emitting (project open: createGraph resets the context transformation to
+   * k=1 itself; without this the app-singleton service would keep the previous
+   * project's scale and the first toolbar zoom click would jump from it).
+   */
+  resetScaleState() {
+    this.currentScale = 1;
   }
 }

--- a/src/app/services/marker-flash.service.spec.ts
+++ b/src/app/services/marker-flash.service.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed } from '@angular/core/testing';
-import { describe, it, expect, beforeEach, beforeAll, afterAll, vi } from 'vitest';
+import { describe, it, expect, beforeEach, beforeAll, afterAll, afterEach, vi } from 'vitest';
 import { MarkerFlashService } from './marker-flash.service';
 
 /**
@@ -104,6 +104,94 @@ describe('MarkerFlashService', () => {
 
     it('rx at the source end means peer(target)→capture(source) (against the path)', () => {
       expect(arrowAlong('rx', 'source')).toBe(false);
+    });
+  });
+
+  describe('reset (project switch)', () => {
+    it('clears the _flashing signal map', async () => {
+      service.flash('link-1', null, null, 'tx', 'node-a');
+      await settle();
+      expect(flashing().size).toBe(1);
+
+      service.reset();
+
+      // Regression: reset() cleared timers/pending/prev/geoCache but left the
+      // signal map — every project switch leaked the previous project's flash
+      // entries (composite keys are link UUIDs, never reused) in this
+      // app-singleton.
+      expect(flashing().size).toBe(0);
+    });
+
+    it('a flash after reset starts from an empty map', async () => {
+      service.flash('link-1', null);
+      await settle();
+      service.reset();
+
+      service.flash('link-2', null);
+      await settle();
+
+      expect(flashing().has(key('link-1'))).toBe(false);
+      expect(flashing().has(key('link-2'))).toBe(true);
+    });
+  });
+
+  describe('with DOM (direction arrows)', () => {
+    const svgHtml = `
+      <svg id="map">
+        <g class="link" link_id="l1" map-source="node-a" map-target="node-b">
+          <g class="link_body">
+            <path class="ethernet_link" d="M0,0 L100,0"></path>
+            <g class="marker-arrow-tx"><path d="stale-arrow"></path></g>
+          </g>
+        </g>
+      </svg>`;
+
+    const groupEl = () => document.querySelector<SVGGElement>('g.link[link_id="l1"]');
+    const arrowSlots = () => document.querySelectorAll('g.link[link_id="l1"] g.marker-arrow-tx, g.link[link_id="l1"] g.marker-arrow-rx');
+
+    beforeEach(() => {
+      document.body.innerHTML = svgHtml;
+      const path = document.querySelector<SVGPathElement>('path.ethernet_link');
+      (path as any).getTotalLength = () => 100;
+      (path as any).getPointAtLength = () => ({ x: 1, y: 1 });
+    });
+
+    afterEach(() => {
+      document.body.innerHTML = '';
+    });
+
+    it('does not remove existing arrows when the capture node matches no endpoint', async () => {
+      // Regression: renderDirArrow removed the slot container BEFORE checking
+      // the capture endpoint; a stale capture (link rewired after the match)
+      // bailed after the removal and the state diff never re-rendered it.
+      service.flash('l1', null, null, 'tx', 'stale-node');
+      await settle();
+
+      expect(groupEl().querySelectorAll('g.marker-arrow-tx').length).toBe(1);
+      expect(groupEl().querySelectorAll('g.marker-arrow-tx path').length).toBe(1);
+    });
+
+    it('re-renders arrows for a flashing link after a redraw wipes them', async () => {
+      // Regression: LinkWidget.draw() removes arrow containers on every
+      // redraw; without redrawArrows the flash kept pulsing without direction
+      // arrows until the state changed.
+      service.flash('l1', null, null, 'tx', 'node-a');
+      await settle();
+      expect(groupEl().querySelectorAll('g.marker-arrow-tx path').length).toBeGreaterThan(0);
+
+      // Simulate the link widget's redraw: it strips the arrow containers.
+      groupEl().querySelectorAll('g.marker-arrow-tx, g.marker-arrow-rx').forEach((n) => n.remove());
+      expect(arrowSlots().length).toBe(0);
+
+      service.redrawArrows('l1');
+
+      expect(groupEl().querySelectorAll('g.marker-arrow-tx path').length).toBeGreaterThan(0);
+    });
+
+    it('redrawArrows is a no-op for links without an active flash', () => {
+      service.flash('other-link', null);
+      // no settle → nothing flushed for l1; redrawArrows must not throw/touch DOM
+      expect(() => service.redrawArrows('l1')).not.toThrow();
     });
   });
 

--- a/src/app/services/marker-flash.service.ts
+++ b/src/app/services/marker-flash.service.ts
@@ -96,19 +96,63 @@ export class MarkerFlashService {
     const destroyRef = inject(DestroyRef);
     this.effectRef = effect(() => this.applyDiff(this._flashing()));
     destroyRef.onDestroy(() => {
-      if (this.flushRaf !== null) {
-        cancelAnimationFrame(this.flushRaf);
-        this.flushRaf = null;
-      }
-      this.flushScheduled = false;
-      this.pending.clear();
+      this.reset();
       this.effectRef.destroy();
-      for (const key of [...this.prev.keys()]) this.clearLink(linkIdOf(key));
-      this.prev.clear();
-      for (const t of this.timers.values()) clearTimeout(t);
-      this.timers.clear();
-      this.geoCache.clear();
     });
+  }
+
+  /**
+   * Drop the cached path geometry for a deleted link. `clearLink` (expiry)
+   * deliberately keeps the cache — the link still exists and will flash again —
+   * but a deleted link's entry would otherwise live forever (this service is an
+   * app-lifetime singleton), slowly leaking memory on churn topologies.
+   */
+  evictLink(linkId: string) {
+    this.geoCache.delete(linkId);
+  }
+
+  /**
+   * Re-render the direction arrows for a link after its widget redrew it.
+   * LinkWidget.draw() removes the arrow containers on every redraw (their
+   * path-local coordinates are stale once the path changes), but applyDiff
+   * only re-renders on flash state CHANGES — so a redraw mid-flash (endpoint
+   * dragged, parallel re-layout, theme switch) would strip the arrows for the
+   * rest of the flash window. No-op when the link isn't flashing.
+   */
+  redrawArrows(linkId: string) {
+    const best = this.bestEntryForLink(this._flashing(), linkId);
+    if (best) {
+      this.setLink(linkId, best.state);
+    }
+  }
+
+  /**
+   * Full reset (project switch). The service is an app-lifetime singleton whose
+   * DestroyRef (root injector) never fires while the app runs, so the project
+   * map must clear timers, staged flashes, DOM state and the geometry cache
+   * when the user leaves a project — otherwise the previous project's flash
+   * state and cache entries leak into the next one.
+   */
+  reset() {
+    if (this.flushRaf !== null) {
+      cancelAnimationFrame(this.flushRaf);
+      this.flushRaf = null;
+    }
+    this.flushScheduled = false;
+    this.pending.clear();
+    // The timers below would have expired these entries — clear them first so
+    // the effect diff cannot resurrect DOM/state for the previous project.
+    for (const t of this.timers.values()) clearTimeout(t);
+    this.timers.clear();
+    // Reset the signal map itself: without this, every project switch
+    // permanently retains the previous project's flash entries (composite keys
+    // are link UUIDs, never reused) — an unbounded leak in this app-singleton.
+    if (this._flashing().size > 0) {
+      this._flashing.set(new Map());
+    }
+    for (const key of [...this.prev.keys()]) this.clearLink(linkIdOf(key));
+    this.prev.clear();
+    this.geoCache.clear();
   }
 
   /**
@@ -305,16 +349,22 @@ export class MarkerFlashService {
     state: FlashState,
     slot: 'tx' | 'rx' | null
   ) {
-    // Only remove OUR slot's container — leave the other direction's arrows alone.
-    const slotClass = slot ? `marker-arrow-${slot}` : 'marker-arrow';
-    group.select(`g.${slotClass}`).remove();
-    if (!slot) return; // legacy (no dir) → pulse only, no arrows.
-
+    // Validate BEFORE touching the DOM: when the capture node no longer
+    // matches a current endpoint (stale capture after a rewired link, or a
+    // marker.match delivered before the link.updated that changed endpoints)
+    // we must bail WITHOUT removing the slot's arrows — the state diff won't
+    // re-render them (identical states are skipped), so removing here would
+    // permanently strip the flash arrows until expiry.
     const sourceId = group.attr('map-source');
     const targetId = group.attr('map-target');
     const captureIsSource = !!state.captureNodeId && state.captureNodeId === sourceId;
     const captureIsTarget = !!state.captureNodeId && state.captureNodeId === targetId;
-    if (!captureIsSource && !captureIsTarget) return;
+    if (state.captureNodeId && !captureIsSource && !captureIsTarget) return;
+
+    // Only remove OUR slot's container — leave the other direction's arrows alone.
+    const slotClass = slot ? `marker-arrow-${slot}` : 'marker-arrow';
+    group.select(`g.${slotClass}`).remove();
+    if (!slot) return; // legacy (no dir) → pulse only, no arrows.
 
     const node = path.node();
     if (!node) return;
@@ -346,7 +396,13 @@ export class MarkerFlashService {
     // Place evenly-spaced arrows along the path. When both tx and rx are active
     // simultaneously, stagger rx arrows by half a step so they don't overlap.
     const count = Math.max(MIN_ARROW_COUNT, Math.min(MAX_ARROW_COUNT, Math.round(len / ARROW_SPACING)));
-    const container = group.append<SVGGElement>('g').attr('class', slotClass);
+    // Append INSIDE g.link_body: the arrows are placed at path-local coordinates
+    // (getPointAtLength), and the path lives in g.link_body — the group that
+    // carries the parallel-link translate(dx,dy). Appending to the outer g.link
+    // would render every parallel bundle member's arrows on the unshifted
+    // centerline (up to ~±35px off in an 8-link bundle).
+    const body = group.select<SVGGElement>('g.link_body');
+    const container = (body.empty() ? group : body).append<SVGGElement>('g').attr('class', slotClass);
     const step = len / (count + 1);
 
     for (let i = 0; i < count; i++) {

--- a/src/app/services/marker-registry.service.ts
+++ b/src/app/services/marker-registry.service.ts
@@ -74,6 +74,16 @@ export class MarkerRegistryService {
     this.setEntries(entries);
   }
 
+  /**
+   * Clear every entry (project switch). This service is an app-lifetime
+   * singleton that outlives the project map component, so without this the
+   * legend keeps rendering the previous project's marker pills until the new
+   * project's links fetch completes — or forever if that fetch fails.
+   */
+  reset() {
+    this._entries.set([]);
+  }
+
   private collect(link: Link, into: MarkerEntry[]) {
     if (!link.markers) {
       return;

--- a/src/app/services/netmiko-device-types.service.spec.ts
+++ b/src/app/services/netmiko-device-types.service.spec.ts
@@ -1,0 +1,64 @@
+import { TestBed } from '@angular/core/testing';
+import { of, throwError } from 'rxjs';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { Controller } from '@models/controller';
+import { HttpController } from './http-controller.service';
+import { NetmikoDeviceTypesService } from './netmiko-device-types.service';
+
+describe('NetmikoDeviceTypesService', () => {
+  let service: NetmikoDeviceTypesService;
+  let httpController: { get: ReturnType<typeof vi.fn> };
+  let controller: Controller;
+
+  beforeEach(() => {
+    httpController = { get: vi.fn() };
+    TestBed.configureTestingModule({
+      providers: [{ provide: HttpController, useValue: httpController }],
+    });
+    service = TestBed.inject(NetmikoDeviceTypesService);
+    controller = { id: 1 } as Controller;
+    vi.clearAllMocks();
+  });
+
+  it('maps the response device_types / netmiko_version', () => {
+    httpController.get.mockReturnValue(
+      of({
+        netmiko_version: '4.7.0',
+        device_types: [
+          { name: 'cisco_ios', telnet: false, custom: false },
+          { name: 'gns3_vpcs_telnet', telnet: true, custom: true },
+        ],
+      })
+    );
+
+    let result: { deviceTypes: unknown; netmikoVersion: unknown } | undefined;
+    service.getDeviceTypes(controller).subscribe((r) => (result = r));
+
+    expect(httpController.get).toHaveBeenCalledWith(controller, '/netmiko/device_types');
+    expect(result!.deviceTypes).toHaveLength(2);
+    expect(result!.netmikoVersion).toBe('4.7.0');
+  });
+
+  it('falls back to null device types on 501 (netmiko missing) or any error', () => {
+    httpController.get.mockReturnValue(throwError(() => new Error('501 Netmiko is not available')));
+
+    let result: { deviceTypes: unknown; netmikoVersion: unknown } | undefined;
+    service.getDeviceTypes(controller).subscribe((r) => (result = r));
+
+    expect(result!.deviceTypes).toBeNull();
+    expect(result!.netmikoVersion).toBeNull();
+  });
+
+  it('caches per controller — second call does not hit the server again', () => {
+    httpController.get.mockReturnValue(of({ netmiko_version: '4.7.0', device_types: [] }));
+
+    service.getDeviceTypes(controller).subscribe();
+    service.getDeviceTypes(controller).subscribe();
+
+    expect(httpController.get).toHaveBeenCalledTimes(1);
+
+    // a different controller is a different cache entry
+    service.getDeviceTypes({ id: 2 } as Controller).subscribe();
+    expect(httpController.get).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/app/services/netmiko-device-types.service.ts
+++ b/src/app/services/netmiko-device-types.service.ts
@@ -1,0 +1,44 @@
+import { Injectable, inject } from '@angular/core';
+import { of, Observable } from 'rxjs';
+import { catchError, map, tap } from 'rxjs/operators';
+import { Controller } from '@models/controller';
+import { NetmikoDeviceTypesResponse } from '@models/netmiko-device-type';
+import { HttpController } from './http-controller.service';
+
+/**
+ * Result of GET /v3/netmiko/device_types. `deviceTypes: null` means the
+ * list is unavailable (501 netmiko missing / any error) — callers keep the
+ * free-text input instead of a dropdown.
+ */
+export interface NetmikoDeviceTypesResult {
+  deviceTypes: NetmikoDeviceTypesResponse['device_types'] | null;
+  netmikoVersion: string | null;
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class NetmikoDeviceTypesService {
+  private readonly httpController = inject(HttpController);
+
+  /** Per-controller session cache; the server caches too, this avoids a request per dialog open. */
+  private readonly cache = new Map<string, NetmikoDeviceTypesResult>();
+
+  getDeviceTypes(controller: Controller): Observable<NetmikoDeviceTypesResult> {
+    const key = controller.id.toString();
+    const cached = this.cache.get(key);
+    if (cached) {
+      return of(cached);
+    }
+
+    return this.httpController.get<NetmikoDeviceTypesResponse>(controller, '/netmiko/device_types').pipe(
+      map((response) => ({
+        deviceTypes: response.device_types ?? [],
+        netmikoVersion: response.netmiko_version ?? null,
+      })),
+      // 501 (netmiko not installed) or any error — the field still works as free text
+      catchError(() => of<NetmikoDeviceTypesResult>({ deviceTypes: null, netmikoVersion: null })),
+      tap((result) => this.cache.set(key, result))
+    );
+  }
+}

--- a/src/app/services/node.service.spec.ts
+++ b/src/app/services/node.service.spec.ts
@@ -595,6 +595,45 @@ describe('NodeService', () => {
       );
     });
 
+    it('should include automation and credential fields in the payload', async () => {
+      const nodeWithCredentials = {
+        ...mockNode,
+        netmiko_device_type: 'cisco_xr',
+        default_username: 'admin',
+        default_password: 'secret',
+      } as Node;
+      mockHttpController.put.mockReturnValue(of(nodeWithCredentials));
+
+      await firstValueFrom(service.updateNode(mockController, nodeWithCredentials));
+
+      expect(mockHttpController.put).toHaveBeenCalledWith(
+        mockController,
+        '/projects/project-123/nodes/node-1',
+        expect.objectContaining({
+          netmiko_device_type: 'cisco_xr',
+          default_username: 'admin',
+          default_password: 'secret',
+        })
+      );
+    });
+
+    it('should forward null credential fields so they can be cleared', async () => {
+      const clearedNode = {
+        ...mockNode,
+        netmiko_device_type: null,
+        default_username: null,
+        default_password: null,
+      } as Node;
+      mockHttpController.put.mockReturnValue(of(clearedNode));
+
+      await firstValueFrom(service.updateNode(mockController, clearedNode));
+
+      const payload = mockHttpController.put.mock.calls[0][2];
+      expect(payload.netmiko_device_type).toBeNull();
+      expect(payload.default_username).toBeNull();
+      expect(payload.default_password).toBeNull();
+    });
+
     it('should emit error when updateNode fails', async () => {
       const error = new Error('Update node failed');
       mockHttpController.put.mockReturnValue(throwError(() => error));
@@ -642,6 +681,28 @@ describe('NodeService', () => {
       const payload = putCall[2];
 
       expect(payload.custom_adapters).toEqual([]);
+    });
+
+    it('should include automation and credential fields in the payload', async () => {
+      const nodeWithCredentials = {
+        ...mockNode,
+        netmiko_device_type: 'cisco_xr',
+        default_username: 'admin',
+        default_password: 'secret',
+      } as Node;
+      mockHttpController.put.mockReturnValue(of(nodeWithCredentials));
+
+      await firstValueFrom(service.updateNodeWithCustomAdapters(mockController, nodeWithCredentials));
+
+      const putCall = mockHttpController.put.mock.calls[0];
+      const payload = putCall[2];
+      expect(payload).toEqual(
+        expect.objectContaining({
+          netmiko_device_type: 'cisco_xr',
+          default_username: 'admin',
+          default_password: 'secret',
+        })
+      );
     });
 
     it('should emit error when updateNodeWithCustomAdapters fails', async () => {

--- a/src/app/services/node.service.ts
+++ b/src/app/services/node.service.ts
@@ -142,6 +142,9 @@ export class NodeService {
       name: node.name,
       properties: node.properties,
       tags: node.tags,
+      netmiko_device_type: node.netmiko_device_type,
+      default_username: node.default_username,
+      default_password: node.default_password,
     });
   }
 
@@ -176,6 +179,9 @@ export class NodeService {
       name: node.name,
       properties: node.properties,
       tags: node.tags,
+      netmiko_device_type: node.netmiko_device_type,
+      default_username: node.default_username,
+      default_password: node.default_password,
     });
   }
 

--- a/src/app/services/nodeConsole.service.ts
+++ b/src/app/services/nodeConsole.service.ts
@@ -74,6 +74,15 @@ export class NodeConsoleService {
     return `${protocol}://${controller.host}:${controller.port}/${environment.current_version}/projects/${node.project_id}/nodes/${node.node_id}/console/ws?token=${controller.authToken}`;
   }
 
+  sendTerminalSize(socket: WebSocket | null, cols: number, rows: number) {
+    // Binary control frame: terminal data travels as text frames (AttachAddon),
+    // so a binary JSON frame is an unambiguous side channel the server turns
+    // into a console resize (docker exec pty / telnet NAWS / ssh pty size).
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      socket.send(new Blob([JSON.stringify({ cols, rows })]));
+    }
+  }
+
   openConsolesForAllNodesInWidget(nodes: Node[]) {
     let nodesToStart = 'Please start the following nodes if you want to open consoles for them: ';
     let nodesToStartCounter = 0;

--- a/src/app/services/notification.service.spec.ts
+++ b/src/app/services/notification.service.spec.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { of } from 'rxjs';
 import { NotificationService, ComputeNotification } from './notification.service';
 import { Controller } from '@models/controller';
+import { Compute } from '@models/compute';
 
 // Mock environment
 vi.mock('environments/environment', () => ({
@@ -31,6 +33,7 @@ vi.stubGlobal('WebSocket', MockWebSocket);
 
 describe('NotificationService', () => {
   let service: NotificationService;
+  let mockComputeService: { getComputes: ReturnType<typeof vi.fn> };
   let mockController: Controller;
 
   beforeEach(() => {
@@ -40,7 +43,11 @@ describe('NotificationService', () => {
     // Ensure WebSocket stub is always set (prevents pollution from other tests)
     vi.stubGlobal('WebSocket', MockWebSocket);
 
-    service = new NotificationService();
+    mockComputeService = {
+      getComputes: vi.fn().mockReturnValue(of([])),
+    };
+
+    service = new NotificationService(mockComputeService as any);
 
     mockController = {
       id: 1,
@@ -285,6 +292,68 @@ describe('NotificationService', () => {
 
       expect(consoleSpy).toHaveBeenCalledWith('Compute notifications WebSocket error');
       consoleSpy.mockRestore();
+    });
+  });
+
+  describe('auto-reconnect', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('should schedule a reconnect with backoff after an unexpected close', () => {
+      service.connectToComputeNotifications(mockController);
+      const ws = MockWebSocket.instances[0];
+
+      ws.onclose?.();
+
+      // Not reconnected immediately — first backoff is 1s..1.25s (+jitter).
+      expect(MockWebSocket.instances).toHaveLength(1);
+      vi.advanceTimersByTime(1300);
+      expect(MockWebSocket.instances).toHaveLength(2);
+      expect(MockWebSocket.instances[1].url).toBe(ws.url);
+    });
+
+    it('should not reconnect after an intentional disconnect', () => {
+      service.connectToComputeNotifications(mockController);
+      service.disconnect();
+
+      vi.advanceTimersByTime(60000);
+
+      expect(MockWebSocket.instances).toHaveLength(1);
+    });
+
+    it('should re-fetch the compute list into the cache after reconnecting', () => {
+      const computes = [{ compute_id: 'local', name: 'Local' } as Compute];
+      mockComputeService.getComputes.mockReturnValue(of(computes));
+
+      service.connectToComputeNotifications(mockController);
+      const first = MockWebSocket.instances[0];
+      first.onopen?.(); // initial connect: consumers own the initial fetch
+      expect(mockComputeService.getComputes).not.toHaveBeenCalled();
+
+      first.onclose?.(); // unexpected close → reconnect
+      vi.advanceTimersByTime(1300);
+      const second = MockWebSocket.instances[1];
+      second.onopen?.(); // reconnect: service resyncs the cache
+
+      expect(mockComputeService.getComputes).toHaveBeenCalledWith(mockController);
+      expect(service.getCachedComputes()).toEqual(computes);
+    });
+
+    it('should force-close a silent connection on liveness timeout', () => {
+      service.connectToComputeNotifications(mockController);
+      const ws = MockWebSocket.instances[0];
+      ws.onopen?.();
+
+      // No inbound frames at all (not even the periodic ping): the liveness
+      // check must force-close so the reconnect path takes over.
+      vi.advanceTimersByTime(21000);
+
+      expect(ws.close).toHaveBeenCalled();
     });
   });
 

--- a/src/app/services/notification.service.ts
+++ b/src/app/services/notification.service.ts
@@ -3,6 +3,7 @@ import { environment } from 'environments/environment';
 import { Controller } from '@models/controller';
 import { Compute } from '@models/compute';
 import { Project } from '@models/project';
+import { ComputeService } from '@services/compute.service';
 
 export interface ComputeNotification {
   action: 'compute.created' | 'compute.updated' | 'compute.deleted';
@@ -16,8 +17,21 @@ export interface ProjectNotification {
 
 @Injectable()
 export class NotificationService {
-  private ws: WebSocket;
-  private currentController: Controller;
+  // The backend pushes a ping on the notification stream every ~5s, so a
+  // healthy connection always has inbound traffic. If nothing arrives for
+  // WS_LIVENESS_TIMEOUT_MS the TCP connection is presumed half-open (onclose
+  // would never fire on its own), so it is force-closed to enter the normal
+  // reconnect path. Mirrors the project WS liveness check in project-map.
+  private readonly WS_LIVENESS_TIMEOUT_MS = 15000;
+  private readonly WS_LIVENESS_CHECK_MS = 5000;
+
+  private ws: WebSocket | null = null;
+  private currentController: Controller | null = null;
+  private intentionalClose = false;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private reconnectAttempt = 0;
+  private livenessTimer: ReturnType<typeof setInterval> | null = null;
+  private lastWsMessageAt = 0;
 
   // Event emitters for compute notifications
   public computeNotificationEmitter = new EventEmitter<ComputeNotification>();
@@ -30,6 +44,8 @@ export class NotificationService {
 
   // EventEmitter for cache updates
   public computeCacheUpdated = new EventEmitter<Compute[]>();
+
+  constructor(private computeService: ComputeService) {}
 
   notificationsPath(controller: Controller): string {
     let protocol: string = 'ws';
@@ -68,9 +84,38 @@ export class NotificationService {
     this.disconnect();
 
     this.currentController = controller;
-    this.ws = new WebSocket(this.notificationsPath(controller));
+    this.openComputeNotificationsWs();
+  }
+
+  /**
+   * Open (or reopen) the controller notifications WebSocket. On an unexpected
+   * close the connection is silently reconnected with exponential backoff; on
+   * a successful reconnect the compute list is re-fetched into the cache —
+   * the notification stream does not replay events missed while disconnected.
+   */
+  private openComputeNotificationsWs() {
+    if (!this.currentController) {
+      return;
+    }
+
+    this.intentionalClose = false;
+    this.ws = new WebSocket(this.notificationsPath(this.currentController));
+
+    this.ws.onopen = () => {
+      // Reconnect (attempt > 0): resync the compute cache to cover missed
+      // events. First connect (attempt 0): consumers fetch the initial list.
+      const isReconnect = this.reconnectAttempt > 0;
+      this.reconnectAttempt = 0;
+      this.startLivenessCheck();
+      if (isReconnect) {
+        this.resyncComputesAfterReconnect();
+      }
+    };
 
     this.ws.onmessage = (event: MessageEvent) => {
+      // Any inbound frame (incl. the periodic ping) proves the connection is
+      // alive — stamp it for the liveness check before dispatching.
+      this.lastWsMessageAt = Date.now();
       const message = JSON.parse(event.data);
       this.handleMessage(message);
     };
@@ -81,19 +126,76 @@ export class NotificationService {
 
     this.ws.onclose = () => {
       this.ws = null;
+      this.stopLivenessCheck();
       // Don't clear currentController - keep it for potential reconnection
       // currentController should only be cleared in disconnect() method
+      if (this.intentionalClose) {
+        return;
+      }
+      this.scheduleReconnect();
     };
   }
 
+  private scheduleReconnect() {
+    if (this.intentionalClose || !this.currentController) {
+      return;
+    }
+    const attempt = this.reconnectAttempt++;
+    // Exponential backoff capped at 30s, +up to 25% jitter to avoid reconnect
+    // storms when many clients drop simultaneously.
+    const base = Math.min(30000, 1000 * 2 ** attempt);
+    const delay = Math.round(base + Math.random() * 0.25 * base);
+    this.reconnectTimer = setTimeout(() => this.openComputeNotificationsWs(), delay);
+  }
+
+  /**
+   * Re-fetch the authoritative compute list after a reconnect and push it
+   * through the cache (setInitialComputes emits computeCacheUpdated) so every
+   * consumer resyncs — missed WS events are not replayed by the server.
+   */
+  private resyncComputesAfterReconnect() {
+    if (!this.currentController) {
+      return;
+    }
+    this.computeService.getComputes(this.currentController).subscribe({
+      next: (computes) => this.setInitialComputes(computes),
+      error: (err) => console.warn('Compute resync after WS reconnect failed', err),
+    });
+  }
+
+  private startLivenessCheck() {
+    this.stopLivenessCheck();
+    this.lastWsMessageAt = Date.now();
+    this.livenessTimer = setInterval(() => {
+      if (Date.now() - this.lastWsMessageAt > this.WS_LIVENESS_TIMEOUT_MS) {
+        console.warn('Compute notifications WS liveness timeout — no message received, forcing reconnect');
+        this.stopLivenessCheck();
+        this.ws?.close(); // onclose drives the normal reconnect path
+      }
+    }, this.WS_LIVENESS_CHECK_MS);
+  }
+
+  private stopLivenessCheck() {
+    if (this.livenessTimer) {
+      clearInterval(this.livenessTimer);
+      this.livenessTimer = null;
+    }
+  }
+
   disconnect() {
+    this.intentionalClose = true;
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    this.stopLivenessCheck();
+    this.reconnectAttempt = 0;
     if (this.ws) {
       this.ws.close();
       this.ws = null;
-      this.currentController = null;
-      // Clear cache when disconnecting
-      this.computeCache.clear();
     }
+    this.currentController = null;
+    this.computeCache.clear();
   }
 
   /**

--- a/src/app/services/validation/base/validation.service.spec.ts
+++ b/src/app/services/validation/base/validation.service.spec.ts
@@ -377,4 +377,45 @@ describe('ValidationService', () => {
       expect(result.errorMessage).toBe('Port must be a non-negative integer');
     });
   });
+
+  describe('validateNetmikoDeviceType', () => {
+    it('should pass validation for empty string (optional field)', () => {
+      const result = service.validateNetmikoDeviceType('');
+
+      expect(result.isValid).toBe(true);
+      expect(result.errorMessage).toBeUndefined();
+    });
+
+    it('should pass validation for lowercase device type', () => {
+      const result = service.validateNetmikoDeviceType('cisco_xr');
+
+      expect(result.isValid).toBe(true);
+      expect(result.errorMessage).toBeUndefined();
+    });
+
+    it('should pass validation for device type with digits', () => {
+      const result = service.validateNetmikoDeviceType('nokia_srlinux_1');
+
+      expect(result.isValid).toBe(true);
+      expect(result.errorMessage).toBeUndefined();
+    });
+
+    it('should fail validation for uppercase letters', () => {
+      const result = service.validateNetmikoDeviceType('Cisco-XR');
+
+      expect(result.isValid).toBe(false);
+      expect(result.errorMessage).toBe(
+        'Netmiko device type must only contain lowercase letters, digits and underscores (e.g. cisco_xr)'
+      );
+    });
+
+    it('should fail validation for dashes', () => {
+      const result = service.validateNetmikoDeviceType('cisco-xr');
+
+      expect(result.isValid).toBe(false);
+      expect(result.errorMessage).toBe(
+        'Netmiko device type must only contain lowercase letters, digits and underscores (e.g. cisco_xr)'
+      );
+    });
+  });
 });

--- a/src/app/services/validation/base/validation.service.ts
+++ b/src/app/services/validation/base/validation.service.ts
@@ -463,4 +463,25 @@ export class ValidationService {
         : formatHint || this.errorMessages.formatInvalid(fieldName, pattern.toString()),
     };
   }
+
+  /**
+   * Validates netmiko_device_type (optional automation field)
+   *
+   * Empty is valid (field is optional). When set, must be a lowercase
+   * identifier (e.g. cisco_xr, nokia_srl) so netmiko/nornir tools can
+   * identify the device CLI type.
+   */
+  validateNetmikoDeviceType(value: string): ValidationResult {
+    if (!value || value.trim() === '') {
+      return { isValid: true };
+    }
+
+    const isValid = /^[a-z0-9_]+$/.test(value.trim());
+    return {
+      isValid,
+      errorMessage: isValid
+        ? undefined
+        : 'Netmiko device type must only contain lowercase letters, digits and underscores (e.g. cisco_xr)',
+    };
+  }
 }

--- a/src/app/services/validation/nodes/docker-validation.service.ts
+++ b/src/app/services/validation/nodes/docker-validation.service.ts
@@ -279,4 +279,11 @@ export class DockerValidationService {
 
     return this.base.validatePortRange(portValue, 1, 65535);
   }
+
+  /**
+   * Validates netmiko device type (optional automation field)
+   */
+  validateNetmikoDeviceType(value: string): ValidationResult {
+    return this.base.validateNetmikoDeviceType(value);
+  }
 }

--- a/src/app/services/validation/nodes/ios-validation.service.ts
+++ b/src/app/services/validation/nodes/ios-validation.service.ts
@@ -244,4 +244,11 @@ export class IosValidationService {
     }
     return { isValid: true };
   }
+
+  /**
+   * Validates netmiko device type (optional automation field)
+   */
+  validateNetmikoDeviceType(value: string): ValidationResult {
+    return this.base.validateNetmikoDeviceType(value);
+  }
 }

--- a/src/app/services/validation/nodes/iou-validation.service.ts
+++ b/src/app/services/validation/nodes/iou-validation.service.ts
@@ -50,4 +50,11 @@ export class IouValidationService {
     }
     return { isValid: true };
   }
+
+  /**
+   * Validates netmiko device type (optional automation field)
+   */
+  validateNetmikoDeviceType(value: string): ValidationResult {
+    return this.base.validateNetmikoDeviceType(value);
+  }
 }

--- a/src/app/services/validation/nodes/qemu-validation.service.ts
+++ b/src/app/services/validation/nodes/qemu-validation.service.ts
@@ -92,4 +92,11 @@ export class QemuValidationService {
     }
     return { isValid: true };
   }
+
+  /**
+   * Validates netmiko device type (optional automation field)
+   */
+  validateNetmikoDeviceType(value: string): ValidationResult {
+    return this.base.validateNetmikoDeviceType(value);
+  }
 }

--- a/src/styles/_dialogs.scss
+++ b/src/styles/_dialogs.scss
@@ -43,6 +43,14 @@
     margin-bottom: 4px;
   }
 
+  /* Three-column row for short fields (netmiko device type / username / password) */
+  .three-column-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 16px;
+    align-items: start;
+  }
+
   /* Modal form container padding */
   .modal-form-container {
     padding: 16px 24px;
@@ -125,6 +133,14 @@
   /* Dialog content - with max-height for scroll */
   .mat-mdc-dialog-content {
     max-height: calc(80vh - 140px);
+  }
+
+  /* Loading state - centered spinner while node data is fetched */
+  .configurator-dialog-loading {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 240px;
   }
 
   /* Tab content - add spacing below tab labels */

--- a/yarn.lock
+++ b/yarn.lock
@@ -380,9 +380,9 @@
     zod "4.3.6"
 
 "@angular/common@^21.0.0":
-  version "21.2.18"
-  resolved "https://registry.yarnpkg.com/@angular/common/-/common-21.2.18.tgz#1eb24633707e0e0eac1cadea623b4b0a047dd62d"
-  integrity sha512-gZugZ8gX/KkACIZ3/ekoImLu5z8a0Iu9O5b84kh8e+++VUjmkmd19IygBsq/8/fF3vKf0UcIKcx3P6A/gb2DJw==
+  version "21.2.21"
+  resolved "https://registry.yarnpkg.com/@angular/common/-/common-21.2.21.tgz#f045750d811c77ccbc55fa1828fdf3e7fe51674f"
+  integrity sha512-ntouT80emF5osQW5XOI6PHSa6E3ZxPGIbwtIYznuiz9bBboW0TRs9YUSNg8TRfOiTBqwG8FKXCr19eyCaaTsgA==
   dependencies:
     tslib "^2.3.0"
 
@@ -401,16 +401,16 @@
     yargs "^18.0.0"
 
 "@angular/compiler@^21.0.0":
-  version "21.2.18"
-  resolved "https://registry.yarnpkg.com/@angular/compiler/-/compiler-21.2.18.tgz#c702773ea970d168c7504db2f0f4036d3e04bcad"
-  integrity sha512-ccnDuKLuzIa0ayijR+alarsHNWIksuGV/lxGTZ0t6/0+B6J/RXupz6M2IO6ZHHEcg8r7pcrLCUBTyp3FoiRJrg==
+  version "21.2.21"
+  resolved "https://registry.yarnpkg.com/@angular/compiler/-/compiler-21.2.21.tgz#632691cc2163235895692db8ffb376fba98e8008"
+  integrity sha512-v2cxgmfsXVPCFivnbTmCdr1X+iDct9ZZUy7InDdKbTSwJld8zSyWwBVr3/8xzZ9hV4F41la5IxIyRyej52Mslw==
   dependencies:
     tslib "^2.3.0"
 
 "@angular/core@^21.0.0":
-  version "21.2.18"
-  resolved "https://registry.yarnpkg.com/@angular/core/-/core-21.2.18.tgz#c8986994ed9eb66d13c1e3875c613bc87581225a"
-  integrity sha512-AG4bb6GU0+qp+vVBjc/IhSPjgcRX8QsCb8jzN8dDyhnjsyuuG/LlIiU0l6n65BI9SGKE9m6TfsJ1ObkkAiE5KQ==
+  version "21.2.21"
+  resolved "https://registry.yarnpkg.com/@angular/core/-/core-21.2.21.tgz#68b4a8482d65cf1bebd2f63c66045842c977149b"
+  integrity sha512-87moY/3TmowvBcM7zYJQcpXg8O5Ro/6uQ2OdVILl7Tq9lBZbQlZcw5N+6b8s8LwRX4ka6srFVeVLW6JoJ1cFUw==
   dependencies:
     tslib "^2.3.0"
 


### PR DESCRIPTION
## Summary

Work built on top of the merged Web UI refactor (#1778). Single commit on top of `3.1` (bdd96f0f3); net diff: **160 files, +4237/−290**. Four independent feature areas — each can be reviewed on its own:

1. [Template & node credentials + netmiko device type](#1-template--node-credentials--netmiko-device-type)
2. [Console terminal size over WebSocket](#2-console-terminal-size-over-websocket)
3. [Dialog loading states & dismiss locks](#3-dialog-loading-states--dismiss-locks)
4. [Cartography fixes](#4-cartography-fixes)

---

## 1. Template & node credentials + netmiko device type

Adds per-template/per-node automation credentials and a `netmiko_device_type` field, wired end to end: appliance install → template details → node configurator → node update PUT.

**Fields:** `default_username`, `default_password`, `netmiko_device_type`.

- **Template details** (Docker / QEMU / IOS / IOU / VPCS): credentials group moved into *General settings*, laid out as one three-column row (`username | password | device type`).
- **Node configurators**: same three-column row; values are included in node update PUTs (`updateNode`, `updateNodeWithCustomAdapters`). `null` values are forwarded explicitly so credentials can be **cleared**, not just set (see `node.service.spec.ts`).
- **Device type dropdown** — new `NetmikoDeviceTypesService` (`src/app/services/netmiko-device-types.service.ts`):
  - calls `GET /v3/netmiko/device_types`, returns `{ device_types, netmiko_version }`
  - per-controller session cache, so opening a dialog doesn't re-request
  - **graceful degradation**: on 501 (netmiko not installed on server) or any error the field falls back to a free-text input — `deviceTypes: null`
- **Appliance metadata persistence**: templates created client-side from an appliance now carry an `appliance_metadata` snapshot (`buildApplianceMetadata` in `src/app/services/appliance-normalizer.ts`), mirroring the server's `_build_appliance_metadata` in `gns3server/controller/appliance_to_template.py`. Version-level values (e.g. credentials specific to the installed version) override appliance-level ones; includes `appliance_id` to identify the source appliance.
- **v8 appliances**: `netmiko_device_type` support when installing v8 appliance files; version `settings` groups are resolved **by name** (v8 files may repeat group ids).

## 2. Console terminal size over WebSocket

The console WebSocket now reports the xterm.js geometry to the server so PTYs get the right size (docker exec pty / telnet NAWS / ssh pty-request):

- **Frame format:** a **binary** frame containing `JSON.stringify({ cols, rows })`. Terminal I/O travels as *text* frames (xterm AttachAddon), so a binary frame is an unambiguous control side-channel.
- Sent on socket open and on every resize (fires from `FitAddon.fit()` / `term.resize()`).
- Implemented in `NodeConsoleService.sendTerminalSize()`, used by both the docked console (`web-console.component.ts`) and the full-window console (`web-console-full-window.component.ts`).

## 3. Dialog loading states & dismiss locks

- **Apply buttons** across template details and configurator dialogs show a spinner while the request is in flight.
- **Node configurators** show a loading state while data loads.
- **Dismiss lock:** while an Apply request is in flight, `dialogRef.disableClose = true` — the dialog cannot be closed (backdrop click / Esc) until the save finishes, so in-flight edits can't be silently lost. Restored to `false` on completion or error.

## 4. Cartography fixes

- **Toolbar zoom restored**, snap correction on drag, and the node label pipeline fixed (`1330ed48`).
- **Marker arrow alignment on parallel links** between the same pair of nodes, marker cache eviction, and UI guards against stale selections (`48ae2a69`, `ef94c0e0` — the latter adds regression tests).
- **Background grid anchored to the scene origin** instead of floating with pan/zoom — eliminates the grid "wobble" during drag (`c5335898`).

---

## Notes for reviewers

- This work was developed in parallel with #1778 and has been squashed onto `3.1` as **one commit**, so the **Files changed** tab shows exactly the net content.
- The cartography fixes predate the refactor and were re-validated against the refactored map code.
- No changes to server API contracts beyond consuming `GET /netmiko/device_types` (501-safe) and sending the binary resize frames on the console WebSocket — both expect matching handling in gns3-server.

## Testing

- New spec: `netmiko-device-types.service.spec.ts` (cache behavior, 501 fallback).
- `node.service.spec.ts`: credential/netmiko fields in PUT payloads, including `null`-clearing.
- Stepper/details specs updated for the new netmiko step and terminal-size control frames; full suite green locally (`vitest`).

