### PR TITLE
feat: add-nodes advanced options & view toggle, marker legend in topology summary

### DIFF
--- a/src/app/components/project-map/marker-legend/marker-legend.component.html
+++ b/src/app/components/project-map/marker-legend/marker-legend.component.html
@@ -1,20 +1,40 @@
-@if (entries().length > 0) {
-<div class="marker-legend" (click)="onClick()" title="Click to open Marker Manager">
-  @for (entry of entries(); track entry.name) {
-  <span
-    class="marker-legend__pill"
-    [matTooltip]="entry.bpf"
-    matTooltipPosition="above"
-    matTooltipClass="marker-legend-tooltip"
-  >
-    <span
-      class="marker-legend__swatch"
-      [style.background]="entry.color"
-      [class.marker-legend__swatch--default]="!entry.color"
-    ></span>
-    <span class="marker-legend__name">{{ entry.name }}</span>
-  </span>
+<div class="marker-legend">
+  <div class="marker-legend__header">
+    <span>{{ entries().length }} markers</span>
+    <button
+      mat-icon-button
+      type="button"
+      class="marker-legend__manage"
+      aria-label="Open marker manager"
+      matTooltip="Open marker manager"
+      matTooltipPosition="left"
+      (click)="onClick()"
+    >
+      <mat-icon>settings</mat-icon>
+    </button>
+  </div>
+
+  @if (entries().length > 0) {
+  <div class="marker-legend__list">
+    @for (entry of entries(); track entry.name) {
+    <div class="marker-legend__row" [matTooltip]="entry.bpf" matTooltipPosition="above">
+      <span
+        class="marker-legend__swatch"
+        [style.background]="entry.color"
+        [class.marker-legend__swatch--default]="!entry.color"
+      ></span>
+      <span class="marker-legend__identity">
+        <strong>{{ entry.name }}</strong>
+        <span>{{ entry.bpf }}</span>
+      </span>
+    </div>
+    }
+  </div>
+  } @else {
+  <div class="marker-legend__empty">
+    <mat-icon>insights</mat-icon>
+    <span>No markers defined</span>
+    <button mat-button type="button" (click)="onClick()">Open marker manager</button>
+  </div>
   }
-  <span class="marker-legend__label">Markers</span>
 </div>
-}

--- a/src/app/components/project-map/marker-legend/marker-legend.component.scss
+++ b/src/app/components/project-map/marker-legend/marker-legend.component.scss
@@ -1,63 +1,98 @@
 .marker-legend {
-  position: fixed;
-  bottom: 76px;
-  left: 50%;
-  transform: translateX(-50%);
-  z-index: 900;
   display: flex;
-  align-items: center;
-  gap: 2px;
-  padding: 4px 6px;
-  border-radius: 8px;
-  background-color: var(--mat-sys-surface);
-  box-shadow: 0 1px 4px color-mix(in srgb, var(--mat-sys-shadow) 15%, transparent),
-    0 0 0 1px var(--mat-sys-outline-variant);
-  cursor: pointer;
-  user-select: none;
-  transition: box-shadow 0.15s ease;
+  flex: 1 1 auto;
+  min-height: 0;
+  flex-direction: column;
 
-  &:hover {
-    box-shadow: 0 2px 8px color-mix(in srgb, var(--mat-sys-shadow) 20%, transparent),
-      0 0 0 1px var(--mat-sys-outline);
+  &__header {
+    display: flex;
+    min-height: var(--topology-control-height);
+    align-items: center;
+    justify-content: space-between;
+    padding-inline: var(--gns3-density-space-3);
+    color: var(--mat-sys-on-surface-variant);
+    font: var(--mat-sys-label-medium);
+    font-weight: 600;
   }
 
-  &__pill {
+  &__manage {
+    width: var(--topology-control-height);
+    height: var(--topology-control-height);
+  }
+
+  &__list {
+    min-height: 0;
+    flex: 1 1 auto;
+    overflow: auto;
+    overflow-x: hidden;
+  }
+
+  &__row {
     display: flex;
+    min-height: var(--topology-row-height);
+    box-sizing: border-box;
     align-items: center;
-    gap: 4px;
-    padding: 2px 6px;
-    border-radius: 4px;
-    transition: background-color 0.1s ease;
+    gap: var(--gns3-density-space-2);
+    padding-inline: var(--gns3-density-space-3);
+    border-bottom: 1px solid var(--mat-sys-outline-variant);
+    cursor: default;
 
     &:hover {
-      background-color: var(--mat-sys-surface-container-highest);
+      background: var(--mat-sys-surface-container);
     }
   }
 
   &__swatch {
-    width: 10px;
-    height: 10px;
-    border-radius: 2px;
-    flex-shrink: 0;
+    width: 12px;
+    height: 12px;
+    flex: 0 0 12px;
+    border-radius: 3px;
 
     &--default {
       background-color: var(--mat-sys-primary);
     }
   }
 
-  &__name {
-    font-size: 11px;
-    font-weight: 500;
-    color: var(--mat-sys-on-surface);
-    white-space: nowrap;
+  &__identity {
+    display: flex;
+    flex: 1 1 auto;
+    flex-direction: column;
+    overflow: hidden;
+
+    strong,
+    span {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    strong {
+      font: var(--mat-sys-body-small);
+      font-weight: 600;
+      color: var(--mat-sys-on-surface);
+    }
+
+    span {
+      color: var(--mat-sys-on-surface-variant);
+      font: var(--mat-sys-label-small);
+    }
   }
 
-  &__label {
-    font-size: 10px;
+  &__empty {
+    display: flex;
+    flex: 1 1 auto;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: var(--gns3-density-space-2);
     color: var(--mat-sys-on-surface-variant);
-    margin-left: 4px;
-    padding-left: 6px;
-    border-left: 1px solid var(--mat-sys-outline-variant);
-    white-space: nowrap;
+
+    mat-icon {
+      color: var(--mat-sys-on-surface-variant);
+    }
+
+    span {
+      font: var(--mat-sys-body-small);
+    }
   }
 }

--- a/src/app/components/project-map/marker-legend/marker-legend.component.ts
+++ b/src/app/components/project-map/marker-legend/marker-legend.component.ts
@@ -1,6 +1,8 @@
 import { ChangeDetectionStrategy, Component, EventEmitter, Output, computed, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatIconModule } from '@angular/material/icon';
+import { MatButtonModule } from '@angular/material/button';
 import { MarkerRegistryService } from '@services/marker-registry.service';
 
 @Component({
@@ -9,7 +11,7 @@ import { MarkerRegistryService } from '@services/marker-registry.service';
   templateUrl: './marker-legend.component.html',
   styleUrl: './marker-legend.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [CommonModule, MatTooltipModule],
+  imports: [CommonModule, MatTooltipModule, MatIconModule, MatButtonModule],
 })
 export class MarkerLegendComponent {
   private readonly registry = inject(MarkerRegistryService);

--- a/src/app/components/project-map/project-map.component.html
+++ b/src/app/components/project-map/project-map.component.html
@@ -270,8 +270,6 @@
     }
   </div>
 
-  <app-marker-legend (openMarkerManager)="toggleMarkerManager()"></app-marker-legend>
-
   @if (project && isMarkerManagerVisible) {
   <app-marker-manager
     [controller]="controller"

--- a/src/app/components/project-map/project-map.component.spec.ts
+++ b/src/app/components/project-map/project-map.component.spec.ts
@@ -894,7 +894,7 @@ describe('ProjectMapComponent', () => {
       mockProjectService.nodes.mockReturnValue(of([]));
       const event = {
         template: { name: 'Router' },
-        controller: 'local',
+        computeId: 'local',
         numberOfNodes: 3,
         x: 0,
         y: 0,

--- a/src/app/components/project-map/project-map.component.ts
+++ b/src/app/components/project-map/project-map.component.ts
@@ -121,7 +121,6 @@ import { LinkCreatedComponent } from '../drawings-listeners/link-created/link-cr
 import { NodeDraggedComponent } from '../drawings-listeners/node-dragged/node-dragged.component';
 import { NodeLabelDraggedComponent } from '../drawings-listeners/node-label-dragged/node-label-dragged.component';
 import { TextAddedComponent } from '../drawings-listeners/text-added/text-added.component';
-import { MarkerLegendComponent } from './marker-legend/marker-legend.component';
 import { MarkerManagerComponent } from './marker-manager/marker-manager.component';
 import { TextEditedComponent } from '../drawings-listeners/text-edited/text-edited.component';
 import { createActionCompletion } from '@utils/action-completion.util';
@@ -165,7 +164,6 @@ import type { TopologyItemCounts } from '@utils/topology-delete-summary.util';
     NodeLabelDraggedComponent,
     TextAddedComponent,
     TextEditedComponent,
-    MarkerLegendComponent,
     MarkerManagerComponent,
     NotificationCenterComponent,
   ],
@@ -380,6 +378,7 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
       this.instance.instance.controller = this.controller;
       this.instance.instance.project = this.project;
       this.instance.instance.openWebConsoleInline.subscribe((data) => this.onOpenWebConsoleInline(data));
+      this.instance.instance.openMarkerManager.subscribe(() => this.toggleMarkerManager());
       // In zoneless mode, createComponent doesn't automatically trigger change detection
       // We need to explicitly detect changes to ensure the component is rendered
       this.instance.changeDetectorRef.detectChanges();

--- a/src/app/components/project-map/project-map.component.ts
+++ b/src/app/components/project-map/project-map.component.ts
@@ -1108,7 +1108,7 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
         nodeAddedEvent.template,
         nodeAddedEvent.x,
         nodeAddedEvent.y,
-        nodeAddedEvent.controller
+        nodeAddedEvent.computeId
       )
       .subscribe(
         (node: Node) => {

--- a/src/app/components/template/template-list-dialog/template-list-dialog.component.html
+++ b/src/app/components/template/template-list-dialog/template-list-dialog.component.html
@@ -30,7 +30,20 @@
 </div>
 <div mat-dialog-content class="dialog-content">
   <section class="dialog-section" aria-labelledby="template-section-title">
-    <h2 id="template-section-title" class="dialog-section__title">Choose a template</h2>
+    <div class="dialog-section__header">
+      <h2 id="template-section-title" class="dialog-section__title">Choose a template</h2>
+      <button
+        mat-icon-button
+        type="button"
+        class="dialog-section__view-toggle"
+        [attr.aria-label]="viewMode() === 'grid' ? 'Switch to list view' : 'Switch to grid view'"
+        [matTooltip]="viewMode() === 'grid' ? 'Switch to list view' : 'Switch to grid view'"
+        matTooltipPosition="left"
+        (click)="toggleViewMode()"
+      >
+        <mat-icon>{{ viewMode() === 'grid' ? 'view_list' : 'grid_view' }}</mat-icon>
+      </button>
+    </div>
     <div class="dialog-fields">
       <mat-form-field subscriptSizing="dynamic">
         <mat-label>Search templates</mat-label>
@@ -54,11 +67,12 @@
       </mat-form-field>
     </div>
 
-    <div class="template-gallery" role="group" aria-label="Node templates">
+    <div class="template-gallery" [class.template-gallery--list]="viewMode() === 'list'" role="group" aria-label="Node templates">
       @for (template of filteredTemplates; track template.template_id ?? template.name) {
       <button
         type="button"
         class="template-card"
+        [class.template-card--list]="viewMode() === 'list'"
         [class.template-card--draggable]="data.allowTopologyDrop"
         [draggable]="data.allowTopologyDrop"
         [attr.aria-pressed]="selectedTemplate() === template"
@@ -75,6 +89,9 @@
           }
         </span>
         <span class="template-card__name">{{ template.name }}</span>
+        @if (viewMode() === 'list') {
+        <span class="template-card__type">{{ formatTemplateType(template.template_type) }}</span>
+        }
         @if (selectedTemplate() === template) {
         <mat-icon class="template-card__selected-icon">check_circle</mat-icon>
         }

--- a/src/app/components/template/template-list-dialog/template-list-dialog.component.html
+++ b/src/app/components/template/template-list-dialog/template-list-dialog.component.html
@@ -93,45 +93,41 @@
       <mat-panel-title>Advanced options</mat-panel-title>
     </mat-expansion-panel-header>
 
-      <section class="dialog-section" aria-labelledby="configuration-section-title">
-        <h2 id="configuration-section-title" class="dialog-section__title">Configuration</h2>
-        <div class="dialog-fields">
-          <div [formGroup]="configurationForm">
-            <mat-form-field subscriptSizing="dynamic">
-              <mat-label>Number of nodes</mat-label>
-              <input type="number" min="1" step="1" matInput formControlName="numberOfNodes" />
-            </mat-form-field>
-          </div>
+      <div class="dialog-fields">
+        <div [formGroup]="configurationForm">
           <mat-form-field subscriptSizing="dynamic">
-            <mat-label>Compute</mat-label>
-            <mat-select
-              [value]="selectedComputeId()"
-              (selectionChange)="selectedComputeId.set($event.value)"
-              [compareWith]="compareComputes"
-            >
-              @for (compute of nodeComputes; track compute.value) {
-              <mat-option [value]="compute.value">
-                {{ compute.display }}
-              </mat-option>
-              }
-            </mat-select>
+            <mat-label>Number of nodes</mat-label>
+            <input type="number" min="1" step="1" matInput formControlName="numberOfNodes" />
           </mat-form-field>
         </div>
-      </section>
+        <mat-form-field subscriptSizing="dynamic">
+          <mat-label>Compute</mat-label>
+          <mat-select
+            [value]="selectedComputeId()"
+            (selectionChange)="selectedComputeId.set($event.value)"
+            [compareWith]="compareComputes"
+          >
+            @for (compute of nodeComputes; track compute.value) {
+            <mat-option [value]="compute.value">
+              {{ compute.display }}
+            </mat-option>
+            }
+          </mat-select>
+        </mat-form-field>
+      </div>
 
-      <section class="dialog-section" aria-labelledby="position-section-title">
-        <h2 id="position-section-title" class="dialog-section__title">Manual position</h2>
-        <form class="dialog-fields" [formGroup]="positionForm">
-          <mat-form-field subscriptSizing="dynamic">
-            <mat-label>Left</mat-label>
-            <input matInput type="number" formControlName="left" />
-          </mat-form-field>
-          <mat-form-field subscriptSizing="dynamic">
-            <mat-label>Top</mat-label>
-            <input matInput type="number" formControlName="top" />
-          </mat-form-field>
-        </form>
-      </section>
+      <div class="advanced-options__divider" role="separator"></div>
+
+      <form class="dialog-fields" [formGroup]="positionForm">
+        <mat-form-field subscriptSizing="dynamic">
+          <mat-label>Left (X)</mat-label>
+          <input matInput type="number" formControlName="left" />
+        </mat-form-field>
+        <mat-form-field subscriptSizing="dynamic">
+          <mat-label>Top (Y)</mat-label>
+          <input matInput type="number" formControlName="top" />
+        </mat-form-field>
+      </form>
     </mat-expansion-panel>
 </div>
 <div mat-dialog-actions>

--- a/src/app/components/template/template-list-dialog/template-list-dialog.component.html
+++ b/src/app/components/template/template-list-dialog/template-list-dialog.component.html
@@ -88,45 +88,51 @@
     </div>
   </section>
 
-  <section class="dialog-section" aria-labelledby="configuration-section-title">
-    <h2 id="configuration-section-title" class="dialog-section__title">Configuration</h2>
-    <div class="dialog-fields">
-      <div [formGroup]="configurationForm">
-        <mat-form-field subscriptSizing="dynamic">
-          <mat-label>Number of nodes</mat-label>
-          <input type="number" min="1" step="1" matInput formControlName="numberOfNodes" />
-        </mat-form-field>
-      </div>
-      <mat-form-field subscriptSizing="dynamic">
-        <mat-label>Controller</mat-label>
-        <mat-select
-          [value]="selectedComputeId()"
-          (selectionChange)="selectedComputeId.set($event.value)"
-          [compareWith]="compareControllers"
-        >
-          @for (controller of nodeControllers; track controller.value) {
-          <mat-option [value]="controller.value">
-            {{ controller.display }}
-          </mat-option>
-          }
-        </mat-select>
-      </mat-form-field>
-    </div>
-  </section>
+  <mat-expansion-panel class="advanced-options">
+    <mat-expansion-panel-header>
+      <mat-panel-title>Advanced options</mat-panel-title>
+    </mat-expansion-panel-header>
 
-  <section class="dialog-section" aria-labelledby="position-section-title">
-    <h2 id="position-section-title" class="dialog-section__title">Manual position</h2>
-    <form class="dialog-fields" [formGroup]="positionForm">
-      <mat-form-field subscriptSizing="dynamic">
-        <mat-label>Left</mat-label>
-        <input matInput type="number" formControlName="left" />
-      </mat-form-field>
-      <mat-form-field subscriptSizing="dynamic">
-        <mat-label>Top</mat-label>
-        <input matInput type="number" formControlName="top" />
-      </mat-form-field>
-    </form>
-  </section>
+      <section class="dialog-section" aria-labelledby="configuration-section-title">
+        <h2 id="configuration-section-title" class="dialog-section__title">Configuration</h2>
+        <div class="dialog-fields">
+          <div [formGroup]="configurationForm">
+            <mat-form-field subscriptSizing="dynamic">
+              <mat-label>Number of nodes</mat-label>
+              <input type="number" min="1" step="1" matInput formControlName="numberOfNodes" />
+            </mat-form-field>
+          </div>
+          <mat-form-field subscriptSizing="dynamic">
+            <mat-label>Compute</mat-label>
+            <mat-select
+              [value]="selectedComputeId()"
+              (selectionChange)="selectedComputeId.set($event.value)"
+              [compareWith]="compareComputes"
+            >
+              @for (compute of nodeComputes; track compute.value) {
+              <mat-option [value]="compute.value">
+                {{ compute.display }}
+              </mat-option>
+              }
+            </mat-select>
+          </mat-form-field>
+        </div>
+      </section>
+
+      <section class="dialog-section" aria-labelledby="position-section-title">
+        <h2 id="position-section-title" class="dialog-section__title">Manual position</h2>
+        <form class="dialog-fields" [formGroup]="positionForm">
+          <mat-form-field subscriptSizing="dynamic">
+            <mat-label>Left</mat-label>
+            <input matInput type="number" formControlName="left" />
+          </mat-form-field>
+          <mat-form-field subscriptSizing="dynamic">
+            <mat-label>Top</mat-label>
+            <input matInput type="number" formControlName="top" />
+          </mat-form-field>
+        </form>
+      </section>
+    </mat-expansion-panel>
 </div>
 <div mat-dialog-actions>
   <button mat-button (click)="onNoClick()" tabindex="-1" color="accent">Close</button>

--- a/src/app/components/template/template-list-dialog/template-list-dialog.component.scss
+++ b/src/app/components/template/template-list-dialog/template-list-dialog.component.scss
@@ -45,6 +45,20 @@
   gap: var(--gns3-density-space-3);
 }
 
+/* Advanced options: flattened expansion panel lying on the dialog surface
+   (no elevation, no own background) — token overrides avoid specificity
+   fights with .mat-expansion-panel's :not([class*=mat-elevation-z]) rule.
+   Separated from the template gallery by the same divider treatment
+   .dialog-section + .dialog-section uses, so it reads as its own block. */
+.advanced-options {
+  --mat-expansion-container-elevation-shadow: none;
+  --mat-expansion-container-background-color: transparent;
+
+  margin-top: var(--gns3-density-space-5);
+  padding-top: var(--gns3-density-space-5);
+  border-top: 1px solid var(--mat-sys-outline-variant);
+}
+
 .dialog-section + .dialog-section {
   margin-top: var(--gns3-density-space-5);
   padding-top: var(--gns3-density-space-5);

--- a/src/app/components/template/template-list-dialog/template-list-dialog.component.scss
+++ b/src/app/components/template/template-list-dialog/template-list-dialog.component.scss
@@ -93,6 +93,13 @@
   border-top: 1px solid var(--mat-sys-outline-variant);
 }
 
+.dialog-section__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--gns3-density-space-2);
+}
+
 .dialog-section__title {
   margin: 0;
   color: var(--mat-sys-on-surface);
@@ -224,6 +231,63 @@
   height: 18px;
   color: var(--mat-sys-primary);
   font-size: 18px;
+}
+
+/* List view: one full-width row per template (symbol + full name + type).
+   Follows the app's list idiom (topology summary rows): uniform row height
+   with hairline separators instead of gaps, rows spanning the full box. */
+.template-gallery--list {
+  grid-template-columns: 1fr;
+  align-content: start;
+  gap: 0;
+  padding: 0;
+
+  .template-gallery__empty {
+    margin: var(--gns3-density-space-3);
+  }
+}
+
+.template-card--list {
+  grid-template-rows: none;
+  grid-template-columns: 28px minmax(0, 1fr) auto;
+  min-height: var(--gns3-density-form-field-height);
+  align-content: stretch;
+  align-items: center;
+  justify-items: start;
+  gap: var(--gns3-density-space-3);
+  padding-inline: var(--gns3-density-space-3) calc(var(--gns3-density-space-3) + 24px);
+  border-bottom: 1px solid var(--mat-sys-outline-variant);
+
+  &:last-child {
+    border-bottom: none;
+  }
+
+  .template-card__image-wrap {
+    width: 28px;
+    height: 28px;
+  }
+
+  .template-card__name {
+    min-height: 0;
+    text-align: left;
+    -webkit-line-clamp: 1;
+  }
+
+  .template-card__type {
+    justify-self: end;
+    color: var(--mat-sys-on-surface-variant);
+    font: var(--mat-sys-label-small);
+    letter-spacing: 0;
+    white-space: nowrap;
+  }
+
+  /* The corner-anchored check suits tall grid cards; center it vertically
+     so it lines up with the row content. */
+  .template-card__selected-icon {
+    top: 50%;
+    right: var(--gns3-density-space-3);
+    transform: translateY(-50%);
+  }
 }
 
 .template-gallery__empty {

--- a/src/app/components/template/template-list-dialog/template-list-dialog.component.scss
+++ b/src/app/components/template/template-list-dialog/template-list-dialog.component.scss
@@ -59,6 +59,14 @@
   border-top: 1px solid var(--mat-sys-outline-variant);
 }
 
+/* Quiet separator between the node/compute fields and the position fields. */
+.advanced-options__divider {
+  height: 1px;
+  margin: var(--gns3-density-space-2) 0;
+  background: var(--mat-sys-outline-variant);
+  opacity: 0.5;
+}
+
 .dialog-section + .dialog-section {
   margin-top: var(--gns3-density-space-5);
   padding-top: var(--gns3-density-space-5);

--- a/src/app/components/template/template-list-dialog/template-list-dialog.component.scss
+++ b/src/app/components/template/template-list-dialog/template-list-dialog.component.scss
@@ -1,4 +1,13 @@
 .dialog-title {
+  /* Compact palette title bar. The global dialog-header rule in _dialogs.scss
+     consumes these tokens (min-height/padding); redefining them here on the
+     title element wins without a specificity fight: 40px buttons + 2x4px
+     padding lands the bar at ~48px (44px compact) instead of 64px. */
+  --gns3-density-section-header-height: calc(
+    var(--gns3-density-space-1) * 2 + var(--gns3-density-section-header-title-size) * 1.2 + 1px
+  );
+  --gns3-density-section-header-padding: var(--gns3-density-space-1) 16px;
+
   display: flex;
   align-items: center;
   gap: var(--gns3-density-space-4);
@@ -25,6 +34,11 @@
 .dialog-title__actions {
   flex: 0 0 auto;
   gap: var(--gns3-density-space-1);
+}
+
+/* Compact action bar: 16px padding around the 40px buttons (~56px total). */
+[mat-dialog-actions] {
+  --mat-dialog-actions-padding: 8px 16px;
 }
 
 .dialog-title__preferences {
@@ -54,9 +68,15 @@
   --mat-expansion-container-elevation-shadow: none;
   --mat-expansion-container-background-color: transparent;
 
-  margin-top: var(--gns3-density-space-5);
-  padding-top: var(--gns3-density-space-5);
+  margin-top: var(--gns3-density-space-1);
+  padding-top: var(--gns3-density-space-1);
   border-top: 1px solid var(--mat-sys-outline-variant);
+
+  /* Align the header text with the 16px content inset instead of the
+     Material default 24px. */
+  mat-expansion-panel-header {
+    padding: 0 16px;
+  }
 }
 
 /* Quiet separator between the node/compute fields and the position fields. */
@@ -98,7 +118,13 @@
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(96px, 1fr));
   gap: var(--gns3-density-space-2);
-  max-height: calc(var(--gns3-density-form-field-height) * 5);
+  /* Height sized to exactly three card rows (icon + 2-line name + card
+     padding/gap) plus the gallery's own padding and border, so no fourth
+     row peeks over the fold. */
+  max-height: calc(
+    (var(--gns3-density-form-field-height) + 2.5em + var(--gns3-density-space-2) * 3) * 3 +
+      var(--gns3-density-space-2) * 4 + 2px
+  );
   padding: var(--gns3-density-space-2);
   overflow-y: auto;
   border: 1px solid var(--mat-sys-outline-variant);

--- a/src/app/components/template/template-list-dialog/template-list-dialog.component.spec.ts
+++ b/src/app/components/template/template-list-dialog/template-list-dialog.component.spec.ts
@@ -141,13 +141,13 @@ describe('TemplateListDialogComponent', () => {
       expect(component.project).toEqual(mockProject);
     });
 
-    it('should show the controller field before a template is selected', () => {
+    it('should show the compute field before a template is selected', () => {
       fixture.detectChanges();
 
       const labels = Array.from(fixture.nativeElement.querySelectorAll('mat-label')).map((label: Element) =>
         label.textContent?.trim()
       );
-      expect(labels).toContain('Controller');
+      expect(labels).toContain('Compute');
       expect(component.selectedComputeId()).toBe('local');
     });
   });
@@ -192,7 +192,7 @@ describe('TemplateListDialogComponent', () => {
         component.ngOnInit();
         fixture.detectChanges();
 
-        expect(component.nodeControllers).toEqual([{ display: 'local', value: 'local' }]);
+        expect(component.nodeComputes).toEqual([{ display: 'local', value: 'local' }]);
       });
 
       it('should call markForCheck when getComputes fails', async () => {
@@ -246,8 +246,8 @@ describe('TemplateListDialogComponent', () => {
       expect(typeof (TemplateListDialogComponent.prototype as any).onNoClick).toBe('function');
     });
 
-    it('should have compareControllers method', () => {
-      expect(typeof (TemplateListDialogComponent.prototype as any).compareControllers).toBe('function');
+    it('should have compareComputes method', () => {
+      expect(typeof (TemplateListDialogComponent.prototype as any).compareComputes).toBe('function');
     });
 
     it('should have filterTemplates method', () => {
@@ -327,7 +327,7 @@ describe('TemplateListDialogComponent', () => {
       component.onAddClick();
 
       expect(emitSpy).toHaveBeenCalledWith(
-        expect.objectContaining({ template, controller: 'local', numberOfNodes: 1, x: 0, y: 0 })
+        expect.objectContaining({ template, computeId: 'local', numberOfNodes: 1, x: 0, y: 0 })
       );
       expect(mockDialogRef.close).not.toHaveBeenCalled();
     });
@@ -337,13 +337,13 @@ describe('TemplateListDialogComponent', () => {
     it('should export NodeAddedEvent interface', () => {
       const event: NodeAddedEvent = {
         template: {} as any,
-        controller: 'local',
+        computeId: 'local',
         numberOfNodes: 1,
         x: 0,
         y: 0,
       };
       expect(event.template).toBeDefined();
-      expect(event.controller).toBe('local');
+      expect(event.computeId).toBe('local');
       expect(event.numberOfNodes).toBe(1);
     });
 

--- a/src/app/components/template/template-list-dialog/template-list-dialog.component.spec.ts
+++ b/src/app/components/template/template-list-dialog/template-list-dialog.component.spec.ts
@@ -333,6 +333,58 @@ describe('TemplateListDialogComponent', () => {
     });
   });
 
+  describe('view mode', () => {
+    // The view mode is read in the field initializer, so tests that verify
+    // restoration need a fresh component built after localStorage is set up.
+    const createFreshComponent = () => {
+      if (fixture) fixture.destroy();
+      fixture = TestBed.createComponent(TemplateListDialogComponent);
+      component = fixture.componentInstance;
+    };
+
+    afterEach(() => {
+      localStorage.removeItem('addNodesViewMode');
+    });
+
+    it('should default to grid view when no preference is stored', () => {
+      localStorage.removeItem('addNodesViewMode');
+      createFreshComponent();
+
+      expect(component.viewMode()).toBe('grid');
+    });
+
+    it('should restore list view from the stored preference', () => {
+      localStorage.setItem('addNodesViewMode', 'list');
+      createFreshComponent();
+
+      expect(component.viewMode()).toBe('list');
+    });
+
+    it('should fall back to grid view for unknown stored values', () => {
+      localStorage.setItem('addNodesViewMode', 'bogus');
+      createFreshComponent();
+
+      expect(component.viewMode()).toBe('grid');
+    });
+
+    it('should toggle grid to list and persist the choice', () => {
+      expect(component.viewMode()).toBe('grid');
+
+      component.toggleViewMode();
+
+      expect(component.viewMode()).toBe('list');
+      expect(localStorage.getItem('addNodesViewMode')).toBe('list');
+    });
+
+    it('should toggle list back to grid', () => {
+      component.toggleViewMode();
+      component.toggleViewMode();
+
+      expect(component.viewMode()).toBe('grid');
+      expect(localStorage.getItem('addNodesViewMode')).toBe('grid');
+    });
+  });
+
   describe('exported types', () => {
     it('should export NodeAddedEvent interface', () => {
       const event: NodeAddedEvent = {

--- a/src/app/components/template/template-list-dialog/template-list-dialog.component.ts
+++ b/src/app/components/template/template-list-dialog/template-list-dialog.component.ts
@@ -27,6 +27,7 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { MatIconModule } from '@angular/material/icon';
+import { MatExpansionModule } from '@angular/material/expansion';
 import { BehaviorSubject, merge, Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
@@ -68,6 +69,7 @@ export interface TemplateDragStartRequest {
     MatInputModule,
     MatSelectModule,
     MatIconModule,
+    MatExpansionModule,
     DragDropModule,
   ],
 })
@@ -101,7 +103,7 @@ export class TemplateListDialogComponent implements OnInit {
   positionForm: UntypedFormGroup;
   templates: Template[] = [];
   filteredTemplates: Template[] = [];
-  nodeControllers: { display: string; value: string }[] = [{ display: 'local', value: 'local' }];
+  nodeComputes: { display: string; value: string }[] = [{ display: 'local', value: 'local' }];
 
   // Model signals for two-way binding
   searchText = model('');
@@ -162,13 +164,13 @@ export class TemplateListDialogComponent implements OnInit {
                 value: c.compute_id,
               };
             });
-          this.nodeControllers = [{ display: 'local', value: 'local' }, ...remoteComputes];
+          this.nodeComputes = [{ display: 'local', value: 'local' }, ...remoteComputes];
           this.cd.markForCheck();
         },
         error: (err) => {
           const message = err.error?.message || err.message || 'Failed to load computes';
           this.toasterService.error(message);
-          this.nodeControllers = [{ display: 'local', value: 'local' }];
+          this.nodeComputes = [{ display: 'local', value: 'local' }];
           this.cd.markForCheck();
         },
       });
@@ -178,13 +180,13 @@ export class TemplateListDialogComponent implements OnInit {
     this.dialogRef.close();
   }
 
-  compareControllers(a: string, b: string): boolean {
+  compareComputes(a: string, b: string): boolean {
     return a === b;
   }
 
   selectTemplate(template: Template): void {
     this.selectedTemplate.set(template);
-    if (template.compute_id && this.nodeControllers.some((controller) => controller.value === template.compute_id)) {
+    if (template.compute_id && this.nodeComputes.some((compute) => compute.value === template.compute_id)) {
       this.selectedComputeId.set(template.compute_id);
     }
   }
@@ -265,7 +267,7 @@ export class TemplateListDialogComponent implements OnInit {
       } else {
         const nodeAddedEvent: NodeAddedEvent = {
           template: this.selectedTemplate(),
-          controller: this.selectedComputeId(),
+          computeId: this.selectedComputeId(),
           numberOfNodes: this.configurationForm.get('numberOfNodes').value,
           x: x,
           y: y,
@@ -278,7 +280,7 @@ export class TemplateListDialogComponent implements OnInit {
 
 export interface NodeAddedEvent {
   template: Template;
-  controller: string;
+  computeId: string;
   name?: string;
   numberOfNodes: number;
   x: number;

--- a/src/app/components/template/template-list-dialog/template-list-dialog.component.ts
+++ b/src/app/components/template/template-list-dialog/template-list-dialog.component.ts
@@ -10,6 +10,7 @@ import {
   Output,
   inject,
   model,
+  signal,
 } from '@angular/core';
 import { DragDropModule } from '@angular/cdk/drag-drop';
 import { CommonModule } from '@angular/common';
@@ -28,6 +29,7 @@ import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { MatIconModule } from '@angular/material/icon';
 import { MatExpansionModule } from '@angular/material/expansion';
+import { MatTooltipModule } from '@angular/material/tooltip';
 import { BehaviorSubject, merge, Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
@@ -53,6 +55,10 @@ export interface TemplateDragStartRequest {
   computeId?: string;
 }
 
+type TemplateViewMode = 'grid' | 'list';
+
+const VIEW_MODE_STORAGE_KEY = 'addNodesViewMode';
+
 @Component({
   standalone: true,
   selector: 'app-template-list-dialog',
@@ -70,6 +76,7 @@ export interface TemplateDragStartRequest {
     MatSelectModule,
     MatIconModule,
     MatExpansionModule,
+    MatTooltipModule,
     DragDropModule,
   ],
 })
@@ -110,6 +117,15 @@ export class TemplateListDialogComponent implements OnInit {
   selectedType = model('all');
   selectedTemplate = model<Template | null>(null);
   selectedComputeId = model('local');
+
+  /** Template gallery layout, persisted across dialog openings. */
+  readonly viewMode = signal<TemplateViewMode>(localStorage.getItem(VIEW_MODE_STORAGE_KEY) === 'list' ? 'list' : 'grid');
+
+  toggleViewMode(): void {
+    const next: TemplateViewMode = this.viewMode() === 'grid' ? 'list' : 'grid';
+    this.viewMode.set(next);
+    localStorage.setItem(VIEW_MODE_STORAGE_KEY, next);
+  }
 
   constructor(@Inject(MAT_DIALOG_DATA) public data: TemplateListDialogData) {
     this.controller = data.controller;

--- a/src/app/components/template/template.component.spec.ts
+++ b/src/app/components/template/template.component.spec.ts
@@ -316,7 +316,7 @@ describe('TemplateComponent', () => {
 
       const emittedEvent = emitSpy.mock.calls[0][0] as NodeAddedEvent;
       expect(emittedEvent.template).toBe(template);
-      expect(emittedEvent.controller).toBe('local');
+      expect(emittedEvent.computeId).toBe('local');
       expect(emittedEvent.numberOfNodes).toBe(1);
       expect(typeof emittedEvent.x).toBe('number');
       expect(typeof emittedEvent.y).toBe('number');
@@ -330,7 +330,7 @@ describe('TemplateComponent', () => {
 
       const emittedEvent = emitSpy.mock.calls[0][0] as NodeAddedEvent;
       expect(emittedEvent.numberOfNodes).toBe(4);
-      expect(emittedEvent.controller).toBe('local');
+      expect(emittedEvent.computeId).toBe('local');
     });
 
     it('should ignore a palette drop outside the topology', () => {
@@ -464,7 +464,7 @@ describe('TemplateComponent', () => {
       const emitSpy = vi.spyOn(component.nodeCreationChange, 'emit');
       const event = {
         template: createMockTemplate('t1', 'Router', 'vpcs'),
-        controller: 'local',
+        computeId: 'local',
         numberOfNodes: 3,
         x: 0,
         y: 0,
@@ -638,7 +638,7 @@ describe('TemplateComponent', () => {
         expect(cdrSpy).toHaveBeenCalled();
         expect(emitSpy).toHaveBeenCalled();
         const emittedEvent = emitSpy.mock.calls[0][0] as NodeAddedEvent;
-        expect(emittedEvent.controller).toBe('local');
+        expect(emittedEvent.computeId).toBe('local');
       });
 
       it('should use fallback message when getComputes error has no message', async () => {

--- a/src/app/components/template/template.component.ts
+++ b/src/app/components/template/template.component.ts
@@ -334,7 +334,7 @@ export class TemplateComponent implements OnInit, OnDestroy {
           // Fallback to local on error
           const nodeAddedEvent: NodeAddedEvent = {
             template: template,
-            controller: preferredComputeId || 'local',
+            computeId: preferredComputeId || 'local',
             numberOfNodes,
             x: finalX,
             y: finalY,
@@ -501,7 +501,7 @@ export class TemplateComponent implements OnInit, OnDestroy {
 
     const nodeAddedEvent: NodeAddedEvent = {
       template: node.template,
-      controller: computeId,
+      computeId,
       numberOfNodes: node.numberOfNodes,
       x: node.x,
       y: node.y,

--- a/src/app/components/topology-summary/topology-summary.component.html
+++ b/src/app/components/topology-summary/topology-summary.component.html
@@ -24,14 +24,14 @@
   <mat-tab-group
     class="inspector-tabs"
     animationDuration="0ms"
-    [selectedIndex]="isTopologyVisible ? 0 : 1"
-    (selectedIndexChange)="toggleTopologyVisibility($event === 0)"
+    [selectedIndex]="selectedTabIndex"
+    (selectedIndexChange)="onTabSelectionChange($event)"
     (mousedown)="startDraggingFromTabStrip($event)"
   >
     <mat-tab>
       <ng-template mat-tab-label>
         <mat-icon>map</mat-icon>
-        <span>Map topology</span>
+        <span>Topology</span>
       </ng-template>
 
       <div class="tab-content">
@@ -157,6 +157,17 @@
             <span>Open console</span>
           </button>
         </mat-menu>
+      </div>
+    </mat-tab>
+
+    <mat-tab>
+      <ng-template mat-tab-label>
+        <mat-icon>insights</mat-icon>
+        <span>Markers</span>
+      </ng-template>
+
+      <div class="tab-content">
+        <app-marker-legend (openMarkerManager)="openMarkerManager.emit()"></app-marker-legend>
       </div>
     </mat-tab>
 

--- a/src/app/components/topology-summary/topology-summary.component.scss
+++ b/src/app/components/topology-summary/topology-summary.component.scss
@@ -123,6 +123,13 @@
   padding: var(--gns3-density-space-2) var(--gns3-density-space-3);
 }
 
+.tab-content app-marker-legend {
+  display: flex;
+  flex: 1 1 auto;
+  min-height: 0;
+  margin: calc(-1 * var(--gns3-density-space-2)) calc(-1 * var(--gns3-density-space-3));
+}
+
 .node-toolbar {
   display: grid;
   min-width: 0;

--- a/src/app/components/topology-summary/topology-summary.component.spec.ts
+++ b/src/app/components/topology-summary/topology-summary.component.spec.ts
@@ -10,6 +10,7 @@ import { NotificationService } from '@services/notification.service';
 import { ToasterService } from '@services/toaster.service';
 import { NodeConsoleService } from '@services/nodeConsole.service';
 import { MapSettingsService } from '@services/mapsettings.service';
+import { MarkerRegistryService } from '@services/marker-registry.service';
 import { Compute } from '@models/compute';
 import { Controller } from '@models/controller';
 import { Project } from '@models/project';
@@ -254,6 +255,7 @@ describe('TopologySummaryComponent', () => {
         { provide: ChangeDetectorRef, useValue: mockChangeDetectorRef },
         { provide: NodeConsoleService, useValue: mockNodeConsoleService },
         { provide: MapSettingsService, useValue: mockMapSettingsService },
+        MarkerRegistryService,
       ],
     }).compileComponents();
 
@@ -279,7 +281,7 @@ describe('TopologySummaryComponent', () => {
 
     it('should have default initial values', () => {
       expect(component.sortingOrder).toBe('asc');
-      expect(component.isTopologyVisible).toBe(true);
+      expect(component.selectedTabIndex).toBe(0);
       expect(component.isDraggingEnabled).toBe(false);
       expect(component.startedStatusFilterEnabled).toBe(false);
       expect(component.stoppedStatusFilterEnabled).toBe(false);
@@ -689,19 +691,19 @@ describe('TopologySummaryComponent', () => {
     });
   });
 
-  describe('toggleTopologyVisibility', () => {
-    it('should set topology visibility to true', () => {
-      component.toggleTopologyVisibility(true);
+  describe('onTabSelectionChange', () => {
+    it('should select the requested tab', () => {
+      component.onTabSelectionChange(1);
 
-      expect(component.isTopologyVisible).toBe(true);
+      expect(component.selectedTabIndex).toBe(1);
     });
 
-    it('should set topology visibility to false without resetting the inspector position', () => {
+    it('should select the computes tab without resetting the inspector position', () => {
       const revertPositionSpy = vi.spyOn(component, 'revertPosition');
 
-      component.toggleTopologyVisibility(false);
+      component.onTabSelectionChange(2);
 
-      expect(component.isTopologyVisible).toBe(false);
+      expect(component.selectedTabIndex).toBe(2);
       expect(revertPositionSpy).not.toHaveBeenCalled();
     });
   });

--- a/src/app/components/topology-summary/topology-summary.component.ts
+++ b/src/app/components/topology-summary/topology-summary.component.ts
@@ -33,6 +33,7 @@ import { NotificationService } from '@services/notification.service';
 import { ToasterService } from '@services/toaster.service';
 import { NodeConsoleService } from '@services/nodeConsole.service';
 import { MapSettingsService } from '@services/mapsettings.service';
+import { MarkerLegendComponent } from '../project-map/marker-legend/marker-legend.component';
 
 @Component({
   selector: 'app-topology-summary',
@@ -55,6 +56,7 @@ import { MapSettingsService } from '@services/mapsettings.service';
     MatMenuModule,
     MatCheckboxModule,
     ResizableModule,
+    MarkerLegendComponent,
   ],
 })
 export class TopologySummaryComponent implements OnInit, OnDestroy {
@@ -72,6 +74,7 @@ export class TopologySummaryComponent implements OnInit, OnDestroy {
   @Input() project: Project;
 
   @Output() openWebConsoleInline = new EventEmitter<{ node: Node; controller: Controller; project: Project }>();
+  @Output() openMarkerManager = new EventEmitter<void>();
 
   private computesInitialized = false;
 
@@ -89,7 +92,8 @@ export class TopologySummaryComponent implements OnInit, OnDestroy {
   searchQuery = '';
   selectedNode: Node | null = null;
 
-  isTopologyVisible: boolean = true;
+  /** Selected inspector tab: 0 = Topology, 1 = Markers, 2 = Computes. */
+  selectedTabIndex: number = 0;
   isDraggingEnabled: boolean = false;
 
   ngOnInit() {
@@ -287,8 +291,8 @@ export class TopologySummaryComponent implements OnInit, OnDestroy {
     localStorage.setItem('heightOfWidget', event.rectangle.height.toString());
   }
 
-  toggleTopologyVisibility(value: boolean) {
-    this.isTopologyVisible = value;
+  onTabSelectionChange(index: number) {
+    this.selectedTabIndex = index;
   }
 
   compareAsc(first: Node, second: Node) {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -259,7 +259,10 @@ body .cdk-overlay-container .cdk-overlay-pane .mat-mdc-menu-panel.template-menu 
   }
 
   .mat-mdc-tab {
-    min-width: 136px;
+    // Equal-width tabs that shrink with the panel (min panel width is 400px)
+    min-width: 0;
+    flex: 1 1 0;
+    padding-inline: var(--gns3-density-space-2);
   }
 
   .mdc-tab__content {

--- a/src/styles/_dialogs.scss
+++ b/src/styles/_dialogs.scss
@@ -1847,6 +1847,15 @@ html[data-density='compact'] .node-configurator-dialog-panel {
   }
 }
 
+// Add-nodes dialog: the collapsed "Advanced options" expansion panel lies flat
+// on the dialog surface; body content is inset so the Configuration / Manual
+// position sections read as nested inside the panel rather than flush with it.
+.add-nodes-dialog-panel {
+  .mat-expansion-panel-body {
+    padding: 0 var(--gns3-density-space-4);
+  }
+}
+
 // Controller Dialogs - 350px/400px
 .controller-dialog-panel {
   --mat-dialog-container-max-width: 400px;

--- a/src/styles/_dialogs.scss
+++ b/src/styles/_dialogs.scss
@@ -1848,11 +1848,12 @@ html[data-density='compact'] .node-configurator-dialog-panel {
 }
 
 // Add-nodes dialog: the collapsed "Advanced options" expansion panel lies flat
-// on the dialog surface; body content is inset so the Configuration / Manual
-// position sections read as nested inside the panel rather than flush with it.
+// on the dialog surface; body content is inset and given vertical breathing
+// room around the flattened field groups.
 .add-nodes-dialog-panel {
   .mat-expansion-panel-body {
-    padding: 0 var(--gns3-density-space-4);
+    padding: var(--gns3-density-space-2) var(--gns3-density-space-4)
+      var(--gns3-density-space-4);
   }
 }
 

--- a/src/styles/_dialogs.scss
+++ b/src/styles/_dialogs.scss
@@ -1837,23 +1837,23 @@ html[data-density='compact'] .node-configurator-dialog-panel {
 // ============================================= */
 
 // Template Dialog - 600px
+// The old explicit width rules never won against the Standard Dialog System
+// (which resolved --gns3-dialog-width to 720px via the legacy group below);
+// set the variable instead so 600px actually applies.
 .template-dialog-panel {
-  --mat-dialog-container-max-width: 600px;
-
-  mat-dialog-container,
-  .mat-mdc-dialog-container {
-    width: 600px;
-    max-width: 600px;
-  }
+  --gns3-dialog-width: 600px;
 }
 
 // Add-nodes dialog: the collapsed "Advanced options" expansion panel lies flat
 // on the dialog surface; body content is inset and given vertical breathing
 // room around the flattened field groups.
 .add-nodes-dialog-panel {
+  .mat-mdc-dialog-content {
+    padding: 12px 16px 0;
+  }
+
   .mat-expansion-panel-body {
-    padding: var(--gns3-density-space-2) var(--gns3-density-space-4)
-      var(--gns3-density-space-4);
+    padding: var(--gns3-density-space-2) var(--gns3-density-space-4) var(--gns3-density-space-1);
   }
 }
 
@@ -2281,8 +2281,7 @@ html[data-density='compact'] .node-configurator-dialog-panel {
     .export-config-action-dialog-panel,
     .import-config-action-dialog-panel,
     .qemu-configurator-dialog-panel,
-    .fault-injection-dialog-panel,
-    .template-dialog-panel
+    .fault-injection-dialog-panel
   ) {
   --gns3-dialog-width: 720px;
 }


### PR DESCRIPTION
## Summary

Three web UI improvements:

### Add-nodes advanced options
- Collapse the advanced options section in the template list dialog and correct compute labeling
- Flatten the advanced options content and compact the palette sizing

### Template gallery view toggle
- Toggle button beside "Choose a template" switches the palette between the icon grid and a denser list showing full names and template types
- List rows follow the app's list idiom: uniform row height, hairline separators, vertically centered selection check
- The chosen view mode persists across dialog openings (localStorage)

### Marker legend in topology summary
- Move the marker legend from a fixed bar on the map canvas into a new **Markers** tab in the topology summary panel (Topology / Markers / Computes), keeping the canvas clean
- The legend lists each marker's color, name and BPF, with an empty state and an entry point to open the marker manager
- Inspector tabs now distribute equally so the three tabs fit the 400px minimum panel width

## Test plan
- `yarn lint` passes
- topology-summary spec (87 tests), project-map spec (41 tests) and template-list-dialog spec (36 tests) pass