### PR TITLE
feat(dialogs): node info dialog tabs and declarative SDS size classes

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -15,3 +15,4 @@ Project-specific memory and context for GNS3 Web UI.
 
 - [Add User Dialog Fixes](add-user-dialog-fixes.md) — Layout, autocomplete UX, chip selection, and scrollbar fixes
 - [Dialog Input Patterns](dialog-input-patterns.md) — Autocomplete single-select, chip multi-select, and scrollbar prevention patterns
+- [Dialog SDS Pane Width Cap](dialog-sds-pane-width-cap.md) — Dialogs collapse to 560px unless the SDS feeds `--gns3-dialog-width` into Material's `--mat-dialog-container-max-width` pane token

--- a/.claude/memory/dialog-sds-pane-width-cap.md
+++ b/.claude/memory/dialog-sds-pane-width-cap.md
@@ -1,0 +1,48 @@
+---
+name: dialog-sds-pane-width-cap
+description: SDS dialogs collapse to 560px unless the shell feeds the size-class width into Material's --mat-dialog-container-max-width pane token
+metadata:
+  type: project
+---
+
+# Dialog SDS Pane Width Cap (560px Collapse)
+
+## Symptom
+
+Every SDS dialog rendered at 560px regardless of its `dialog-{small,medium,large,extra-large}-panel`
+size class (440/720/880/1040px). Affected all 131 call sites after the size-class migration.
+
+## Root Cause
+
+Material's dialog theme emits a default on the **overlay pane** itself:
+
+- `.cdk-overlay-pane.mat-mdc-dialog-panel { max-width: var(--mat-dialog-container-max-width, 560px) }`
+- The theme materializes the token as 560px (one block per theme variant, 16 blocks in styles.css)
+
+The pane is the shrink-to-fit root of the whole dialog chain (popover-API wrapper → pane →
+`mat-dialog-container` → inner container → surface), so the pane cap crushes everything below it.
+The SDS sets its own `--gns3-dialog-width` on the *container* — one level below the pane — and the
+legacy per-panel width groups always co-set the Material token, which is why widths worked before
+the migration. The migration dropped the token feed, re-activating the 560px fallback.
+
+Panels that still set the token directly kept working: node configurator
+(`src/styles/_dialogs.scss`, `min(1080px, calc(100vw - 48px))`) and the compact-density rule.
+That asymmetry is the tell for this failure.
+
+## Fix
+
+The SDS shell (`:is(.base-dialog-panel, ...)` block in `src/styles/_dialogs.scss`) bridges the
+token: `--mat-dialog-container-max-width: min(var(--gns3-dialog-width, 440px), var(--gns3-dialog-viewport-cap))`.
+
+**Contract**: any mechanism that changes dialog width must feed `--mat-dialog-container-max-width`
+on the pane, not only the SDS property.
+
+## Debugging Traps
+
+- `getComputedStyle(mat-dialog-container).width` reports the **post-shrink used width**, not the
+  declared width. During this incident the container's own width/max-width resolved correctly to
+  the declared size while computed width read 560px — it looked like the declarations were dropped
+  when they were fine. When a dialog is stuck at 560px, inspect the pane's token first.
+- The viewport clamp lives in `--gns3-dialog-viewport-cap` so width declarations keep math-function
+  arguments var()-only: the CSS pipeline strips `calc()` from `min()` arguments, and plain var()
+  references are immune to transform surprises.

--- a/.claude/skills/gns3-angular-material-dialog/SKILL.md
+++ b/.claude/skills/gns3-angular-material-dialog/SKILL.md
@@ -22,23 +22,31 @@ writing any code.
 ## Style System Overview
 
 The project has **two parallel class hierarchies** — one for general dialogs,
-one for confirmation dialogs. Always pick the right branch.
+one for confirmation dialogs. Both are sized by the Standard Dialog System
+(SDS): a `dialog-*-panel` size class sets `--gns3-dialog-width`, and every
+dialog call site carries exactly one.
 
 ### Branch 1 — General Dialogs
 
 ```
 .base-dialog-panel          ← all dialogs inherit this
-    ├── .configurator-dialog-panel   (800px × 80vh — node config)
-    ├── .simple-dialog-panel         (500px × 80vh — sub-dialogs)
-    └── .custom-dialog-panel         (special / one-off sizing)
+    └── one size class (required):
+        ├── .dialog-small-panel         (440px — confirmations, short forms)
+        ├── .dialog-medium-panel        (720px — editors, sub-dialogs)
+        ├── .dialog-large-panel         (880px — tabs, grids, wide editors)
+        └── .dialog-extra-large-panel   (1040px — dense management tables)
 ```
+
+Legacy role classes (`configurator-dialog-panel`, `simple-dialog-panel`) may
+appear as extra array elements but no longer control sizing.
 
 | Mode | panelClass array | When to use |
 |---|---|---|
-| Standard | `['base-dialog-panel']` | Generic informational or form dialogs |
-| Configurator | `['base-dialog-panel', 'configurator-dialog-panel']` | Node / resource setup with tabs, grids |
-| Simple | `['simple-dialog-panel']` | Sub-dialogs launched from within another dialog |
-| Custom | `['base-dialog-panel', 'my-custom-panel']` | One-off sizing needs |
+| Small | `['base-dialog-panel', 'dialog-small-panel']` | Generic informational or short form dialogs |
+| Medium | `['base-dialog-panel', 'dialog-medium-panel']` | Editors, sub-dialogs launched from within another dialog |
+| Large | `['base-dialog-panel', 'dialog-large-panel', 'configurator-dialog-panel']` | Node / resource setup with tabs, grids |
+| Extra large | `['base-dialog-panel', 'dialog-extra-large-panel']` | Dense tables / management workflows |
+| Custom width | `['base-dialog-panel', 'dialog-small-panel', 'my-custom-panel']` | One-off width: set `--gns3-dialog-width` in `_dialogs.scss` deviations section |
 
 ### Branch 2 — Confirmation Dialogs
 
@@ -46,11 +54,12 @@ one for confirmation dialogs. Always pick the right branch.
 .base-confirmation-dialog-panel     ← all confirmation dialogs inherit this
     ├── .confirmation-danger-panel   (delete / remove)
     ├── .confirmation-warning-panel  (unlock / risky action)
-    └── .confirmation-info-panel     (acknowledge / confirm)
+    └── .confirmation-neutral-panel  (acknowledge / neutral confirm)
 ```
 
-> **Rule**: confirmation dialogs always use BOTH the base class AND one
-> variant class. Example: `['base-confirmation-dialog-panel', 'confirmation-danger-panel']`
+> **Rule**: confirmation dialogs always use the base class, a size class
+> (almost always `dialog-small-panel`), AND one variant class. Example:
+> `['base-confirmation-dialog-panel', 'confirmation-danger-panel', 'dialog-small-panel']`
 
 ---
 
@@ -59,19 +68,21 @@ one for confirmation dialogs. Always pick the right branch.
 Before writing any code, answer these questions:
 
 1. **Is this a destructive / risky / informational confirmation?**
-   → Yes → Confirmation branch. Pick danger / warning / info variant.
+   → Yes → Confirmation branch. Pick danger / warning / neutral variant.
    → No → General branch. Continue.
 
-2. **Does it configure a node or resource with tabs / form grids?**
-   → Yes → `configurator-dialog-panel`
+2. **Pick a size class** — small (440) / medium (720) / large (880) /
+   extra-large (1040). Non-standard width → nearest size class + a
+   `--gns3-dialog-width` override in the `_dialogs.scss` deviations section
+   (which sits after the size classes so the override wins).
 
-3. **Is it launched from inside another dialog?**
-   → Yes → `simple-dialog-panel`
+3. **Legacy role hint still useful?** Configurator-style tabs/forms may also
+   carry `configurator-dialog-panel`; nested sub-dialogs may carry
+   `simple-dialog-panel`. These are styling aliases only — they never size.
 
-4. **Does it need a custom size?**
-   → Yes → `custom-dialog-panel` (add your own width/height in the panel CSS)
-
-5. **Otherwise** → `base-dialog-panel` alone.
+4. **Is it a specialized node configurator or Docker network editor?**
+   → Yes → `node-configurator-dialog-panel` / `docker-network-config-dialog-panel`
+   purpose-built shells (excluded from the SDS).
 
 ---
 

--- a/.claude/skills/gns3-angular-material-dialog/SKILL.md
+++ b/.claude/skills/gns3-angular-material-dialog/SKILL.md
@@ -40,6 +40,11 @@ dialog call site carries exactly one.
 Legacy role classes (`configurator-dialog-panel`, `simple-dialog-panel`) may
 appear as extra array elements but no longer control sizing.
 
+Optional height tiers: `dialog-height-60-panel` / `dialog-height-80-panel`
+set a fixed viewport-ratio height (60vh / 80vh). Opt-in modifiers — dialogs
+are content-sized unless they declare one. Example:
+`['base-dialog-panel', 'dialog-medium-panel', 'my-editor-panel', 'dialog-height-60-panel']`
+
 | Mode | panelClass array | When to use |
 |---|---|---|
 | Small | `['base-dialog-panel', 'dialog-small-panel']` | Generic informational or short form dialogs |

--- a/.claude/skills/gns3-angular-material-dialog/references/templates.md
+++ b/.claude/skills/gns3-angular-material-dialog/references/templates.md
@@ -5,12 +5,12 @@ entity name (e.g. `Project`, `Node`, `Image`).
 
 ---
 
-## 1. Standard Dialog (`base-dialog-panel`)
+## 1. Standard Dialog (`base-dialog-panel` + size class)
 
 ### Open call
 ```typescript
 this.dialog.open(EditNounDialogComponent, {
-  panelClass: ['base-dialog-panel'],
+  panelClass: ['base-dialog-panel', 'dialog-small-panel'],
   data: { noun } satisfies EditNounDialogData,
 });
 ```
@@ -73,14 +73,14 @@ export interface EditNounDialogResult { name: string; /* ... */ }
 
 ---
 
-## 2. Configurator Dialog (`base-dialog-panel` + `configurator-dialog-panel`)
+## 2. Configurator Dialog (`base-dialog-panel` + `dialog-large-panel`)
 
-Use for node / resource configuration with tabs or form grids (800px wide).
+Use for node / resource configuration with tabs or form grids (880px wide).
 
 ### Open call
 ```typescript
 this.dialog.open(ConfigureNounDialogComponent, {
-  panelClass: ['base-dialog-panel', 'configurator-dialog-panel'],
+  panelClass: ['base-dialog-panel', 'dialog-large-panel', 'configurator-dialog-panel'],
   data: { noun } satisfies ConfigureNounDialogData,
 });
 ```
@@ -162,14 +162,14 @@ export interface ConfigureNounDialogResult { /* typed result */ }
 
 ---
 
-## 3. Simple Sub-Dialog (`simple-dialog-panel`)
+## 3. Simple Sub-Dialog (`dialog-medium-panel`)
 
-Use when launching a child dialog from inside another dialog (500px wide).
+Use when launching a child dialog from inside another dialog (720px wide).
 
 ### Open call
 ```typescript
 this.dialog.open(SelectNounDialogComponent, {
-  panelClass: ['simple-dialog-panel'],
+  panelClass: ['base-dialog-panel', 'dialog-medium-panel', 'simple-dialog-panel'],
   data: { options } satisfies SelectNounDialogData,
 });
 ```
@@ -197,7 +197,7 @@ Minimal: title + one short sentence + two buttons only. No forms, no tabs.
 ### 4a. Danger (delete / remove)
 ```typescript
 this.dialog.open(ConfirmDeleteNounDialogComponent, {
-  panelClass: ['base-confirmation-dialog-panel', 'confirmation-danger-panel'],
+  panelClass: ['base-confirmation-dialog-panel', 'confirmation-danger-panel', 'dialog-small-panel'],
   data: { nounName: noun.name } satisfies ConfirmDeleteNounDialogData,
 });
 ```
@@ -219,7 +219,7 @@ this.dialog.open(ConfirmDeleteNounDialogComponent, {
 
 ### 4b. Warning (unlock / risky action)
 ```typescript
-panelClass: ['base-confirmation-dialog-panel', 'confirmation-warning-panel']
+panelClass: ['base-confirmation-dialog-panel', 'confirmation-warning-panel', 'dialog-small-panel']
 ```
 ```html
 <h2 mat-dialog-title>Unlock Noun?</h2>
@@ -234,9 +234,9 @@ panelClass: ['base-confirmation-dialog-panel', 'confirmation-warning-panel']
 </mat-dialog-actions>
 ```
 
-### 4c. Info (acknowledge / confirm)
+### 4c. Neutral (acknowledge / confirm)
 ```typescript
-panelClass: ['base-confirmation-dialog-panel', 'confirmation-info-panel']
+panelClass: ['base-confirmation-dialog-panel', 'confirmation-neutral-panel', 'dialog-small-panel']
 ```
 ```html
 <h2 mat-dialog-title>Confirm Action</h2>

--- a/src/app/components/acl-management/acl-management.component.ts
+++ b/src/app/components/acl-management/acl-management.component.ts
@@ -165,7 +165,7 @@ export class AclManagementComponent implements OnInit, AfterViewInit {
 
   addACE() {
     const dialogRef = this.dialog.open(AddAceDialogComponent, {
-      panelClass: ['base-dialog-panel', 'add-ace-dialog-panel'],
+      panelClass: ['base-dialog-panel', 'add-ace-dialog-panel', 'dialog-extra-large-panel'],
       autoFocus: false,
       disableClose: true,
       data: { endpoints: this.endpoints() },
@@ -178,7 +178,7 @@ export class AclManagementComponent implements OnInit, AfterViewInit {
   onDelete(ace: ACE) {
     this.dialog
       .open(ConfirmationDialogComponent, {
-        panelClass: ['base-confirmation-dialog-panel', 'confirmation-danger-panel'],
+        panelClass: ['base-confirmation-dialog-panel', 'confirmation-danger-panel', 'dialog-small-panel'],
         autoFocus: '.cancel-button',
         data: {
           title: 'Delete access rule?',
@@ -219,7 +219,7 @@ export class AclManagementComponent implements OnInit, AfterViewInit {
     const selectedAces = [...this.selection.selected];
     this.dialog
       .open(ConfirmationDialogComponent, {
-        panelClass: ['base-confirmation-dialog-panel', 'confirmation-danger-panel'],
+        panelClass: ['base-confirmation-dialog-panel', 'confirmation-danger-panel', 'dialog-small-panel'],
         autoFocus: '.cancel-button',
         data: {
           title: 'Delete access rules?',

--- a/src/app/components/api-key-management/api-key-management-dialog.component.ts
+++ b/src/app/components/api-key-management/api-key-management-dialog.component.ts
@@ -1,4 +1,13 @@
-import { ChangeDetectionStrategy, Component, computed, DestroyRef, Inject, inject, OnInit, signal } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  DestroyRef,
+  Inject,
+  inject,
+  OnInit,
+  signal,
+} from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MatDialogModule, MatDialog, MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { MatButtonModule } from '@angular/material/button';
@@ -13,8 +22,14 @@ import { ApiKey } from '@models/api/api-key';
 import { ApiKeyService } from '@services/api-key.service';
 import { ToasterService } from '@services/toaster.service';
 import { AddApiKeyDialogComponent } from './add-api-key-dialog/add-api-key-dialog.component';
-import { ApiKeyDisplayDialogComponent, ApiKeyDisplayDialogData } from './api-key-display-dialog/api-key-display-dialog.component';
-import { ConfirmationDialogComponent, ConfirmationDialogData } from '@components/dialogs/confirmation-dialog/confirmation-dialog.component';
+import {
+  ApiKeyDisplayDialogComponent,
+  ApiKeyDisplayDialogData,
+} from './api-key-display-dialog/api-key-display-dialog.component';
+import {
+  ConfirmationDialogComponent,
+  ConfirmationDialogData,
+} from '@components/dialogs/confirmation-dialog/confirmation-dialog.component';
 import { filter } from 'rxjs';
 
 export interface ApiKeyManagementDialogData {
@@ -91,50 +106,56 @@ export class ApiKeyManagementDialogComponent implements OnInit {
   // ── Data fetching ─────────────────────────────────────────────
   private loadKeys() {
     this.isLoading.set(true);
-    this.apiKeyService.list(this.data.controller).pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
-      next: (keys) => {
-        this._keys.set(keys);
-        this.isLoading.set(false);
-      },
-      error: (err) => {
-        this.isLoading.set(false);
-        this.toasterService.error(err.error?.message || err.message || 'Failed to load API keys');
-      },
-    });
+    this.apiKeyService
+      .list(this.data.controller)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (keys) => {
+          this._keys.set(keys);
+          this.isLoading.set(false);
+        },
+        error: (err) => {
+          this.isLoading.set(false);
+          this.toasterService.error(err.error?.message || err.message || 'Failed to load API keys');
+        },
+      });
   }
 
   // ── Actions ───────────────────────────────────────────────────
   onCreate() {
     this.dialog
       .open(AddApiKeyDialogComponent, {
-        panelClass: ['base-dialog-panel', 'simple-dialog-panel', 'add-api-key-dialog-panel'],
+        panelClass: ['base-dialog-panel', 'simple-dialog-panel', 'add-api-key-dialog-panel', 'dialog-medium-panel'],
         autoFocus: false,
         disableClose: true,
       })
       .afterClosed()
       .pipe(filter(Boolean), takeUntilDestroyed(this.destroyRef))
       .subscribe((name: string) => {
-        this.apiKeyService.create(this.data.controller, name).pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
-          next: (response) => {
-            this.loadKeys();
-            this.dialog.open(ApiKeyDisplayDialogComponent, {
-              panelClass: ['base-dialog-panel', 'simple-dialog-panel'],
-              autoFocus: false,
-              disableClose: true,
-              data: { response } satisfies ApiKeyDisplayDialogData,
-            });
-          },
-          error: (err) => {
-            this.toasterService.error(err.error?.message || err.message || 'Failed to create API key');
-          },
-        });
+        this.apiKeyService
+          .create(this.data.controller, name)
+          .pipe(takeUntilDestroyed(this.destroyRef))
+          .subscribe({
+            next: (response) => {
+              this.loadKeys();
+              this.dialog.open(ApiKeyDisplayDialogComponent, {
+                panelClass: ['base-dialog-panel', 'simple-dialog-panel', 'dialog-medium-panel'],
+                autoFocus: false,
+                disableClose: true,
+                data: { response } satisfies ApiKeyDisplayDialogData,
+              });
+            },
+            error: (err) => {
+              this.toasterService.error(err.error?.message || err.message || 'Failed to create API key');
+            },
+          });
       });
   }
 
   onRevoke(key: ApiKey) {
     this.dialog
       .open(ConfirmationDialogComponent, {
-        panelClass: ['base-confirmation-dialog-panel', 'confirmation-danger-panel'],
+        panelClass: ['base-confirmation-dialog-panel', 'confirmation-danger-panel', 'dialog-small-panel'],
         data: {
           title: 'Revoke API Key',
           message: `Are you sure you want to revoke "${key.name}"? Any services using this key will immediately lose access. You can restore it later.`,
@@ -145,22 +166,25 @@ export class ApiKeyManagementDialogComponent implements OnInit {
       .afterClosed()
       .pipe(filter(Boolean), takeUntilDestroyed(this.destroyRef))
       .subscribe(() => {
-        this.apiKeyService.revoke(this.data.controller, key.api_key_id).pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
-          next: (response) => {
-            this.toasterService.success(response.message || 'API key revoked');
-            this.loadKeys();
-          },
-          error: (err) => {
-            this.toasterService.error(err.error?.message || err.message || 'Failed to revoke API key');
-          },
-        });
+        this.apiKeyService
+          .revoke(this.data.controller, key.api_key_id)
+          .pipe(takeUntilDestroyed(this.destroyRef))
+          .subscribe({
+            next: (response) => {
+              this.toasterService.success(response.message || 'API key revoked');
+              this.loadKeys();
+            },
+            error: (err) => {
+              this.toasterService.error(err.error?.message || err.message || 'Failed to revoke API key');
+            },
+          });
       });
   }
 
   onRestore(key: ApiKey) {
     this.dialog
       .open(ConfirmationDialogComponent, {
-        panelClass: ['base-confirmation-dialog-panel', 'confirmation-warning-panel'],
+        panelClass: ['base-confirmation-dialog-panel', 'confirmation-warning-panel', 'dialog-small-panel'],
         data: {
           title: 'Restore API Key',
           message: `Restore "${key.name}"? It will become active again.`,
@@ -171,22 +195,25 @@ export class ApiKeyManagementDialogComponent implements OnInit {
       .afterClosed()
       .pipe(filter(Boolean), takeUntilDestroyed(this.destroyRef))
       .subscribe(() => {
-        this.apiKeyService.restore(this.data.controller, key.api_key_id).pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
-          next: (response) => {
-            this.toasterService.success(response.message || 'API key restored');
-            this.loadKeys();
-          },
-          error: (err) => {
-            this.toasterService.error(err.error?.message || err.message || 'Failed to restore API key');
-          },
-        });
+        this.apiKeyService
+          .restore(this.data.controller, key.api_key_id)
+          .pipe(takeUntilDestroyed(this.destroyRef))
+          .subscribe({
+            next: (response) => {
+              this.toasterService.success(response.message || 'API key restored');
+              this.loadKeys();
+            },
+            error: (err) => {
+              this.toasterService.error(err.error?.message || err.message || 'Failed to restore API key');
+            },
+          });
       });
   }
 
   onPermanentDelete(key: ApiKey) {
     this.dialog
       .open(ConfirmationDialogComponent, {
-        panelClass: ['base-confirmation-dialog-panel', 'confirmation-danger-panel'],
+        panelClass: ['base-confirmation-dialog-panel', 'confirmation-danger-panel', 'dialog-small-panel'],
         data: {
           title: 'Permanently Delete API Key',
           message: `Delete "${key.name}" permanently? This action cannot be undone.`,
@@ -197,15 +224,18 @@ export class ApiKeyManagementDialogComponent implements OnInit {
       .afterClosed()
       .pipe(filter(Boolean), takeUntilDestroyed(this.destroyRef))
       .subscribe(() => {
-        this.apiKeyService.delete(this.data.controller, key.api_key_id).pipe(takeUntilDestroyed(this.destroyRef)).subscribe({
-          next: () => {
-            this.toasterService.success('API key permanently deleted');
-            this.loadKeys();
-          },
-          error: (err) => {
-            this.toasterService.error(err.error?.message || err.message || 'Failed to delete API key');
-          },
-        });
+        this.apiKeyService
+          .delete(this.data.controller, key.api_key_id)
+          .pipe(takeUntilDestroyed(this.destroyRef))
+          .subscribe({
+            next: () => {
+              this.toasterService.success('API key permanently deleted');
+              this.loadKeys();
+            },
+            error: (err) => {
+              this.toasterService.error(err.error?.message || err.message || 'Failed to delete API key');
+            },
+          });
       });
   }
 

--- a/src/app/components/computes/computes.component.ts
+++ b/src/app/components/computes/computes.component.ts
@@ -196,7 +196,7 @@ export class ComputesComponent implements OnInit, OnDestroy {
 
   openAddDialog() {
     const dialogRef = this.dialog.open(AddComputeDialogComponent, {
-      panelClass: ['base-dialog-panel', 'simple-dialog-panel'],
+      panelClass: ['base-dialog-panel', 'simple-dialog-panel', 'dialog-medium-panel'],
       autoFocus: false,
       disableClose: true,
       data: { controller: this.controller },
@@ -224,7 +224,7 @@ export class ComputesComponent implements OnInit, OnDestroy {
     this.computeService.getCompute(this.controller, compute.compute_id).subscribe({
       next: (fullCompute) => {
         const dialogRef = this.dialog.open(AddComputeDialogComponent, {
-          panelClass: ['base-dialog-panel', 'simple-dialog-panel'],
+          panelClass: ['base-dialog-panel', 'simple-dialog-panel', 'dialog-medium-panel'],
           autoFocus: false,
           disableClose: true,
           data: { controller: this.controller, compute: fullCompute },
@@ -256,7 +256,7 @@ export class ComputesComponent implements OnInit, OnDestroy {
 
   deleteCompute(compute: Compute) {
     const dialogRef = this.dialog.open(ConfirmationDialogComponent, {
-      panelClass: ['base-confirmation-dialog-panel', 'confirmation-danger-panel'],
+      panelClass: ['base-confirmation-dialog-panel', 'confirmation-danger-panel', 'dialog-small-panel'],
       autoFocus: '.cancel-button',
       disableClose: true,
       data: {

--- a/src/app/components/controllers/controllers.component.ts
+++ b/src/app/components/controllers/controllers.component.ts
@@ -221,28 +221,31 @@ export class ControllersComponent implements OnInit, AfterViewInit, OnDestroy {
 
   createModal() {
     const dialogRef = this.dialog.open(AddControllerDialogComponent, {
-      panelClass: ['base-dialog-panel', 'controller-small-dialog-panel', 'add-controller-dialog-panel'],
+      panelClass: [
+        'base-dialog-panel',
+        'controller-small-dialog-panel',
+        'add-controller-dialog-panel',
+        'dialog-medium-panel',
+      ],
       autoFocus: false,
       disableClose: true,
     });
 
     dialogRef.afterClosed().subscribe((controller) => {
       if (controller) {
-        this.controllerService
-          .create(controller)
-          .then(
-            (created: Controller) => {
-              created.status = 'stopped';
-              this.controllerDatabase.addController(created);
-              this.updateControllerOnlineStatus(created);
-              this.changeDetector.markForCheck();
-            },
-            (err) => {
-              const message = err.error?.message || err.message || 'Failed to create controller';
-              this.toasterService.error(message);
-              this.changeDetector.markForCheck();
-            }
-          );
+        this.controllerService.create(controller).then(
+          (created: Controller) => {
+            created.status = 'stopped';
+            this.controllerDatabase.addController(created);
+            this.updateControllerOnlineStatus(created);
+            this.changeDetector.markForCheck();
+          },
+          (err) => {
+            const message = err.error?.message || err.message || 'Failed to create controller';
+            this.toasterService.error(message);
+            this.changeDetector.markForCheck();
+          }
+        );
       }
     });
   }
@@ -317,7 +320,12 @@ export class ControllersComponent implements OnInit, AfterViewInit, OnDestroy {
 
   editController(controller: Controller) {
     const dialogRef = this.dialog.open(EditControllerDialogComponent, {
-      panelClass: ['base-dialog-panel', 'controller-dialog-panel', 'edit-controller-dialog-panel'],
+      panelClass: [
+        'base-dialog-panel',
+        'controller-dialog-panel',
+        'edit-controller-dialog-panel',
+        'dialog-medium-panel',
+      ],
       autoFocus: false,
       disableClose: true,
       data: { controller: controller },
@@ -381,7 +389,6 @@ export class ControllersComponent implements OnInit, AfterViewInit, OnDestroy {
       length: this.dataSource.filteredLength.value,
     });
   }
-
 }
 
 export class ControllerDataSource extends DataSource<Controller> {

--- a/src/app/components/group-details/group-ai-profile-tab/group-ai-profile-tab.component.ts
+++ b/src/app/components/group-details/group-ai-profile-tab/group-ai-profile-tab.component.ts
@@ -162,7 +162,7 @@ export class GroupAiProfileTabComponent implements OnInit, OnDestroy {
    */
   openCreateDialog(): void {
     const dialogRef = this.dialog.open(AiProfileDialogComponent, {
-      panelClass: ['base-dialog-panel', 'ai-profile-dialog-panel'],
+      panelClass: ['base-dialog-panel', 'ai-profile-dialog-panel', 'dialog-large-panel'],
       data: {
         mode: 'create',
         config: null,
@@ -185,7 +185,7 @@ export class GroupAiProfileTabComponent implements OnInit, OnDestroy {
    */
   openEditDialog(config: LLMModelConfigResponse): void {
     const dialogRef = this.dialog.open(AiProfileDialogComponent, {
-      panelClass: ['base-dialog-panel', 'ai-profile-dialog-panel'],
+      panelClass: ['base-dialog-panel', 'ai-profile-dialog-panel', 'dialog-large-panel'],
       data: {
         mode: 'edit',
         config: { ...config },
@@ -254,7 +254,7 @@ export class GroupAiProfileTabComponent implements OnInit, OnDestroy {
    */
   deleteConfig(config: LLMModelConfigResponse): void {
     const dialogRef = this.dialog.open(ConfirmationDialogComponent, {
-      panelClass: ['base-confirmation-dialog-panel', 'confirmation-danger-panel'],
+      panelClass: ['base-confirmation-dialog-panel', 'confirmation-danger-panel', 'dialog-small-panel'],
       autoFocus: '.cancel-button',
       data: {
         title: 'Delete configuration?',

--- a/src/app/components/group-management/group-detail-dialog/group-detail-dialog.component.spec.ts
+++ b/src/app/components/group-management/group-detail-dialog/group-detail-dialog.component.spec.ts
@@ -456,7 +456,12 @@ describe('GroupDetailDialogComponent', () => {
       component.openAddUserDialog();
 
       expect(mockDialog.open).toHaveBeenCalledWith(AddUserToGroupDialogComponent, {
-        panelClass: ['base-dialog-panel', 'simple-dialog-panel', 'add-user-to-group-dialog-panel'],
+        panelClass: [
+          'base-dialog-panel',
+          'simple-dialog-panel',
+          'add-user-to-group-dialog-panel',
+          'dialog-medium-panel',
+        ],
         data: { controller: mockController, group: mockGroup },
       });
     });
@@ -489,7 +494,7 @@ describe('GroupDetailDialogComponent', () => {
       component.openRemoveUserDialog(mockUser);
 
       expect(mockDialog.open).toHaveBeenCalledWith(ConfirmationDialogComponent, {
-        panelClass: ['base-confirmation-dialog-panel', 'confirmation-warning-panel'],
+        panelClass: ['base-confirmation-dialog-panel', 'confirmation-warning-panel', 'dialog-small-panel'],
         autoFocus: '.cancel-button',
         data: {
           title: 'Remove user from group?',
@@ -555,7 +560,7 @@ describe('GroupDetailDialogComponent', () => {
       component.openUserDetailDialog(mockUser);
 
       expect(mockDialog.open).toHaveBeenCalledWith(UserDetailDialogComponent, {
-        panelClass: ['base-dialog-panel', 'configurator-dialog-panel'],
+        panelClass: ['base-dialog-panel', 'configurator-dialog-panel', 'dialog-large-panel'],
         data: { user: mockUser, controller: mockController },
       });
     });

--- a/src/app/components/group-management/group-detail-dialog/group-detail-dialog.component.ts
+++ b/src/app/components/group-management/group-detail-dialog/group-detail-dialog.component.ts
@@ -1,4 +1,14 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Inject, OnInit, inject, signal, computed, model } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  Inject,
+  OnInit,
+  inject,
+  signal,
+  computed,
+  model,
+} from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { UntypedFormControl, UntypedFormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
@@ -175,7 +185,12 @@ export class GroupDetailDialogComponent implements OnInit {
   openAddUserDialog(): void {
     this.dialog
       .open(AddUserToGroupDialogComponent, {
-        panelClass: ['base-dialog-panel', 'simple-dialog-panel', 'add-user-to-group-dialog-panel'],
+        panelClass: [
+          'base-dialog-panel',
+          'simple-dialog-panel',
+          'add-user-to-group-dialog-panel',
+          'dialog-medium-panel',
+        ],
         data: { controller: this.controller, group: this.group },
       })
       .afterClosed()
@@ -189,7 +204,7 @@ export class GroupDetailDialogComponent implements OnInit {
   openRemoveUserDialog(user: User): void {
     this.dialog
       .open(ConfirmationDialogComponent, {
-        panelClass: ['base-confirmation-dialog-panel', 'confirmation-warning-panel'],
+        panelClass: ['base-confirmation-dialog-panel', 'confirmation-warning-panel', 'dialog-small-panel'],
         autoFocus: '.cancel-button',
         data: {
           title: 'Remove user from group?',
@@ -219,7 +234,7 @@ export class GroupDetailDialogComponent implements OnInit {
 
   openUserDetailDialog(user: User): void {
     this.dialog.open(UserDetailDialogComponent, {
-      panelClass: ['base-dialog-panel', 'configurator-dialog-panel'],
+      panelClass: ['base-dialog-panel', 'configurator-dialog-panel', 'dialog-large-panel'],
       data: { user, controller: this.controller } as UserDetailDialogData,
     });
   }

--- a/src/app/components/group-management/group-management.component.ts
+++ b/src/app/components/group-management/group-management.component.ts
@@ -226,7 +226,7 @@ export class GroupManagementComponent implements OnInit, AfterViewInit {
 
   openGroupAiProfileDialog(group: Group) {
     this.dialog.open(GroupAiProfileDialogComponent, {
-      panelClass: ['base-dialog-panel', 'configurator-dialog-panel', 'dialog-large-panel'],
+      panelClass: ['base-dialog-panel', 'configurator-dialog-panel', 'dialog-extra-large-panel'],
       data: { group, controller: this.controller } as GroupAiProfileDialogData,
     });
   }

--- a/src/app/components/group-management/group-management.component.ts
+++ b/src/app/components/group-management/group-management.component.ts
@@ -180,11 +180,13 @@ export class GroupManagementComponent implements OnInit, AfterViewInit {
   onDelete(groupsToDelete: Group[]) {
     this.dialog
       .open(ConfirmationDialogComponent, {
-        panelClass: ['base-confirmation-dialog-panel', 'confirmation-danger-panel'],
+        panelClass: ['base-confirmation-dialog-panel', 'confirmation-danger-panel', 'dialog-small-panel'],
         autoFocus: '.cancel-button',
         data: {
           title: groupsToDelete.length === 1 ? 'Delete group?' : 'Delete groups?',
-          message: `${groupsToDelete.length} selected ${groupsToDelete.length === 1 ? 'group' : 'groups'} will be permanently deleted.`,
+          message: `${groupsToDelete.length} selected ${
+            groupsToDelete.length === 1 ? 'group' : 'groups'
+          } will be permanently deleted.`,
           details: groupsToDelete.map((group) => group.name),
           note: 'This action cannot be undone.',
           confirmButtonText: groupsToDelete.length === 1 ? 'Delete group' : 'Delete groups',
@@ -216,7 +218,7 @@ export class GroupManagementComponent implements OnInit, AfterViewInit {
 
   openGroupDetailDialog(group: Group) {
     this.dialog.open(GroupDetailDialogComponent, {
-      panelClass: ['base-dialog-panel', 'configurator-dialog-panel'],
+      panelClass: ['base-dialog-panel', 'configurator-dialog-panel', 'dialog-large-panel'],
       data: { group, controller: this.controller } as GroupDetailDialogData,
       maxWidth: '90vw',
     });
@@ -224,7 +226,7 @@ export class GroupManagementComponent implements OnInit, AfterViewInit {
 
   openGroupAiProfileDialog(group: Group) {
     this.dialog.open(GroupAiProfileDialogComponent, {
-      panelClass: ['base-dialog-panel', 'configurator-dialog-panel'],
+      panelClass: ['base-dialog-panel', 'configurator-dialog-panel', 'dialog-large-panel'],
       data: { group, controller: this.controller } as GroupAiProfileDialogData,
     });
   }

--- a/src/app/components/image-manager/image-manager.component.ts
+++ b/src/app/components/image-manager/image-manager.component.ts
@@ -278,7 +278,7 @@ export class ImageManagerComponent implements OnInit, OnDestroy {
 
   deleteFile(path: string): void {
     const dialogRef = this.dialog.open(ConfirmationDialogComponent, {
-      panelClass: ['base-confirmation-dialog-panel', 'confirmation-danger-panel'],
+      panelClass: ['base-confirmation-dialog-panel', 'confirmation-danger-panel', 'dialog-small-panel'],
       autoFocus: '.cancel-button',
       data: {
         title: 'Delete image?',
@@ -384,7 +384,7 @@ export class ImageManagerComponent implements OnInit, OnDestroy {
 
   installAllImages(): void {
     const dialogRef = this.dialog.open(ConfirmationDialogComponent, {
-      panelClass: ['base-confirmation-dialog-panel', 'confirmation-neutral-panel'],
+      panelClass: ['base-confirmation-dialog-panel', 'confirmation-neutral-panel', 'dialog-small-panel'],
       autoFocus: '.cancel-button',
       data: {
         title: 'Install all images?',
@@ -414,7 +414,7 @@ export class ImageManagerComponent implements OnInit, OnDestroy {
 
   pruneImages(): void {
     const dialogRef = this.dialog.open(ConfirmationDialogComponent, {
-      panelClass: ['base-confirmation-dialog-panel', 'confirmation-danger-panel'],
+      panelClass: ['base-confirmation-dialog-panel', 'confirmation-danger-panel', 'dialog-small-panel'],
       autoFocus: '.cancel-button',
       data: {
         title: 'Prune unused images?',
@@ -448,7 +448,7 @@ export class ImageManagerComponent implements OnInit, OnDestroy {
 
   addImageDialog(): void {
     const dialogRef = this.dialog.open(AddImageDialogComponent, {
-      panelClass: ['base-dialog-panel', 'add-image-dialog-panel'],
+      panelClass: ['base-dialog-panel', 'add-image-dialog-panel', 'dialog-small-panel'],
       autoFocus: false,
       data: this.controller,
     });
@@ -462,7 +462,7 @@ export class ImageManagerComponent implements OnInit, OnDestroy {
   deleteAllFiles(): void {
     const images = this.getSelectedRows();
     const confirmationRef = this.dialog.open(ConfirmationDialogComponent, {
-      panelClass: ['base-confirmation-dialog-panel', 'confirmation-danger-panel'],
+      panelClass: ['base-confirmation-dialog-panel', 'confirmation-danger-panel', 'dialog-small-panel'],
       autoFocus: '.cancel-button',
       data: {
         title: 'Delete selected images?',
@@ -484,7 +484,12 @@ export class ImageManagerComponent implements OnInit, OnDestroy {
 
   private openImageDeletionProgress(images: ImageTableRow[]): void {
     const dialogRef = this.dialog.open(DeleteAllImageFilesDialogComponent, {
-      panelClass: ['base-confirmation-dialog-panel', 'confirmation-danger-panel', 'delete-all-images-dialog-panel'],
+      panelClass: [
+        'base-confirmation-dialog-panel',
+        'confirmation-danger-panel',
+        'delete-all-images-dialog-panel',
+        'dialog-small-panel',
+      ],
       autoFocus: false,
       disableClose: true,
       data: {

--- a/src/app/components/preferences/common/delete-template-component/delete-template.component.spec.ts
+++ b/src/app/components/preferences/common/delete-template-component/delete-template.component.spec.ts
@@ -94,7 +94,7 @@ describe('DeleteTemplateComponent', () => {
     component.deleteItem(templateName, templateId);
 
     expect((component as any).dialog.open).toHaveBeenCalledWith(ConfirmationDialogComponent, {
-      panelClass: ['base-confirmation-dialog-panel', 'confirmation-danger-panel'],
+      panelClass: ['base-confirmation-dialog-panel', 'confirmation-danger-panel', 'dialog-small-panel'],
       autoFocus: '.cancel-button',
       data: {
         title: 'Delete template?',

--- a/src/app/components/preferences/common/delete-template-component/delete-template.component.ts
+++ b/src/app/components/preferences/common/delete-template-component/delete-template.component.ts
@@ -22,7 +22,7 @@ export class DeleteTemplateComponent {
 
   deleteItem(templateName, templateId) {
     const dialogRef = this.dialog.open(ConfirmationDialogComponent, {
-      panelClass: ['base-confirmation-dialog-panel', 'confirmation-danger-panel'],
+      panelClass: ['base-confirmation-dialog-panel', 'confirmation-danger-panel', 'dialog-small-panel'],
       autoFocus: '.cancel-button',
       data: {
         title: 'Delete template?',

--- a/src/app/components/preferences/common/symbols/symbols.component.ts
+++ b/src/app/components/preferences/common/symbols/symbols.component.ts
@@ -198,7 +198,7 @@ export class SymbolsComponent implements OnInit {
     };
 
     const dialogRef = this.dialog.open(ConfirmationDialogComponent, {
-      panelClass: ['base-confirmation-dialog-panel', 'confirmation-danger-panel'],
+      panelClass: ['base-confirmation-dialog-panel', 'confirmation-danger-panel', 'dialog-small-panel'],
       data: dialogData,
     });
 
@@ -309,7 +309,7 @@ export class SymbolsComponent implements OnInit {
     };
 
     const dialogRef = this.dialog.open(ConfirmationDialogComponent, {
-      panelClass: ['base-confirmation-dialog-panel', 'confirmation-danger-panel'],
+      panelClass: ['base-confirmation-dialog-panel', 'confirmation-danger-panel', 'dialog-small-panel'],
       data: dialogData,
     });
 

--- a/src/app/components/preferences/docker/docker-template-details/docker-template-details.component.ts
+++ b/src/app/components/preferences/docker/docker-template-details/docker-template-details.component.ts
@@ -1,4 +1,13 @@
-import { Component, ChangeDetectionStrategy, ChangeDetectorRef, OnInit, model, inject, signal, computed } from '@angular/core';
+import {
+  Component,
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  OnInit,
+  model,
+  inject,
+  signal,
+  computed,
+} from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
@@ -204,7 +213,9 @@ export class DockerTemplateDetailsComponent implements OnInit {
     this.applianceMetadata.set(setApplianceCredential(this.applianceMetadata(), field, value));
   }
 
-  selectSection(section: string): void { this.activeSection = section; }
+  selectSection(section: string): void {
+    this.activeSection = section;
+  }
 
   onSave() {
     // Validate name (required)
@@ -368,7 +379,7 @@ export class DockerTemplateDetailsComponent implements OnInit {
     }
     const dialogConfig = this.dialogConfig.openConfig('base', {
       autoFocus: false,
-      panelClass: ['base-dialog-panel', 'docker-configurator-dialog-panel'],
+      panelClass: ['base-dialog-panel', 'docker-configurator-dialog-panel', 'dialog-extra-large-panel'],
       disableClose: true,
       data: {},
     });

--- a/src/app/components/preferences/qemu/qemu-vm-template-details/qemu-vm-template-details.component.ts
+++ b/src/app/components/preferences/qemu/qemu-vm-template-details/qemu-vm-template-details.component.ts
@@ -1,4 +1,13 @@
-import { Component, ChangeDetectionStrategy, ChangeDetectorRef, OnInit, model, signal, inject, computed } from '@angular/core';
+import {
+  Component,
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  OnInit,
+  model,
+  signal,
+  inject,
+  computed,
+} from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
@@ -404,7 +413,7 @@ export class QemuVmTemplateDetailsComponent implements OnInit {
     }
 
     const dialogRef = this.dialog.open(CustomAdaptersComponent, {
-      panelClass: 'custom-adapters-dialog-panel',
+      panelClass: ['custom-adapters-dialog-panel', 'dialog-extra-large-panel'],
       data: {
         adapters: adaptersForDialog,
         networkTypes: this.networkTypes,
@@ -491,7 +500,10 @@ export class QemuVmTemplateDetailsComponent implements OnInit {
       return;
     }
     const netmikoValidation = this.validationService.validateNetmikoDeviceType(this.netmikoDeviceType());
-    if (!netmikoValidation.isValid) { this.toasterService.error(netmikoValidation.errorMessage); return; }
+    if (!netmikoValidation.isValid) {
+      this.toasterService.error(netmikoValidation.errorMessage);
+      return;
+    }
 
     // Update qemuTemplate from model signals
     this.qemuTemplate.name = this.templateName();
@@ -604,14 +616,28 @@ export class QemuVmTemplateDetailsComponent implements OnInit {
 
   toggleSection(section: string): void {
     switch (section) {
-      case 'general': this.generalSettingsExpanded = !this.generalSettingsExpanded; break;
-      case 'hdd': this.hddExpanded = !this.hddExpanded; break;
-      case 'cddvd': this.cdDvdExpanded = !this.cdDvdExpanded; break;
-      case 'network': this.networkExpanded = !this.networkExpanded; break;
-      case 'advanced': this.advancedExpanded = !this.advancedExpanded; break;
-      case 'usage': this.usageExpanded = !this.usageExpanded; break;
+      case 'general':
+        this.generalSettingsExpanded = !this.generalSettingsExpanded;
+        break;
+      case 'hdd':
+        this.hddExpanded = !this.hddExpanded;
+        break;
+      case 'cddvd':
+        this.cdDvdExpanded = !this.cdDvdExpanded;
+        break;
+      case 'network':
+        this.networkExpanded = !this.networkExpanded;
+        break;
+      case 'advanced':
+        this.advancedExpanded = !this.advancedExpanded;
+        break;
+      case 'usage':
+        this.usageExpanded = !this.usageExpanded;
+        break;
     }
   }
 
-  selectSection(section: string): void { this.activeSection = section; }
+  selectSection(section: string): void {
+    this.activeSection = section;
+  }
 }

--- a/src/app/components/preferences/virtual-box/virtual-box-template-details/virtual-box-template-details.component.ts
+++ b/src/app/components/preferences/virtual-box/virtual-box-template-details/virtual-box-template-details.component.ts
@@ -164,13 +164,21 @@ export class VirtualBoxTemplateDetailsComponent implements OnInit {
 
   toggleSection(section: string) {
     switch (section) {
-      case 'general': this.generalSettingsExpanded = !this.generalSettingsExpanded; break;
-      case 'network': this.networkExpanded = !this.networkExpanded; break;
-      case 'usage': this.usageExpanded = !this.usageExpanded; break;
+      case 'general':
+        this.generalSettingsExpanded = !this.generalSettingsExpanded;
+        break;
+      case 'network':
+        this.networkExpanded = !this.networkExpanded;
+        break;
+      case 'usage':
+        this.usageExpanded = !this.usageExpanded;
+        break;
     }
   }
 
-  selectSection(section: string): void { this.activeSection = section; }
+  selectSection(section: string): void {
+    this.activeSection = section;
+  }
 
   openCustomAdaptersDialog() {
     // Generate complete adapter list for display
@@ -215,7 +223,7 @@ export class VirtualBoxTemplateDetailsComponent implements OnInit {
     }
 
     const dialogRef = this.dialog.open(CustomAdaptersComponent, {
-      panelClass: 'custom-adapters-dialog-panel',
+      panelClass: ['custom-adapters-dialog-panel', 'dialog-extra-large-panel'],
       data: {
         adapters: adaptersForDialog,
         networkTypes: this.networkTypes,

--- a/src/app/components/preferences/vmware/vmware-template-details/vmware-template-details.component.ts
+++ b/src/app/components/preferences/vmware/vmware-template-details/vmware-template-details.component.ts
@@ -255,7 +255,7 @@ export class VmwareTemplateDetailsComponent implements OnInit {
     }
 
     const dialogRef = this.dialog.open(CustomAdaptersComponent, {
-      panelClass: 'custom-adapters-dialog-panel',
+      panelClass: ['custom-adapters-dialog-panel', 'dialog-extra-large-panel'],
       data: {
         adapters: adaptersForDialog,
         networkTypes: this.networkTypes,
@@ -320,11 +320,19 @@ export class VmwareTemplateDetailsComponent implements OnInit {
 
   toggleSection(section: string): void {
     switch (section) {
-      case 'general': this.generalSettingsExpanded = !this.generalSettingsExpanded; break;
-      case 'network': this.networkExpanded = !this.networkExpanded; break;
-      case 'usage': this.usageExpanded = !this.usageExpanded; break;
+      case 'general':
+        this.generalSettingsExpanded = !this.generalSettingsExpanded;
+        break;
+      case 'network':
+        this.networkExpanded = !this.networkExpanded;
+        break;
+      case 'usage':
+        this.usageExpanded = !this.usageExpanded;
+        break;
     }
   }
 
-  selectSection(section: string): void { this.activeSection = section; }
+  selectSection(section: string): void {
+    this.activeSection = section;
+  }
 }

--- a/src/app/components/project-map/ai-chat/chat-message-list.component.ts
+++ b/src/app/components/project-map/ai-chat/chat-message-list.component.ts
@@ -181,7 +181,7 @@ export class ChatMessageListComponent implements OnChanges, AfterViewChecked, Af
 
     this.dialog.open(CodeBlockDialogComponent, {
       data,
-      panelClass: ['base-dialog-panel', 'code-block-dialog-panel'],
+      panelClass: ['base-dialog-panel', 'code-block-dialog-panel', 'dialog-extra-large-panel'],
     });
   }
 

--- a/src/app/components/project-map/ai-chat/chat-session-list.component.ts
+++ b/src/app/components/project-map/ai-chat/chat-session-list.component.ts
@@ -153,7 +153,7 @@ export class ChatSessionListComponent {
   deleteSession(session: ChatSession): void {
     const title = session.title || 'New chat';
     const dialogRef = this.dialog.open(ConfirmationDialogComponent, {
-      panelClass: ['base-confirmation-dialog-panel', 'confirmation-danger-panel'],
+      panelClass: ['base-confirmation-dialog-panel', 'confirmation-danger-panel', 'dialog-small-panel'],
       autoFocus: '.cancel-button',
       data: {
         title: 'Delete chat?',

--- a/src/app/components/project-map/context-menu/actions/edit-config/edit-config-action.component.spec.ts
+++ b/src/app/components/project-map/context-menu/actions/edit-config/edit-config-action.component.spec.ts
@@ -132,7 +132,7 @@ describe('EditConfigActionComponent', () => {
       expect(mockDialog.open).toHaveBeenCalledWith(
         ConfigEditorDialogComponent,
         expect.objectContaining({
-          panelClass: ['base-dialog-panel', 'edit-config-action-dialog-panel'],
+          panelClass: ['base-dialog-panel', 'edit-config-action-dialog-panel', 'dialog-medium-panel'],
           autoFocus: false,
           disableClose: false,
         })
@@ -151,7 +151,7 @@ describe('EditConfigActionComponent', () => {
       expect(mockDialog.open).toHaveBeenCalledWith(
         ConfigEditorDialogComponent,
         expect.objectContaining({
-          panelClass: ['base-dialog-panel', 'edit-config-action-dialog-panel'],
+          panelClass: ['base-dialog-panel', 'edit-config-action-dialog-panel', 'dialog-medium-panel'],
           autoFocus: false,
           disableClose: false,
         })

--- a/src/app/components/project-map/context-menu/actions/edit-config/edit-config-action.component.ts
+++ b/src/app/components/project-map/context-menu/actions/edit-config/edit-config-action.component.ts
@@ -23,7 +23,7 @@ export class EditConfigActionComponent {
 
   editConfig() {
     const dialogRef = this.dialog.open(ConfigEditorDialogComponent, {
-      panelClass: ['base-dialog-panel', 'edit-config-action-dialog-panel'],
+      panelClass: ['base-dialog-panel', 'edit-config-action-dialog-panel', 'dialog-medium-panel'],
       autoFocus: false,
       disableClose: false,
     });

--- a/src/app/components/project-map/context-menu/actions/edit-style-action/edit-style-action.component.ts
+++ b/src/app/components/project-map/context-menu/actions/edit-style-action/edit-style-action.component.ts
@@ -31,7 +31,7 @@ export class EditStyleActionComponent implements OnChanges {
 
   editStyle() {
     const dialogRef = this.dialog.open(StyleEditorDialogComponent, {
-      panelClass: ['base-dialog-panel', 'simple-dialog-panel', 'edit-style-action-dialog-panel'],
+      panelClass: ['base-dialog-panel', 'simple-dialog-panel', 'edit-style-action-dialog-panel', 'dialog-medium-panel'],
       autoFocus: false,
       disableClose: false,
     });

--- a/src/app/components/project-map/context-menu/actions/edit-text-action/edit-text-action.component.ts
+++ b/src/app/components/project-map/context-menu/actions/edit-text-action/edit-text-action.component.ts
@@ -30,7 +30,7 @@ export class EditTextActionComponent {
 
   editText() {
     const dialogRef = this.dialog.open(TextEditorDialogComponent, {
-      panelClass: ['base-dialog-panel', 'edit-text-action-dialog-panel'],
+      panelClass: ['base-dialog-panel', 'edit-text-action-dialog-panel', 'dialog-medium-panel'],
       autoFocus: false,
       disableClose: false,
     });

--- a/src/app/components/project-map/context-menu/actions/export-config/export-config-action.component.spec.ts
+++ b/src/app/components/project-map/context-menu/actions/export-config/export-config-action.component.spec.ts
@@ -226,7 +226,7 @@ describe('ExportConfigActionComponent', () => {
       fixture.detectChanges();
 
       expect(mockDialog.open).toHaveBeenCalledWith(ConfigDialogComponent, {
-        panelClass: ['base-dialog-panel', 'export-config-action-dialog-panel'],
+        panelClass: ['base-dialog-panel', 'export-config-action-dialog-panel', 'dialog-medium-panel'],
         autoFocus: false,
         disableClose: false,
       });

--- a/src/app/components/project-map/context-menu/actions/export-config/export-config-action.component.ts
+++ b/src/app/components/project-map/context-menu/actions/export-config/export-config-action.component.ts
@@ -39,7 +39,7 @@ export class ExportConfigActionComponent {
       });
     } else {
       const dialogRef = this.dialog.open(ConfigDialogComponent, {
-        panelClass: ['base-dialog-panel', 'export-config-action-dialog-panel'],
+        panelClass: ['base-dialog-panel', 'export-config-action-dialog-panel', 'dialog-medium-panel'],
         autoFocus: false,
         disableClose: false,
       });

--- a/src/app/components/project-map/context-menu/actions/idle-pc-action/idle-pc-action.component.spec.ts
+++ b/src/app/components/project-map/context-menu/actions/idle-pc-action/idle-pc-action.component.spec.ts
@@ -212,7 +212,7 @@ describe('IdlePcActionComponent', () => {
       component.idlePC();
 
       expect(mockDialog.open).toHaveBeenCalledWith(IdlePCDialogComponent, {
-        panelClass: ['base-dialog-panel', 'idle-pc-action-dialog-panel'],
+        panelClass: ['base-dialog-panel', 'idle-pc-action-dialog-panel', 'dialog-small-panel'],
         autoFocus: false,
         disableClose: false,
       });

--- a/src/app/components/project-map/context-menu/actions/idle-pc-action/idle-pc-action.component.ts
+++ b/src/app/components/project-map/context-menu/actions/idle-pc-action/idle-pc-action.component.ts
@@ -23,7 +23,7 @@ export class IdlePcActionComponent {
 
   idlePC() {
     const dialogRef = this.dialog.open(IdlePCDialogComponent, {
-      panelClass: ['base-dialog-panel', 'idle-pc-action-dialog-panel'],
+      panelClass: ['base-dialog-panel', 'idle-pc-action-dialog-panel', 'dialog-small-panel'],
       autoFocus: false,
       disableClose: false,
     });

--- a/src/app/components/project-map/context-menu/actions/import-config/import-config-action.component.spec.ts
+++ b/src/app/components/project-map/context-menu/actions/import-config/import-config-action.component.spec.ts
@@ -175,7 +175,7 @@ describe('ImportConfigActionComponent', () => {
       component.triggerClick();
 
       expect(mockDialog.open).toHaveBeenCalledWith(ConfigDialogComponent, {
-        panelClass: ['base-dialog-panel', 'import-config-action-dialog-panel'],
+        panelClass: ['base-dialog-panel', 'import-config-action-dialog-panel', 'dialog-medium-panel'],
         autoFocus: false,
         disableClose: false,
       });

--- a/src/app/components/project-map/context-menu/actions/import-config/import-config-action.component.ts
+++ b/src/app/components/project-map/context-menu/actions/import-config/import-config-action.component.ts
@@ -40,7 +40,7 @@ export class ImportConfigActionComponent {
     this.fileInput().nativeElement.value = '';
     if (this.node().node_type !== 'vpcs') {
       const dialogRef = this.dialog.open(ConfigDialogComponent, {
-        panelClass: ['base-dialog-panel', 'import-config-action-dialog-panel'],
+        panelClass: ['base-dialog-panel', 'import-config-action-dialog-panel', 'dialog-medium-panel'],
         autoFocus: false,
         disableClose: false,
       });
@@ -79,7 +79,9 @@ export class ImportConfigActionComponent {
             this.cdr.markForCheck();
           },
           error: (error) => {
-            this.toasterService.error(error.error?.message || error.message || 'Failed to import startup configuration');
+            this.toasterService.error(
+              error.error?.message || error.message || 'Failed to import startup configuration'
+            );
             this.cdr.markForCheck();
           },
         });
@@ -90,7 +92,9 @@ export class ImportConfigActionComponent {
             this.cdr.markForCheck();
           },
           error: (error) => {
-            this.toasterService.error(error.error?.message || error.message || 'Failed to import private configuration');
+            this.toasterService.error(
+              error.error?.message || error.message || 'Failed to import private configuration'
+            );
             this.cdr.markForCheck();
           },
         });

--- a/src/app/components/project-map/context-menu/actions/lock-action/lock-action.component.ts
+++ b/src/app/components/project-map/context-menu/actions/lock-action/lock-action.component.ts
@@ -59,7 +59,7 @@ export class LockActionComponent implements OnChanges {
       const action = isLocking ? 'lock' : 'unlock';
 
       const dialogRef = this.dialog.open(ConfirmationDialogComponent, {
-        panelClass: ['base-confirmation-dialog-panel', 'confirmation-warning-panel'],
+        panelClass: ['base-confirmation-dialog-panel', 'confirmation-warning-panel', 'dialog-small-panel'],
         autoFocus: '.cancel-button',
         data: {
           title: `${action === 'lock' ? 'Lock' : 'Unlock'} selected items?`,
@@ -96,10 +96,9 @@ export class LockActionComponent implements OnChanges {
     const completion = createActionCompletion(operationCount, (count) => {
       this.projectService.projectUpdateLockIcon();
       if (count > 0) {
-        this.toasterService.success(
-          `Lock status updated for ${count} ${count === 1 ? 'item' : 'items'}.`,
-          { showToast: false }
-        );
+        this.toasterService.success(`Lock status updated for ${count} ${count === 1 ? 'item' : 'items'}.`, {
+          showToast: false,
+        });
       }
     });
 

--- a/src/app/components/project-map/context-menu/actions/show-node-action/show-node-action.component.spec.ts
+++ b/src/app/components/project-map/context-menu/actions/show-node-action/show-node-action.component.spec.ts
@@ -176,7 +176,7 @@ describe('ShowNodeActionComponent', () => {
       component.showNode();
 
       expect(mockDialog.open).toHaveBeenCalledWith(InfoDialogComponent, {
-        panelClass: ['base-dialog-panel', 'show-node-action-dialog-panel'],
+        panelClass: ['base-dialog-panel', 'show-node-action-dialog-panel', 'dialog-small-panel'],
         autoFocus: false,
         data: { node: undefined, controller: undefined },
       });
@@ -193,7 +193,7 @@ describe('ShowNodeActionComponent', () => {
       component.showNode();
 
       expect(mockDialog.open).toHaveBeenCalledWith(InfoDialogComponent, {
-        panelClass: ['base-dialog-panel', 'show-node-action-dialog-panel'],
+        panelClass: ['base-dialog-panel', 'show-node-action-dialog-panel', 'dialog-small-panel'],
         autoFocus: false,
         data: { node: mockNode, controller: mockController },
       });

--- a/src/app/components/project-map/context-menu/actions/show-node-action/show-node-action.component.spec.ts
+++ b/src/app/components/project-map/context-menu/actions/show-node-action/show-node-action.component.spec.ts
@@ -120,15 +120,10 @@ describe('ShowNodeActionComponent', () => {
   let fixture: ComponentFixture<ShowNodeActionComponent>;
   let component: ShowNodeActionComponent;
   let mockDialog: any;
-  let mockDialogRef: any;
-  let mockDialogInstance: any;
 
   beforeEach(async () => {
-    mockDialogInstance = {};
-    mockDialogRef = { close: vi.fn() };
     mockDialog = {
       open: vi.fn().mockReturnValue({
-        componentInstance: mockDialogInstance,
         close: vi.fn(),
       }),
     };
@@ -183,11 +178,11 @@ describe('ShowNodeActionComponent', () => {
       expect(mockDialog.open).toHaveBeenCalledWith(InfoDialogComponent, {
         panelClass: ['base-dialog-panel', 'show-node-action-dialog-panel'],
         autoFocus: false,
-        disableClose: false,
+        data: { node: undefined, controller: undefined },
       });
     });
 
-    it('should pass node and controller to dialog componentInstance', () => {
+    it('should pass node and controller to the dialog via MAT_DIALOG_DATA', () => {
       fixture.detectChanges();
       const mockNode = createMockNode();
       const mockController = createMockController();
@@ -197,17 +192,11 @@ describe('ShowNodeActionComponent', () => {
 
       component.showNode();
 
-      expect(mockDialogInstance.node).toBe(mockNode);
-      expect(mockDialogInstance.controller).toBe(mockController);
-    });
-
-    it('should open dialog with undefined inputs when node and controller not set', () => {
-      fixture.detectChanges();
-
-      component.showNode();
-
-      expect(mockDialogInstance.node).toBeUndefined();
-      expect(mockDialogInstance.controller).toBeUndefined();
+      expect(mockDialog.open).toHaveBeenCalledWith(InfoDialogComponent, {
+        panelClass: ['base-dialog-panel', 'show-node-action-dialog-panel'],
+        autoFocus: false,
+        data: { node: mockNode, controller: mockController },
+      });
     });
 
     it('should open dialog multiple times', () => {

--- a/src/app/components/project-map/context-menu/actions/show-node-action/show-node-action.component.spec.ts
+++ b/src/app/components/project-map/context-menu/actions/show-node-action/show-node-action.component.spec.ts
@@ -176,7 +176,12 @@ describe('ShowNodeActionComponent', () => {
       component.showNode();
 
       expect(mockDialog.open).toHaveBeenCalledWith(InfoDialogComponent, {
-        panelClass: ['base-dialog-panel', 'show-node-action-dialog-panel', 'dialog-small-panel'],
+        panelClass: [
+          'base-dialog-panel',
+          'show-node-action-dialog-panel',
+          'dialog-small-panel',
+          'dialog-height-60-panel',
+        ],
         autoFocus: false,
         data: { node: undefined, controller: undefined },
       });
@@ -193,7 +198,12 @@ describe('ShowNodeActionComponent', () => {
       component.showNode();
 
       expect(mockDialog.open).toHaveBeenCalledWith(InfoDialogComponent, {
-        panelClass: ['base-dialog-panel', 'show-node-action-dialog-panel', 'dialog-small-panel'],
+        panelClass: [
+          'base-dialog-panel',
+          'show-node-action-dialog-panel',
+          'dialog-small-panel',
+          'dialog-height-60-panel',
+        ],
         autoFocus: false,
         data: { node: mockNode, controller: mockController },
       });

--- a/src/app/components/project-map/context-menu/actions/show-node-action/show-node-action.component.ts
+++ b/src/app/components/project-map/context-menu/actions/show-node-action/show-node-action.component.ts
@@ -21,7 +21,7 @@ export class ShowNodeActionComponent {
 
   showNode() {
     this.dialog.open(InfoDialogComponent, {
-      panelClass: ['base-dialog-panel', 'show-node-action-dialog-panel'],
+      panelClass: ['base-dialog-panel', 'show-node-action-dialog-panel', 'dialog-small-panel'],
       autoFocus: false,
       data: { node: this.node(), controller: this.controller() } satisfies InfoDialogData,
     });

--- a/src/app/components/project-map/context-menu/actions/show-node-action/show-node-action.component.ts
+++ b/src/app/components/project-map/context-menu/actions/show-node-action/show-node-action.component.ts
@@ -21,7 +21,12 @@ export class ShowNodeActionComponent {
 
   showNode() {
     this.dialog.open(InfoDialogComponent, {
-      panelClass: ['base-dialog-panel', 'show-node-action-dialog-panel', 'dialog-small-panel'],
+      panelClass: [
+        'base-dialog-panel',
+        'show-node-action-dialog-panel',
+        'dialog-small-panel',
+        'dialog-height-60-panel',
+      ],
       autoFocus: false,
       data: { node: this.node(), controller: this.controller() } satisfies InfoDialogData,
     });

--- a/src/app/components/project-map/context-menu/actions/show-node-action/show-node-action.component.ts
+++ b/src/app/components/project-map/context-menu/actions/show-node-action/show-node-action.component.ts
@@ -5,7 +5,7 @@ import { MatMenuModule } from '@angular/material/menu';
 import { MatDialog } from '@angular/material/dialog';
 import { Node } from '../../../../../cartography/models/node';
 import { Controller } from '@models/controller';
-import { InfoDialogComponent } from '../../../info-dialog/info-dialog.component';
+import { InfoDialogComponent, InfoDialogData } from '../../../info-dialog/info-dialog.component';
 
 @Component({
   selector: 'app-show-node-action',
@@ -20,13 +20,10 @@ export class ShowNodeActionComponent {
   readonly controller = input<Controller>(undefined);
 
   showNode() {
-    const dialogRef = this.dialog.open(InfoDialogComponent, {
+    this.dialog.open(InfoDialogComponent, {
       panelClass: ['base-dialog-panel', 'show-node-action-dialog-panel'],
       autoFocus: false,
-      disableClose: false,
+      data: { node: this.node(), controller: this.controller() } satisfies InfoDialogData,
     });
-    let instance = dialogRef.componentInstance;
-    instance.node = this.node();
-    instance.controller = this.controller();
   }
 }

--- a/src/app/components/project-map/info-dialog/info-dialog.component.html
+++ b/src/app/components/project-map/info-dialog/info-dialog.component.html
@@ -1,28 +1,89 @@
-<h1 mat-dialog-title>
-  {{ node.name }}
-  <button mat-icon-button class="close-btn" (click)="onCloseClick()">
-    <mat-icon>close</mat-icon>
-  </button>
-</h1>
+<h2 mat-dialog-title>{{ data.node.name }}</h2>
 
-<div class="modal-form-container">
+<mat-dialog-content>
   <mat-tab-group animationDuration="0ms">
     <mat-tab label="General information">
-      <div class="textBox">
-        @for (info of infoList; track info) {
-        <div>{{ info }}</div>
+      <div class="info-dialog__tab-body">
+        <div class="detail-row">
+          <span class="detail-row__label">Status</span>
+          <span class="detail-row__value detail-row__value--status">
+            <span class="status-dot" [attr.data-status]="statusKey"></span>
+            {{ info.statusLabel }}
+          </span>
+        </div>
+        <div class="detail-row">
+          <span class="detail-row__label">Node type</span>
+          <span class="detail-row__value">{{ info.nodeTypeLabel }}</span>
+        </div>
+        <div class="detail-row">
+          <span class="detail-row__label">Node ID</span>
+          <span class="detail-row__value detail-row__value--mono"
+            ><code>{{ info.nodeId }}</code></span
+          >
+        </div>
+        <div class="detail-row">
+          <span class="detail-row__label">Console</span>
+          <span class="detail-row__value">{{ consoleLabel }}</span>
+        </div>
+        <div class="detail-row">
+          <span class="detail-row__label">Controller</span>
+          <span class="detail-row__value">{{ controllerLabel }}</span>
+        </div>
+        <div class="detail-row">
+          <span class="detail-row__label">Controller ID</span>
+          <span class="detail-row__value detail-row__value--mono"
+            ><code>{{ info.controller.id }}</code></span
+          >
+        </div>
+
+        @if (info.ports.length) {
+        <table class="info-dialog__ports-table">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Link type</th>
+            </tr>
+          </thead>
+          <tbody>
+            @for (port of info.ports; track port.name) {
+            <tr>
+              <td>{{ port.name }}</td>
+              <td>{{ port.linkType || '—' }}</td>
+            </tr>
+            }
+          </tbody>
+        </table>
         }
       </div>
     </mat-tab>
+
     <mat-tab label="Usage instructions">
-      <div class="textBox">
-        {{ usage }}
+      <div class="info-dialog__tab-body">
+        @if (usage) {
+        <markdown class="info-dialog__usage" [data]="usage"></markdown>
+        } @else {
+        <p class="info-dialog__empty-note">No usage information has been provided for this node.</p>
+        }
       </div>
     </mat-tab>
+
     <mat-tab label="Command line">
-      <div class="textBox">
-        {{ commandLine }}
+      <div class="info-dialog__tab-body">
+        @if (commandLineInfo.kind === 'available') {
+        <div class="info-dialog__code-header">
+          <button mat-icon-button matTooltip="Copy to clipboard" (click)="copyCommandLine()">
+            <mat-icon>content_copy</mat-icon>
+          </button>
+        </div>
+        <pre class="info-dialog__code"><code>{{ commandLineInfo.commandLine }}</code></pre>
+        } @else {
+        <p class="info-dialog__empty-note">{{ commandLineInfo.message }}</p>
+        }
       </div>
     </mat-tab>
   </mat-tab-group>
-</div>
+</mat-dialog-content>
+
+<mat-dialog-actions align="end">
+  <button mat-button (click)="onClose()">Close</button>
+</mat-dialog-actions>

--- a/src/app/components/project-map/info-dialog/info-dialog.component.scss
+++ b/src/app/components/project-map/info-dialog/info-dialog.component.scss
@@ -3,31 +3,116 @@
  * Using MD3 CSS variables
  */
 
-[mat-dialog-title] {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  color: var(--mat-sys-on-primary-container);
+.info-dialog__tab-body {
+  padding: 16px 0 8px;
 }
 
-.close-btn {
-  margin-left: auto;
-}
+.detail-row {
+  margin-bottom: 16px;
 
-.modal-form-container {
-  padding: 16px;
-  height: 300px;
-  display: flex;
-  flex-direction: column;
-  color: var(--mat-sys-on-surface-variant);
+  &__label {
+    display: block;
+    margin-bottom: 4px;
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--mat-sys-on-surface-variant);
+  }
 
-  mat-tab-group {
-    flex: 1;
-    overflow: auto;
+  &__value {
+    font-size: 14px;
+    color: var(--mat-sys-on-surface);
+
+    &--status {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    &--mono code {
+      padding: 4px 8px;
+      background: var(--mat-sys-surface-container-highest);
+      border-radius: 4px;
+      font-family: monospace;
+      font-size: 13px;
+      word-break: break-all;
+      user-select: all;
+    }
   }
 }
 
-.textBox {
+.status-dot {
+  display: inline-block;
+  flex: 0 0 12px;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--mat-sys-outline);
+
+  &[data-status='started'] {
+    background: var(--custom-mat-sys-success);
+  }
+
+  &[data-status='stopped'] {
+    background: var(--mat-sys-error);
+  }
+
+  &[data-status='suspended'] {
+    background: var(--mat-sys-secondary);
+  }
+
+  &[data-status='always-on'] {
+    background: var(--mat-sys-primary);
+  }
+}
+
+.info-dialog__ports-table {
+  width: 100%;
   margin-top: 8px;
+  border-collapse: collapse;
+
+  th {
+    padding: 6px 16px 6px 0;
+    border-bottom: 1px solid var(--mat-sys-outline-variant);
+    text-align: left;
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--mat-sys-on-surface-variant);
+  }
+
+  td {
+    padding: 6px 16px 6px 0;
+    border-bottom: 1px solid var(--mat-sys-outline-variant);
+    font-size: 13px;
+    color: var(--mat-sys-on-surface);
+  }
+
+  tr:last-child td {
+    border-bottom: none;
+  }
+}
+
+.info-dialog__code-header {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.info-dialog__code {
+  display: block;
+  margin: 0;
+  padding: 16px;
+  background: var(--mat-sys-surface-container-highest);
+  color: var(--mat-sys-on-surface);
+  border-radius: 8px;
+  font-family: monospace;
+  font-size: 13px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow-x: auto;
+}
+
+.info-dialog__empty-note {
+  margin: 16px 0 8px;
+  font-size: 14px;
   color: var(--mat-sys-on-surface-variant);
 }

--- a/src/app/components/project-map/info-dialog/info-dialog.component.spec.ts
+++ b/src/app/components/project-map/info-dialog/info-dialog.component.spec.ts
@@ -1,11 +1,15 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { MatDialogRef, MatDialogModule } from '@angular/material/dialog';
+import { MatDialogRef, MatDialogModule, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
-import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatTabsModule } from '@angular/material/tabs';
+import { HttpClientModule } from '@angular/common/http';
+import { MarkdownModule } from 'ngx-markdown';
+import { Clipboard } from '@angular/cdk/clipboard';
 import { InfoDialogComponent } from './info-dialog.component';
-import { InfoService } from '@services/info.service';
+import { InfoService, NodeCommandLineInfo, NodeInfo } from '@services/info.service';
+import { ToasterService } from '@services/toaster.service';
 import { Node, Properties } from '../../../cartography/models/node';
 import { Controller } from '@models/controller';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
@@ -14,6 +18,8 @@ describe('InfoDialogComponent', () => {
   let fixture: ComponentFixture<InfoDialogComponent>;
   let mockDialogRef: any;
   let mockInfoService: any;
+  let mockClipboard: any;
+  let mockToasterService: any;
 
   const createMockProperties = (): Properties => ({
     adapter_type: '',
@@ -125,14 +131,53 @@ describe('InfoDialogComponent', () => {
     return Object.assign({}, defaults, overrides);
   };
 
+  const createMockNodeInfo = (overrides: Partial<NodeInfo> = {}): NodeInfo => ({
+    status: 'started',
+    statusLabel: 'Started',
+    alwaysOn: false,
+    nodeType: 'qemu',
+    nodeTypeLabel: 'QEMU VM',
+    nodeId: 'node-1',
+    console: { port: 5000, type: 'telnet' },
+    controller: { id: 1, name: 'Main Controller', port: 3080 },
+    ports: [
+      { name: 'eth0', linkType: 'ethernet' },
+      { name: 'eth1', linkType: 'ethernet' },
+    ],
+    ...overrides,
+  });
+
+  const createMockCommandLineInfo = (overrides: Partial<NodeCommandLineInfo> = {}): NodeCommandLineInfo => ({
+    kind: 'available',
+    commandLine: 'telnet 127.0.0.1 5000',
+    message: '',
+    ...overrides,
+  });
+
+  const createFixture = (node: Node, controller: Controller): ComponentFixture<InfoDialogComponent> => {
+    TestBed.overrideProvider(MAT_DIALOG_DATA, { useValue: { node, controller } });
+    const f = TestBed.createComponent(InfoDialogComponent);
+    f.detectChanges();
+    return f;
+  };
+
   beforeEach(async () => {
     mockDialogRef = {
       close: vi.fn(),
     };
 
     mockInfoService = {
-      getInfoAboutNode: vi.fn().mockReturnValue(['Info line 1', 'Info line 2']),
-      getCommandLine: vi.fn().mockReturnValue('telnet 127.0.0.1 5000'),
+      getInfoAboutNode: vi.fn().mockReturnValue(createMockNodeInfo()),
+      getCommandLine: vi.fn().mockReturnValue(createMockCommandLineInfo()),
+    };
+
+    mockClipboard = {
+      copy: vi.fn().mockReturnValue(true),
+    };
+
+    mockToasterService = {
+      success: vi.fn(),
+      error: vi.fn(),
     };
 
     await TestBed.configureTestingModule({
@@ -140,236 +185,204 @@ describe('InfoDialogComponent', () => {
         MatDialogModule,
         MatButtonModule,
         MatIconModule,
-        MatProgressSpinnerModule,
+        MatTooltipModule,
         MatTabsModule,
+        HttpClientModule,
+        MarkdownModule.forRoot(),
         InfoDialogComponent,
       ],
     })
       .overrideProvider(MatDialogRef, { useValue: mockDialogRef })
       .overrideProvider(InfoService, { useValue: mockInfoService })
+      .overrideProvider(Clipboard, { useValue: mockClipboard })
+      .overrideProvider(ToasterService, { useValue: mockToasterService })
       .compileComponents();
-
-    fixture = TestBed.createComponent(InfoDialogComponent);
   });
 
   afterEach(() => {
-    fixture.destroy();
+    if (fixture) {
+      fixture.destroy();
+    }
   });
 
   describe('initialization', () => {
     it('should display node name in dialog title', () => {
-      const mockNode = createMockNode();
-      const mockController = createMockController();
+      fixture = createFixture(createMockNode(), createMockController());
 
-      fixture.componentRef.setInput('node', mockNode);
-      fixture.componentRef.setInput('controller', mockController);
-      fixture.detectChanges();
-
-      const titleEl = fixture.nativeElement.querySelector('h1[mat-dialog-title]');
+      const titleEl = fixture.nativeElement.querySelector('h2[mat-dialog-title]');
       expect(titleEl.textContent).toContain('Test Router');
     });
 
     it('should call infoService.getInfoAboutNode with node and controller', () => {
       const mockNode = createMockNode();
       const mockController = createMockController();
-
-      fixture.componentRef.setInput('node', mockNode);
-      fixture.componentRef.setInput('controller', mockController);
-      fixture.detectChanges();
+      fixture = createFixture(mockNode, mockController);
 
       expect(mockInfoService.getInfoAboutNode).toHaveBeenCalledWith(mockNode, mockController);
     });
 
     it('should call infoService.getCommandLine with node', () => {
       const mockNode = createMockNode();
-      const mockController = createMockController();
-
-      fixture.componentRef.setInput('node', mockNode);
-      fixture.componentRef.setInput('controller', mockController);
-      fixture.detectChanges();
+      fixture = createFixture(mockNode, createMockController());
 
       expect(mockInfoService.getCommandLine).toHaveBeenCalledWith(mockNode);
     });
 
-    it('should populate infoList from infoService', () => {
-      const mockNode = createMockNode();
-      const mockController = createMockController();
+    it('should render structured info rows on the General information tab', () => {
+      fixture = createFixture(createMockNode(), createMockController());
 
-      fixture.componentRef.setInput('node', mockNode);
-      fixture.componentRef.setInput('controller', mockController);
-      fixture.detectChanges();
-
-      const infoTabContent = fixture.nativeElement.querySelector('.mat-mdc-tab-body-active .textBox');
-      expect(infoTabContent.textContent).toContain('Info line 1');
-      expect(infoTabContent.textContent).toContain('Info line 2');
+      const activeBody = fixture.nativeElement.querySelector('.mat-mdc-tab-body-active');
+      const values = Array.from(activeBody.querySelectorAll('.detail-row__value')).map((el: HTMLElement) =>
+        el.textContent.trim()
+      );
+      expect(values.some((text) => text.includes('Started'))).toBe(true);
+      expect(values.some((text) => text.includes('QEMU VM'))).toBe(true);
+      expect(values.some((text) => text.includes('node-1'))).toBe(true);
+      expect(values.some((text) => text.includes('telnet (port 5000)'))).toBe(true);
+      expect(values.some((text) => text.includes('Main Controller (port 3080)'))).toBe(true);
     });
 
-    it('should display usage from node.usage', () => {
-      const mockNode = createMockNode({ usage: 'Router usage info' });
-      const mockController = createMockController();
+    it('should render a status dot keyed by node status', () => {
+      fixture = createFixture(createMockNode(), createMockController());
 
-      fixture.componentRef.setInput('node', mockNode);
-      fixture.componentRef.setInput('controller', mockController);
+      const statusDot = fixture.nativeElement.querySelector('.status-dot');
+      expect(statusDot.getAttribute('data-status')).toBe('started');
+    });
+
+    it('should render the ports table with name and link type', () => {
+      fixture = createFixture(createMockNode(), createMockController());
+
+      const rows = Array.from(fixture.nativeElement.querySelectorAll('.info-dialog__ports-table tbody tr')) as HTMLElement[];
+      expect(rows.length).toBe(2);
+      expect(rows[0].textContent).toContain('eth0');
+      expect(rows[0].textContent).toContain('ethernet');
+    });
+
+    it('should omit the ports table when the node has no ports', () => {
+      mockInfoService.getInfoAboutNode.mockReturnValue(createMockNodeInfo({ ports: [] }));
+      fixture = createFixture(createMockNode(), createMockController());
+
+      expect(fixture.nativeElement.querySelector('.info-dialog__ports-table')).toBeNull();
+    });
+  });
+
+  describe('Usage instructions tab', () => {
+    it('should render usage markdown', async () => {
+      fixture = createFixture(createMockNode({ usage: '# Router usage info' }), createMockController());
+
+      const tabLabels = fixture.nativeElement.querySelectorAll('.mat-mdc-tab');
+      tabLabels[1].click();
+      fixture.detectChanges();
+      // ngx-markdown's render() awaits parse() before inserting the compiled HTML.
+      // The global setup installs fake timers, so flush them explicitly.
+      await vi.runAllTimersAsync();
       fixture.detectChanges();
 
-      // Click on Usage instructions tab
+      const usageEl = fixture.nativeElement.querySelector('markdown.info-dialog__usage');
+      expect(usageEl).toBeTruthy();
+      expect(usageEl.textContent).toContain('Router usage info');
+    });
+
+    it('should display default message when node has no usage', () => {
+      fixture = createFixture(createMockNode({ usage: '' }), createMockController());
+
       const tabLabels = fixture.nativeElement.querySelectorAll('.mat-mdc-tab');
       tabLabels[1].click();
       fixture.detectChanges();
 
-      const activeTabContent = fixture.nativeElement.querySelector('.mat-mdc-tab-body-active .textBox');
-      expect(activeTabContent.textContent).toContain('Router usage info');
+      const activeBody = fixture.nativeElement.querySelector('.mat-mdc-tab-body-active');
+      expect(activeBody.textContent).toContain('No usage information has been provided for this node.');
+      expect(activeBody.querySelector('markdown')).toBeNull();
     });
+  });
 
-    it('should display commandLine from infoService', () => {
-      const mockNode = createMockNode();
-      const mockController = createMockController();
+  describe('Command line tab', () => {
+    it('should render the command line in a code block with a copy button', () => {
+      fixture = createFixture(createMockNode(), createMockController());
 
-      fixture.componentRef.setInput('node', mockNode);
-      fixture.componentRef.setInput('controller', mockController);
-      fixture.detectChanges();
-
-      // Click on Command line tab
       const tabLabels = fixture.nativeElement.querySelectorAll('.mat-mdc-tab');
       tabLabels[2].click();
       fixture.detectChanges();
 
-      const activeTabContent = fixture.nativeElement.querySelector('.mat-mdc-tab-body-active .textBox');
-      expect(activeTabContent.textContent).toContain('telnet 127.0.0.1 5000');
+      const codeBlock = fixture.nativeElement.querySelector('.info-dialog__code');
+      expect(codeBlock.textContent).toContain('telnet 127.0.0.1 5000');
+      expect(fixture.nativeElement.querySelector('.info-dialog__code-header button')).toBeTruthy();
     });
-  });
 
-  describe('when node has no usage', () => {
-    it('should display default usage message', () => {
-      const mockNode = createMockNode({ usage: '' });
-      const mockController = createMockController();
+    it('should copy the command line and show a success toast', () => {
+      fixture = createFixture(createMockNode(), createMockController());
 
-      fixture.componentRef.setInput('node', mockNode);
-      fixture.componentRef.setInput('controller', mockController);
-      fixture.detectChanges();
-
-      // Click on Usage instructions tab
       const tabLabels = fixture.nativeElement.querySelectorAll('.mat-mdc-tab');
-      tabLabels[1].click();
+      tabLabels[2].click();
       fixture.detectChanges();
 
-      const activeTabContent = fixture.nativeElement.querySelector('.mat-mdc-tab-body-active .textBox');
-      expect(activeTabContent.textContent).toContain('No usage information has been provided for this node.');
+      const copyButton = fixture.nativeElement.querySelector('.info-dialog__code-header button');
+      copyButton.click();
+
+      expect(mockClipboard.copy).toHaveBeenCalledWith('telnet 127.0.0.1 5000');
+      expect(mockToasterService.success).toHaveBeenCalledWith('Command line copied to clipboard');
+    });
+
+    it('should show an error toast when copying fails', () => {
+      mockClipboard.copy.mockReturnValue(false);
+      fixture = createFixture(createMockNode(), createMockController());
+
+      const tabLabels = fixture.nativeElement.querySelectorAll('.mat-mdc-tab');
+      tabLabels[2].click();
+      fixture.detectChanges();
+
+      const copyButton = fixture.nativeElement.querySelector('.info-dialog__code-header button');
+      copyButton.click();
+
+      expect(mockToasterService.error).toHaveBeenCalledWith('Failed to copy to clipboard');
+    });
+
+    it('should show the unsupported message without a copy button for unsupported node types', () => {
+      mockInfoService.getCommandLine.mockReturnValue(
+        createMockCommandLineInfo({
+          kind: 'unsupported',
+          commandLine: '',
+          message: 'Command line information is not supported for this type of node.',
+        })
+      );
+      fixture = createFixture(createMockNode(), createMockController());
+
+      const tabLabels = fixture.nativeElement.querySelectorAll('.mat-mdc-tab');
+      tabLabels[2].click();
+      fixture.detectChanges();
+
+      const activeBody = fixture.nativeElement.querySelector('.mat-mdc-tab-body-active');
+      expect(activeBody.textContent).toContain('Command line information is not supported');
+      expect(fixture.nativeElement.querySelector('.info-dialog__code-header button')).toBeNull();
+    });
+
+    it('should show the start-node message when the command line is unavailable', () => {
+      mockInfoService.getCommandLine.mockReturnValue(
+        createMockCommandLineInfo({
+          kind: 'not-running',
+          commandLine: '',
+          message: 'Please start the node in order to get the command line information.',
+        })
+      );
+      fixture = createFixture(createMockNode(), createMockController());
+
+      const tabLabels = fixture.nativeElement.querySelectorAll('.mat-mdc-tab');
+      tabLabels[2].click();
+      fixture.detectChanges();
+
+      const activeBody = fixture.nativeElement.querySelector('.mat-mdc-tab-body-active');
+      expect(activeBody.textContent).toContain('Please start the node');
     });
   });
 
-  describe('onCloseClick', () => {
-    it('should close the dialog', () => {
-      const mockNode = createMockNode();
-      const mockController = createMockController();
+  describe('onClose', () => {
+    it('should close the dialog from the footer Close button', () => {
+      fixture = createFixture(createMockNode(), createMockController());
 
-      fixture.componentRef.setInput('node', mockNode);
-      fixture.componentRef.setInput('controller', mockController);
-      fixture.detectChanges();
-
-      const closeButton = fixture.nativeElement.querySelector('.close-btn');
+      const closeButton = fixture.nativeElement.querySelector('mat-dialog-actions button');
       closeButton.click();
 
       expect(mockDialogRef.close).toHaveBeenCalled();
-    });
-  });
-
-  describe('dynamips node type', () => {
-    it('should show dynamips-specific info', () => {
-      const mockNode = createMockNode({ node_type: 'dynamips', name: 'R1' });
-      const mockController = createMockController();
-      mockInfoService.getInfoAboutNode.mockReturnValue([
-        `Dynamips R1 is always on.`,
-        `Running on controller Main Controller with port 3080.`,
-        `Controller ID is 1.`,
-      ]);
-
-      fixture.componentRef.setInput('node', mockNode);
-      fixture.componentRef.setInput('controller', mockController);
-      fixture.detectChanges();
-
-      const infoTabContent = fixture.nativeElement.querySelector('.mat-mdc-tab-body-active .textBox');
-      expect(infoTabContent.textContent).toContain('Dynamips R1 is always on.');
-    });
-  });
-
-  describe('vpcs node type', () => {
-    it('should show vpcs-specific status info', () => {
-      const mockNode = createMockNode({
-        node_type: 'vpcs',
-        name: 'PC1',
-        status: 'started',
-      });
-      const mockController = createMockController();
-      mockInfoService.getInfoAboutNode.mockReturnValue([`Node PC1 is started.`]);
-
-      fixture.componentRef.setInput('node', mockNode);
-      fixture.componentRef.setInput('controller', mockController);
-      fixture.detectChanges();
-
-      const infoTabContent = fixture.nativeElement.querySelector('.mat-mdc-tab-body-active .textBox');
-      expect(infoTabContent.textContent).toContain('Node PC1 is started.');
-    });
-  });
-
-  describe('qemu node type', () => {
-    it('should show qemu-specific info with status', () => {
-      const mockNode = createMockNode({
-        node_type: 'qemu',
-        name: 'Ubuntu VM',
-        status: 'running',
-      });
-      const mockController = createMockController();
-      mockInfoService.getInfoAboutNode.mockReturnValue([`QEMU VM Ubuntu VM is running.`]);
-
-      fixture.componentRef.setInput('node', mockNode);
-      fixture.componentRef.setInput('controller', mockController);
-      fixture.detectChanges();
-
-      const infoTabContent = fixture.nativeElement.querySelector('.mat-mdc-tab-body-active .textBox');
-      expect(infoTabContent.textContent).toContain('QEMU VM Ubuntu VM is running.');
-    });
-  });
-
-  describe('command line tab', () => {
-    it('should show command line not supported message for dynamips', () => {
-      const mockNode = createMockNode({ node_type: 'dynamips' });
-      const mockController = createMockController();
-      mockInfoService.getCommandLine.mockReturnValue(
-        'Command line information is not supported for this type of node.'
-      );
-
-      fixture.componentRef.setInput('node', mockNode);
-      fixture.componentRef.setInput('controller', mockController);
-      fixture.detectChanges();
-
-      // Click on Command line tab
-      const tabLabels = fixture.nativeElement.querySelectorAll('.mat-mdc-tab');
-      tabLabels[2].click();
-      fixture.detectChanges();
-
-      const activeTabContent = fixture.nativeElement.querySelector('.mat-mdc-tab-body-active .textBox');
-      expect(activeTabContent.textContent).toContain('Command line information is not supported');
-    });
-
-    it('should show command line not supported message when command_line is unavailable', () => {
-      const mockNode = createMockNode({ node_type: 'vpcs' });
-      const mockController = createMockController();
-      mockInfoService.getCommandLine.mockReturnValue(
-        'Please start the node in order to get the command line information.'
-      );
-
-      fixture.componentRef.setInput('node', mockNode);
-      fixture.componentRef.setInput('controller', mockController);
-      fixture.detectChanges();
-
-      // Click on Command line tab
-      const tabLabels = fixture.nativeElement.querySelectorAll('.mat-mdc-tab');
-      tabLabels[2].click();
-      fixture.detectChanges();
-
-      const activeTabContent = fixture.nativeElement.querySelector('.mat-mdc-tab-body-active .textBox');
-      expect(activeTabContent.textContent).toContain('Please start the node');
     });
   });
 });

--- a/src/app/components/project-map/info-dialog/info-dialog.component.ts
+++ b/src/app/components/project-map/info-dialog/info-dialog.component.ts
@@ -1,40 +1,70 @@
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, OnInit, inject } from '@angular/core';
-import { MatDialogRef, MatDialogModule } from '@angular/material/dialog';
+import { ChangeDetectionStrategy, Component, Inject, inject } from '@angular/core';
+import { MatDialogModule, MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
-import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatTabsModule } from '@angular/material/tabs';
+import { MarkdownModule } from 'ngx-markdown';
+import { Clipboard } from '@angular/cdk/clipboard';
 import { Node } from '../../../cartography/models/node';
 import { Controller } from '@models/controller';
-import { InfoService } from '@services/info.service';
+import { InfoService, NodeCommandLineInfo, NodeInfo } from '@services/info.service';
+import { ToasterService } from '@services/toaster.service';
+
+export interface InfoDialogData {
+  node: Node;
+  controller: Controller;
+}
 
 @Component({
   standalone: true,
   selector: 'app-info-dialog',
   templateUrl: './info-dialog.component.html',
-  styleUrls: ['./info-dialog.component.scss'],
+  styleUrl: './info-dialog.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [MatDialogModule, MatButtonModule, MatIconModule, MatProgressSpinnerModule, MatTabsModule],
+  imports: [MatDialogModule, MatButtonModule, MatIconModule, MatTooltipModule, MatTabsModule, MarkdownModule],
 })
-export class InfoDialogComponent implements OnInit {
-  public dialogRef = inject(MatDialogRef<InfoDialogComponent>);
-  private infoService = inject(InfoService);
-  private cd = inject(ChangeDetectorRef);
+export class InfoDialogComponent {
+  protected readonly dialogRef = inject(MatDialogRef<InfoDialogComponent>);
+  private readonly infoService = inject(InfoService);
+  private readonly clipboard = inject(Clipboard);
+  private readonly toasterService = inject(ToasterService);
 
-  @Input() controller: Controller;
-  @Input() node: Node;
-  infoList: string[] = [];
-  usage: string = '';
-  commandLine: string = '';
+  readonly info: NodeInfo;
+  readonly commandLineInfo: NodeCommandLineInfo;
+  readonly usage: string;
 
-  ngOnInit() {
-    this.infoList = this.infoService.getInfoAboutNode(this.node, this.controller);
-    this.commandLine = this.infoService.getCommandLine(this.node);
-    this.usage = this.node.usage ? this.node.usage : `No usage information has been provided for this node.`;
-    this.cd.markForCheck();
+  constructor(@Inject(MAT_DIALOG_DATA) public data: InfoDialogData) {
+    this.info = this.infoService.getInfoAboutNode(data.node, data.controller);
+    this.commandLineInfo = this.infoService.getCommandLine(data.node);
+    this.usage = data.node.usage ?? '';
   }
 
-  onCloseClick() {
+  get statusKey(): string {
+    return this.info.alwaysOn ? 'always-on' : this.info.status;
+  }
+
+  get consoleLabel(): string {
+    return this.info.console ? `${this.info.console.type} (port ${this.info.console.port})` : '—';
+  }
+
+  get controllerLabel(): string {
+    return `${this.info.controller.name} (port ${this.info.controller.port})`;
+  }
+
+  copyCommandLine(): void {
+    if (this.commandLineInfo.kind !== 'available') {
+      return;
+    }
+    const copied = this.clipboard.copy(this.commandLineInfo.commandLine);
+    if (copied) {
+      this.toasterService.success('Command line copied to clipboard');
+    } else {
+      this.toasterService.error('Failed to copy to clipboard');
+    }
+  }
+
+  onClose(): void {
     this.dialogRef.close();
   }
 }

--- a/src/app/components/project-map/marker-manager/marker-manager.component.ts
+++ b/src/app/components/project-map/marker-manager/marker-manager.component.ts
@@ -376,18 +376,21 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
     const project = this.project();
     if (!controller || !project) return;
     this.loading.set(true);
-    this.markerService.listDefinitions(controller, project.project_id).pipe(takeUntil(this.destroy$)).subscribe({
-      next: (map: MarkerDefinitionMap) => {
-        this.definitions.set(this.toDefinitionRows(map));
-        this.loading.set(false);
-        this.cdr.markForCheck();
-      },
-      error: (err) => {
-        this.defError.set(err.error?.message || err.message || 'Failed to load definitions');
-        this.loading.set(false);
-        this.cdr.markForCheck();
-      },
-    });
+    this.markerService
+      .listDefinitions(controller, project.project_id)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (map: MarkerDefinitionMap) => {
+          this.definitions.set(this.toDefinitionRows(map));
+          this.loading.set(false);
+          this.cdr.markForCheck();
+        },
+        error: (err) => {
+          this.defError.set(err.error?.message || err.message || 'Failed to load definitions');
+          this.loading.set(false);
+          this.cdr.markForCheck();
+        },
+      });
   }
 
   private buildNodeOptions() {
@@ -421,20 +424,23 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
     // (pre-mutation) response applied last would wipe markers that were just
     // created. Track the newest request and drop stale responses.
     const seq = ++this.aggregateRequestSeq;
-    this.markerService.aggregateList(controller, project.project_id).pipe(takeUntil(this.destroy$)).subscribe({
-      next: (map: AggregateMarkerMap) => {
-        if (seq !== this.aggregateRequestSeq) return; // stale response superseded
-        this.linkGroups.set(this.buildGroups(map));
-        this.markerRegistryService.rebuildFromAggregate(map);
-        this.syncLinkMarkersFromAggregate(map);
-        this.cdr.markForCheck();
-      },
-      error: (err) => {
-        if (seq !== this.aggregateRequestSeq) return;
-        this.linkError.set({ linkId: null, message: err.error?.message || err.message || 'Failed to load markers' });
-        this.cdr.markForCheck();
-      },
-    });
+    this.markerService
+      .aggregateList(controller, project.project_id)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (map: AggregateMarkerMap) => {
+          if (seq !== this.aggregateRequestSeq) return; // stale response superseded
+          this.linkGroups.set(this.buildGroups(map));
+          this.markerRegistryService.rebuildFromAggregate(map);
+          this.syncLinkMarkersFromAggregate(map);
+          this.cdr.markForCheck();
+        },
+        error: (err) => {
+          if (seq !== this.aggregateRequestSeq) return;
+          this.linkError.set({ linkId: null, message: err.error?.message || err.message || 'Failed to load markers' });
+          this.cdr.markForCheck();
+        },
+      });
   }
 
   private toDefinitionRows(map: MarkerDefinitionMap): DefinitionRow[] {
@@ -595,10 +601,13 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
       this.cdr.markForCheck();
     };
     const runUpdate = () => {
-      this.markerService.updateDefinition(controller, project.project_id, editing!, body).pipe(takeUntil(this.destroy$)).subscribe({
-        next: () => done(),
-        error: fail,
-      });
+      this.markerService
+        .updateDefinition(controller, project.project_id, editing!, body)
+        .pipe(takeUntil(this.destroy$))
+        .subscribe({
+          next: () => done(),
+          error: fail,
+        });
     };
 
     if (editing) {
@@ -611,7 +620,7 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
             confirmButtonText: 'Save',
             cancelButtonText: 'Cancel',
           },
-          panelClass: ['base-confirmation-dialog-panel', 'confirmation-warning-panel'],
+          panelClass: ['base-confirmation-dialog-panel', 'confirmation-warning-panel', 'dialog-small-panel'],
           autoFocus: false,
           restoreFocus: false,
         });
@@ -627,10 +636,13 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
         runUpdate();
       }
     } else {
-      this.markerService.createDefinition(controller, project.project_id, body).pipe(takeUntil(this.destroy$)).subscribe({
-        next: () => done(),
-        error: fail,
-      });
+      this.markerService
+        .createDefinition(controller, project.project_id, body)
+        .pipe(takeUntil(this.destroy$))
+        .subscribe({
+          next: () => done(),
+          error: fail,
+        });
     }
   }
 
@@ -667,22 +679,25 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
     if (this.isDeletingDefinition(row.name)) return;
     this.defError.set(null);
     this.markPending(this.deletingDefinition, row.name);
-    this.markerService.deleteDefinition(controller, project.project_id, row.name).pipe(takeUntil(this.destroy$)).subscribe({
-      next: () => {
-        this.clearPending(this.deletingDefinition, row.name);
-        this.toasterService.success(`Marker definition "${row.name}" deleted.`);
-        if (this.editingDefinition() === row.name) this.cancelEditDefinition();
-        this.loadDefinitions();
-        this.loadAggregate();
-      },
-      error: (err) => {
-        this.clearPending(this.deletingDefinition, row.name);
-        const message = err.error?.message || err.message || 'Failed to delete definition';
-        this.defError.set(message);
-        this.toasterService.error(message);
-        this.cdr.markForCheck();
-      },
-    });
+    this.markerService
+      .deleteDefinition(controller, project.project_id, row.name)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: () => {
+          this.clearPending(this.deletingDefinition, row.name);
+          this.toasterService.success(`Marker definition "${row.name}" deleted.`);
+          if (this.editingDefinition() === row.name) this.cancelEditDefinition();
+          this.loadDefinitions();
+          this.loadAggregate();
+        },
+        error: (err) => {
+          this.clearPending(this.deletingDefinition, row.name);
+          const message = err.error?.message || err.message || 'Failed to delete definition';
+          this.defError.set(message);
+          this.toasterService.error(message);
+          this.cdr.markForCheck();
+        },
+      });
   }
 
   // ---- private per-link marker create / delete (Links tab) ----
@@ -856,25 +871,28 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
     if (v.capture_node_id && v.capture_node_id !== MARKER_CAPTURE_AUTO) body.capture_node_id = v.capture_node_id;
     if (v.data_link_type) body.data_link_type = v.data_link_type;
 
-    this.markerService.create(controller, project.project_id, linkId, body).pipe(takeUntil(this.destroy$)).subscribe({
-      next: () => {
-        this.submittingMarker.set(null);
-        this.toasterService.success(`Marker "${body.name}" created.`);
-        // Close the create form and return to the list — same behavior in the
-        // selected-link and aggregate views. (The selected-link view previously
-        // kept the form open via markerForm.reset().)
-        this.toggleAddMarker(linkId);
-        this.refreshLink(linkId);
-        this.loadAggregate();
-      },
-      error: (err) => {
-        this.submittingMarker.set(null);
-        const message = err.error?.message || err.message || 'Failed to create marker';
-        this.linkError.set({ linkId, message });
-        this.toasterService.error(message);
-        this.cdr.markForCheck();
-      },
-    });
+    this.markerService
+      .create(controller, project.project_id, linkId, body)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: () => {
+          this.submittingMarker.set(null);
+          this.toasterService.success(`Marker "${body.name}" created.`);
+          // Close the create form and return to the list — same behavior in the
+          // selected-link and aggregate views. (The selected-link view previously
+          // kept the form open via markerForm.reset().)
+          this.toggleAddMarker(linkId);
+          this.refreshLink(linkId);
+          this.loadAggregate();
+        },
+        error: (err) => {
+          this.submittingMarker.set(null);
+          const message = err.error?.message || err.message || 'Failed to create marker';
+          this.linkError.set({ linkId, message });
+          this.toasterService.error(message);
+          this.cdr.markForCheck();
+        },
+      });
   }
 
   deleteMarker(linkId: string, name: string) {
@@ -885,21 +903,24 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
     if (this.isDeletingMarker(linkId, name)) return;
     this.linkError.set(null);
     this.markPending(this.deletingMarker, key);
-    this.markerService.delete(controller, project.project_id, linkId, name).pipe(takeUntil(this.destroy$)).subscribe({
-      next: () => {
-        this.clearPending(this.deletingMarker, key);
-        this.toasterService.success(`Marker "${name}" deleted.`);
-        this.refreshLink(linkId);
-        this.loadAggregate();
-      },
-      error: (err) => {
-        this.clearPending(this.deletingMarker, key);
-        const message = err.error?.message || err.message || 'Failed to delete marker';
-        this.linkError.set({ linkId, message });
-        this.toasterService.error(message);
-        this.cdr.markForCheck();
-      },
-    });
+    this.markerService
+      .delete(controller, project.project_id, linkId, name)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: () => {
+          this.clearPending(this.deletingMarker, key);
+          this.toasterService.success(`Marker "${name}" deleted.`);
+          this.refreshLink(linkId);
+          this.loadAggregate();
+        },
+        error: (err) => {
+          this.clearPending(this.deletingMarker, key);
+          const message = err.error?.message || err.message || 'Failed to delete marker';
+          this.linkError.set({ linkId, message });
+          this.toasterService.error(message);
+          this.cdr.markForCheck();
+        },
+      });
   }
 
   startEditMarker(linkId: string, marker: GroupMarker) {
@@ -953,22 +974,25 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
     const dir = this.dirToBody(v.direction);
     if (dir) body.direction = dir;
 
-    this.markerService.update(controller, project.project_id, linkId, editing.name, body).pipe(takeUntil(this.destroy$)).subscribe({
-      next: () => {
-        this.submittingEditMarker.set(false);
-        this.toasterService.success(`Marker "${editing.name}" updated.`);
-        this.editingMarker.set(null);
-        this.refreshLink(linkId);
-        this.loadAggregate();
-      },
-      error: (err) => {
-        this.submittingEditMarker.set(false);
-        const message = err.error?.message || err.message || 'Failed to update marker';
-        this.linkError.set({ linkId, message });
-        this.toasterService.error(message);
-        this.cdr.markForCheck();
-      },
-    });
+    this.markerService
+      .update(controller, project.project_id, linkId, editing.name, body)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: () => {
+          this.submittingEditMarker.set(false);
+          this.toasterService.success(`Marker "${editing.name}" updated.`);
+          this.editingMarker.set(null);
+          this.refreshLink(linkId);
+          this.loadAggregate();
+        },
+        error: (err) => {
+          this.submittingEditMarker.set(false);
+          const message = err.error?.message || err.message || 'Failed to update marker';
+          this.linkError.set({ linkId, message });
+          this.toasterService.error(message);
+          this.cdr.markForCheck();
+        },
+      });
   }
 
   // ---- per-definition pause/resume (toggles every inherited copy of a rule) ----
@@ -1050,9 +1074,7 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
    */
   private applyEnabledLocal(linkId: string, name: string, enabled: boolean) {
     const groups = this.linkGroups().map((g) =>
-      g.linkId !== linkId
-        ? g
-        : { ...g, markers: g.markers.map((m) => (m.name === name ? { ...m, enabled } : m)) }
+      g.linkId !== linkId ? g : { ...g, markers: g.markers.map((m) => (m.name === name ? { ...m, enabled } : m)) }
     );
     this.linkGroups.set(groups);
   }
@@ -1062,19 +1084,21 @@ export class MarkerManagerComponent implements OnInit, OnDestroy {
     const controller = this.controller();
     const project = this.project();
     if (!controller || !project) return;
-    this.linkService.getLink(controller, project.project_id, linkId).pipe(takeUntil(this.destroy$)).subscribe({
-      next: (link) => {
-        this.linksDataSource.update(link);
-        const mapLink = this.mapLinksDataSource.get(linkId);
-        if (mapLink) {
-          mapLink.markers = link.markers;
-          this.mapLinksDataSource.update(mapLink);
-        }
-        this.markerRegistryService.reconcileLink(link);
-      },
-      error: (err) =>
-        this.toasterService.error(err.error?.message || err.message || 'Failed to refresh link'),
-    });
+    this.linkService
+      .getLink(controller, project.project_id, linkId)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (link) => {
+          this.linksDataSource.update(link);
+          const mapLink = this.mapLinksDataSource.get(linkId);
+          if (mapLink) {
+            mapLink.markers = link.markers;
+            this.mapLinksDataSource.update(mapLink);
+          }
+          this.markerRegistryService.reconcileLink(link);
+        },
+        error: (err) => this.toasterService.error(err.error?.message || err.message || 'Failed to refresh link'),
+      });
   }
 
   private asNumber(v: unknown): number | null {

--- a/src/app/components/project-map/new-template-dialog/new-template-dialog.component.ts
+++ b/src/app/components/project-map/new-template-dialog/new-template-dialog.component.ts
@@ -45,7 +45,11 @@ import { IosTemplate } from '@models/templates/ios-template';
 import { IouTemplate } from '@models/templates/iou-template';
 import { QemuTemplate } from '@models/templates/qemu-template';
 import { ApplianceService } from '@services/appliances.service';
-import { getVersionSettingProperties, buildApplianceMetadata, normalizeAppliance } from '@services/appliance-normalizer';
+import {
+  getVersionSettingProperties,
+  buildApplianceMetadata,
+  normalizeAppliance,
+} from '@services/appliance-normalizer';
 import { ControllerService } from '@services/controller.service';
 import { DockerService } from '@services/docker.service';
 import { IosService } from '@services/ios.service';
@@ -186,9 +190,7 @@ export class NewTemplateDialogComponent implements OnInit {
 
   readonly lastStepIndex = computed(() => (this.requiresImages() ? 3 : 2));
 
-  readonly browseStepTitle = computed(() =>
-    this.action() === 'install' ? 'Choose appliance' : 'Import appliance'
-  );
+  readonly browseStepTitle = computed(() => (this.action() === 'install' ? 'Choose appliance' : 'Import appliance'));
 
   readonly browseStepDescription = computed(() =>
     this.action() === 'install' ? 'Select from the registry' : 'Upload a .gns3a file'
@@ -426,8 +428,7 @@ export class NewTemplateDialogComponent implements OnInit {
    * editing. Mirrors the behaviour of the manual template creation pages.
    */
   goBack(): void {
-    const controllerId =
-      this.controller?.id ?? parseInt(this.route.snapshot.paramMap.get('controller_id') ?? '', 10);
+    const controllerId = this.controller?.id ?? parseInt(this.route.snapshot.paramMap.get('controller_id') ?? '', 10);
     this.router.navigate(['/controller', controllerId, 'preferences']);
   }
 
@@ -699,65 +700,67 @@ export class NewTemplateDialogComponent implements OnInit {
 
     this.computeChecksumMd5(file, false, (percent) => {
       this.uploadServiceService.processBarCount(percent);
-    }).then((output) => {
-      if (this.checksumCancelled) return;
+    })
+      .then((output) => {
+        if (this.checksumCancelled) return;
 
-      const imageToInstall = this.applianceToInstall()?.images?.find((n) => n.filename === imageName);
+        const imageToInstall = this.applianceToInstall()?.images?.find((n) => n.filename === imageName);
 
-      // Defensive: an imported .gns3a may reference a version image that is
-      // missing from the top-level images array. Bail out cleanly instead of
-      // crashing on imageToInstall.md5sum and leaving the wizard stuck.
-      if (!imageToInstall) {
+        // Defensive: an imported .gns3a may reference a version image that is
+        // missing from the top-level images array. Bail out cleanly instead of
+        // crashing on imageToInstall.md5sum and leaving the wizard stuck.
+        if (!imageToInstall) {
+          this.resetUploadState();
+          this.toasterService.error(`Image '${imageName}' was not found in the appliance definition`);
+          this.cd.markForCheck();
+          return;
+        }
+
+        if (imageToInstall.md5sum !== output) {
+          // Close the checksum snackbar so it does not linger behind the dialog.
+          this.uploadServiceService.processBarCount(null);
+          this.uploadServiceService.setMessage('');
+          this.uploadServiceService.setComputing(false);
+          this.progressService.deactivate();
+          const dialogRef = this.dialog.open(ConfirmationDialogComponent, {
+            autoFocus: '.cancel-button',
+            disableClose: true,
+            panelClass: ['base-confirmation-dialog-panel', 'confirmation-warning-panel', 'dialog-small-panel'],
+            data: {
+              title: 'Use image with a different checksum?',
+              message: `The selected file has MD5 checksum ${output}, but ${imageToInstall.md5sum} was expected.`,
+              note: 'Only continue if you trust this image.',
+              confirmButtonText: 'Use image',
+              tone: 'warning',
+              icon: 'verified_user',
+            },
+          });
+          dialogRef.afterClosed().subscribe((answer: boolean) => {
+            if (answer) {
+              this.openSnackBar();
+              this.uploadServiceService.setMessage('Uploading');
+              this.uploadServiceService.setComputing(false);
+              this.importImageFile(imageName);
+            } else {
+              this.resetUploadState();
+              this.cd.markForCheck();
+            }
+          });
+        } else {
+          this.uploadServiceService.setMessage('Uploading');
+          this.uploadServiceService.setComputing(false);
+          this.uploadServiceService.processBarCount(0);
+          this.importImageFile(imageName);
+        }
+      })
+      .catch((err) => {
+        // A local read error must close the progress UI and clear the queued
+        // file; otherwise the wizard remains in a stale checksum phase.
+        if (this.checksumCancelled) return;
         this.resetUploadState();
-        this.toasterService.error(`Image '${imageName}' was not found in the appliance definition`);
+        this.toasterService.error(typeof err === 'string' ? err : 'MD5 computation failed - error reading the file');
         this.cd.markForCheck();
-        return;
-      }
-
-      if (imageToInstall.md5sum !== output) {
-        // Close the checksum snackbar so it does not linger behind the dialog.
-        this.uploadServiceService.processBarCount(null);
-        this.uploadServiceService.setMessage('');
-        this.uploadServiceService.setComputing(false);
-        this.progressService.deactivate();
-        const dialogRef = this.dialog.open(ConfirmationDialogComponent, {
-          autoFocus: '.cancel-button',
-          disableClose: true,
-          panelClass: ['base-confirmation-dialog-panel', 'confirmation-warning-panel'],
-          data: {
-            title: 'Use image with a different checksum?',
-            message: `The selected file has MD5 checksum ${output}, but ${imageToInstall.md5sum} was expected.`,
-            note: 'Only continue if you trust this image.',
-            confirmButtonText: 'Use image',
-            tone: 'warning',
-            icon: 'verified_user',
-          },
-        });
-        dialogRef.afterClosed().subscribe((answer: boolean) => {
-          if (answer) {
-            this.openSnackBar();
-            this.uploadServiceService.setMessage('Uploading');
-            this.uploadServiceService.setComputing(false);
-            this.importImageFile(imageName);
-          } else {
-            this.resetUploadState();
-            this.cd.markForCheck();
-          }
-        });
-      } else {
-        this.uploadServiceService.setMessage('Uploading');
-        this.uploadServiceService.setComputing(false);
-        this.uploadServiceService.processBarCount(0);
-        this.importImageFile(imageName);
-      }
-    }).catch((err) => {
-      // A local read error must close the progress UI and clear the queued
-      // file; otherwise the wizard remains in a stale checksum phase.
-      if (this.checksumCancelled) return;
-      this.resetUploadState();
-      this.toasterService.error(typeof err === 'string' ? err : 'MD5 computation failed - error reading the file');
-      this.cd.markForCheck();
-    });
+      });
   }
 
   private importImageFile(imageName: string) {
@@ -844,14 +847,17 @@ export class NewTemplateDialogComponent implements OnInit {
    * Check if all images in a version are ready
    */
   isVersionComplete(version: Version): boolean {
-    return this.getVersionImageCount(version) > 0 && this.getVersionReadyCount(version) === this.getVersionImageCount(version);
+    return (
+      this.getVersionImageCount(version) > 0 &&
+      this.getVersionReadyCount(version) === this.getVersionImageCount(version)
+    );
   }
 
   openConfirmationDialog(message: string, link: string) {
     const dialogRef = this.dialog.open(ConfirmationDialogComponent, {
       autoFocus: '.cancel-button',
       disableClose: true,
-      panelClass: ['base-confirmation-dialog-panel', 'confirmation-neutral-panel'],
+      panelClass: ['base-confirmation-dialog-panel', 'confirmation-neutral-panel', 'dialog-small-panel'],
       data: {
         title: 'Open external download?',
         message,
@@ -1128,11 +1134,7 @@ export class NewTemplateDialogComponent implements OnInit {
       .join(', ');
   }
 
-  private computeChecksumMd5(
-    file: File,
-    encode = false,
-    onProgress?: (percent: number) => void
-  ): Promise<string> {
+  private computeChecksumMd5(file: File, encode = false, onProgress?: (percent: number) => void): Promise<string> {
     return new Promise((resolve, reject) => {
       const chunkSize = 2097152;
       const spark = new SparkMD5.ArrayBuffer();

--- a/src/app/components/project-map/node-editors/configurator/docker/configurator-docker.component.ts
+++ b/src/app/components/project-map/node-editors/configurator/docker/configurator-docker.component.ts
@@ -80,7 +80,7 @@ export class ConfiguratorDialogDockerComponent implements OnInit {
   ];
   private conf = {
     autoFocus: false,
-    panelClass: ['base-dialog-panel', 'docker-configurator-dialog-panel'],
+    panelClass: ['base-dialog-panel', 'docker-configurator-dialog-panel', 'dialog-extra-large-panel'],
     disableClose: true,
   };
   private networkConfigurationDialog = {
@@ -117,7 +117,8 @@ export class ConfiguratorDialogDockerComponent implements OnInit {
   readonly extraConfigs = signal<ExtraConfig[]>([]);
   readonly usage = model('');
   readonly netmikoDeviceType = model('');
-  readonly defaultUsername = model(''); readonly defaultPassword = model('');
+  readonly defaultUsername = model('');
+  readonly defaultPassword = model('');
   // inherited values shown as placeholders when the node fields are empty
   readonly defaultUsernamePlaceholder = signal('');
   readonly defaultPasswordPlaceholder = signal('');
@@ -145,7 +146,7 @@ export class ConfiguratorDialogDockerComponent implements OnInit {
         this.environment.set(node.properties.environment || '');
         this.extraHosts.set(node.properties.extra_hosts || '');
         const volumes = node.properties.extra_volumes;
-        this.extraVolumes.set(Array.isArray(volumes) ? volumes.join('\n') : (volumes || ''));
+        this.extraVolumes.set(Array.isArray(volumes) ? volumes.join('\n') : volumes || '');
         this.extraConfigs.set(
           (node.properties.extra_configs || []).map((c) => ({ target: c.target || '', content: c.content ?? '' }))
         );
@@ -159,8 +160,12 @@ export class ConfiguratorDialogDockerComponent implements OnInit {
             next: (templates) => {
               const metadata = templates.find((tpl) => tpl.template_id === node.template_id)?.appliance_metadata;
               if (metadata) {
-                this.defaultUsernamePlaceholder.set(node.default_username ? '' : (metadata.default_username as string) || '');
-                this.defaultPasswordPlaceholder.set(node.default_password ? '' : (metadata.default_password as string) || '');
+                this.defaultUsernamePlaceholder.set(
+                  node.default_username ? '' : (metadata.default_username as string) || ''
+                );
+                this.defaultPasswordPlaceholder.set(
+                  node.default_password ? '' : (metadata.default_password as string) || ''
+                );
                 this.cd.markForCheck();
               }
             },
@@ -328,7 +333,11 @@ export class ConfiguratorDialogDockerComponent implements OnInit {
     this.node.properties.console_http_path = this.consoleHttpPath();
     this.node.properties.environment = this.environment();
     this.node.properties.extra_hosts = this.extraHosts();
-    this.node.properties.extra_volumes = this.extraVolumes() ? this.extraVolumes().split('\n').filter((v) => v.trim()) : [] as any;
+    this.node.properties.extra_volumes = this.extraVolumes()
+      ? this.extraVolumes()
+          .split('\n')
+          .filter((v) => v.trim())
+      : ([] as any);
     const extraConfigs = this.extraConfigs()
       .filter((c) => (c.target || '').trim())
       .map((c) => ({ target: c.target.trim(), content: c.content ?? '' }));

--- a/src/app/components/project-map/node-editors/configurator/qemu/configurator-qemu.component.ts
+++ b/src/app/components/project-map/node-editors/configurator/qemu/configurator-qemu.component.ts
@@ -97,7 +97,7 @@ export class ConfiguratorDialogQemuComponent implements OnInit {
 
   private conf = {
     autoFocus: false,
-    panelClass: ['base-dialog-panel', 'qemu-configurator-dialog-panel'],
+    panelClass: ['base-dialog-panel', 'qemu-configurator-dialog-panel', 'dialog-medium-panel'],
     disableClose: true,
   };
   dialogRefQemuImageCreator;
@@ -116,23 +116,32 @@ export class ConfiguratorDialogQemuComponent implements OnInit {
   readonly auxType = model('');
   readonly consoleAutoStart = model(false);
   // HDD
-  readonly hdaDiskImage = model(''); readonly hdaDiskInterface = model('');
-  readonly hdbDiskImage = model(''); readonly hdbDiskInterface = model('');
-  readonly hdcDiskImage = model(''); readonly hdcDiskInterface = model('');
-  readonly hddDiskImage = model(''); readonly hddDiskInterface = model('');
+  readonly hdaDiskImage = model('');
+  readonly hdaDiskInterface = model('');
+  readonly hdbDiskImage = model('');
+  readonly hdbDiskInterface = model('');
+  readonly hdcDiskImage = model('');
+  readonly hdcDiskInterface = model('');
+  readonly hddDiskImage = model('');
+  readonly hddDiskInterface = model('');
   // CD/DVD
   readonly cdromImage = model('');
   // Advanced
-  readonly initrd = model(''); readonly kernelImage = model('');
-  readonly kernelCommandLine = model(''); readonly biosImage = model('');
+  readonly initrd = model('');
+  readonly kernelImage = model('');
+  readonly kernelCommandLine = model('');
+  readonly biosImage = model('');
   readonly activateCpuThrottling = model(false);
   readonly cpuThrottling = model('');
-  readonly processPriority = model(''); readonly qemuPath = model('');
-  readonly options = model(''); readonly tpm = model(false);
+  readonly processPriority = model('');
+  readonly qemuPath = model('');
+  readonly options = model('');
+  readonly tpm = model(false);
   readonly uefi = model(false);
   readonly usage = model('');
   readonly netmikoDeviceType = model('');
-  readonly defaultUsername = model(''); readonly defaultPassword = model('');
+  readonly defaultUsername = model('');
+  readonly defaultPassword = model('');
   // inherited values shown as placeholders when the node fields are empty
   readonly defaultUsernamePlaceholder = signal('');
   readonly defaultPasswordPlaceholder = signal('');
@@ -140,7 +149,8 @@ export class ConfiguratorDialogQemuComponent implements OnInit {
   readonly maxcpus = model('');
   readonly createConfigDisk = model(false);
   // Network
-  readonly adapters = model(''); readonly macAddress = model('');
+  readonly adapters = model('');
+  readonly macAddress = model('');
   readonly adapterType = model('');
   readonly replicateNetworkState = model(false);
 
@@ -189,8 +199,12 @@ export class ConfiguratorDialogQemuComponent implements OnInit {
             next: (templates) => {
               const metadata = templates.find((tpl) => tpl.template_id === node.template_id)?.appliance_metadata;
               if (metadata) {
-                this.defaultUsernamePlaceholder.set(node.default_username ? '' : (metadata.default_username as string) || '');
-                this.defaultPasswordPlaceholder.set(node.default_password ? '' : (metadata.default_password as string) || '');
+                this.defaultUsernamePlaceholder.set(
+                  node.default_username ? '' : (metadata.default_username as string) || ''
+                );
+                this.defaultPasswordPlaceholder.set(
+                  node.default_password ? '' : (metadata.default_password as string) || ''
+                );
                 this.cd.markForCheck();
               }
             },
@@ -216,17 +230,22 @@ export class ConfiguratorDialogQemuComponent implements OnInit {
             this.allNodeFiles = files.map((f: any) => f.path);
             // Filter disk images based on file_type from Python magic library
             this.projectDiskFiles = files
-              .filter((f: any) => f.file_type?.toLowerCase().includes('qemu') ||
-                                 f.file_type?.toLowerCase().includes('qcow') ||
-                                 f.file_type?.toLowerCase().includes('vmdk') ||
-                                 f.file_type?.toLowerCase().includes('vmware') ||
-                                 f.file_type?.toLowerCase().includes('virtual') ||
-                                 f.file_type?.toLowerCase().includes('disk image'))
+              .filter(
+                (f: any) =>
+                  f.file_type?.toLowerCase().includes('qemu') ||
+                  f.file_type?.toLowerCase().includes('qcow') ||
+                  f.file_type?.toLowerCase().includes('vmdk') ||
+                  f.file_type?.toLowerCase().includes('vmware') ||
+                  f.file_type?.toLowerCase().includes('virtual') ||
+                  f.file_type?.toLowerCase().includes('disk image')
+              )
               .map((f: any) => f.path);
             // Filter ISO images based on file_type
             this.projectIsoFiles = files
-              .filter((f: any) => f.file_type?.toLowerCase().includes('iso 9660') ||
-                                 f.file_type?.toLowerCase().includes('cd-rom'))
+              .filter(
+                (f: any) =>
+                  f.file_type?.toLowerCase().includes('iso 9660') || f.file_type?.toLowerCase().includes('cd-rom')
+              )
               .map((f: any) => f.path);
             this.cd.markForCheck();
           },
@@ -322,16 +341,22 @@ export class ConfiguratorDialogQemuComponent implements OnInit {
         this.allNodeFiles = files.map((f: any) => f.path);
         // Filter disk images based on file_type from Python magic library
         this.projectDiskFiles = files
-          .filter((f: any) => f.file_type?.toLowerCase().includes('qemu') ||
-                             f.file_type?.toLowerCase().includes('qcow') ||
-                             f.file_type?.toLowerCase().includes('vmdk') ||
-                             f.file_type?.toLowerCase().includes('vmware') ||
-                             f.file_type?.toLowerCase().includes('virtual') ||
-                             f.file_type?.toLowerCase().includes('disk image'))
+          .filter(
+            (f: any) =>
+              f.file_type?.toLowerCase().includes('qemu') ||
+              f.file_type?.toLowerCase().includes('qcow') ||
+              f.file_type?.toLowerCase().includes('vmdk') ||
+              f.file_type?.toLowerCase().includes('vmware') ||
+              f.file_type?.toLowerCase().includes('virtual') ||
+              f.file_type?.toLowerCase().includes('disk image')
+          )
           .map((f: any) => f.path);
         // Filter ISO images based on file_type
-        this.projectIsoFiles = files.filter((f: any) => f.file_type?.toLowerCase().includes('iso 9660') ||
-                                                   f.file_type?.toLowerCase().includes('cd-rom')).map((f: any) => f.path);
+        this.projectIsoFiles = files
+          .filter(
+            (f: any) => f.file_type?.toLowerCase().includes('iso 9660') || f.file_type?.toLowerCase().includes('cd-rom')
+          )
+          .map((f: any) => f.path);
         this.cd.markForCheck();
       },
       error: () => {},
@@ -341,7 +366,9 @@ export class ConfiguratorDialogQemuComponent implements OnInit {
   private refreshGlobalImages() {
     this.imageManagerService.getImages(this.controller).subscribe({
       next: (images: any[]) => {
-        this.globalIsoImages = images.filter((img: any) => img.filename?.endsWith('.iso')).map((img: any) => img.filename);
+        this.globalIsoImages = images
+          .filter((img: any) => img.filename?.endsWith('.iso'))
+          .map((img: any) => img.filename);
         this.cd.markForCheck();
       },
       error: () => {},
@@ -352,9 +379,10 @@ export class ConfiguratorDialogQemuComponent implements OnInit {
     const file = event.target.files[0];
     if (!file) return;
     const filename = file.name;
-    const upload$ = target === 'device'
-      ? this.nodeService.uploadNodeFile(this.controller, this.node.project_id, this.node.node_id, filename, file)
-      : this.imageManagerService.uploadedImage(this.controller, false, filename, file);
+    const upload$ =
+      target === 'device'
+        ? this.nodeService.uploadNodeFile(this.controller, this.node.project_id, this.node.node_id, filename, file)
+        : this.imageManagerService.uploadedImage(this.controller, false, filename, file);
     upload$.subscribe({
       next: () => {
         this.node.properties.cdrom_image = filename;
@@ -376,9 +404,10 @@ export class ConfiguratorDialogQemuComponent implements OnInit {
 
   private uploadFile(file: File, signal: { set: (v: string) => void }, propKey: string, target: 'device' | 'global') {
     const filename = file.name;
-    const upload$ = target === 'device'
-      ? this.nodeService.uploadNodeFile(this.controller, this.node.project_id, this.node.node_id, filename, file)
-      : this.imageManagerService.uploadedImage(this.controller, false, filename, file);
+    const upload$ =
+      target === 'device'
+        ? this.nodeService.uploadNodeFile(this.controller, this.node.project_id, this.node.node_id, filename, file)
+        : this.imageManagerService.uploadedImage(this.controller, false, filename, file);
     upload$.subscribe({
       next: () => {
         (this.node.properties as any)[propKey] = filename;
@@ -494,7 +523,7 @@ export class ConfiguratorDialogQemuComponent implements OnInit {
     }
 
     const dialogRef = this.dialog.open(CustomAdaptersComponent, {
-      panelClass: 'custom-adapters-dialog-panel',
+      panelClass: ['custom-adapters-dialog-panel', 'dialog-extra-large-panel'],
       data: {
         adapters: adaptersForDialog,
         networkTypes: this.networkTypes,
@@ -522,11 +551,20 @@ export class ConfiguratorDialogQemuComponent implements OnInit {
 
     // Validate required fields
     const nameValidation = this.validationService.required(this.nodeName(), 'Name');
-    if (!nameValidation.isValid) { this.toasterService.error(nameValidation.errorMessage); return; }
+    if (!nameValidation.isValid) {
+      this.toasterService.error(nameValidation.errorMessage);
+      return;
+    }
     const ramValidation = this.validationService.required(this.ram(), 'RAM');
-    if (!ramValidation.isValid) { this.toasterService.error(ramValidation.errorMessage); return; }
+    if (!ramValidation.isValid) {
+      this.toasterService.error(ramValidation.errorMessage);
+      return;
+    }
     const netmikoValidation = this.validationService.validateNetmikoDeviceType(this.netmikoDeviceType());
-    if (!netmikoValidation.isValid) { this.toasterService.error(netmikoValidation.errorMessage); return; }
+    if (!netmikoValidation.isValid) {
+      this.toasterService.error(netmikoValidation.errorMessage);
+      return;
+    }
 
     // Merge signal values back into node
     this.node.name = this.nodeName();

--- a/src/app/components/project-map/node-editors/configurator/virtualbox/configurator-virtualbox.component.ts
+++ b/src/app/components/project-map/node-editors/configurator/virtualbox/configurator-virtualbox.component.ts
@@ -173,7 +173,7 @@ export class ConfiguratorDialogVirtualBoxComponent implements OnInit {
     }
 
     const dialogRef = this.dialog.open(CustomAdaptersComponent, {
-      panelClass: 'custom-adapters-dialog-panel',
+      panelClass: ['custom-adapters-dialog-panel', 'dialog-extra-large-panel'],
       data: {
         adapters: adaptersForDialog,
         networkTypes: this.networkTypes,

--- a/src/app/components/project-map/node-editors/configurator/vmware/configurator-vmware.component.ts
+++ b/src/app/components/project-map/node-editors/configurator/vmware/configurator-vmware.component.ts
@@ -173,7 +173,7 @@ export class ConfiguratorDialogVmwareComponent implements OnInit {
     }
 
     const dialogRef = this.dialog.open(CustomAdaptersComponent, {
-      panelClass: 'custom-adapters-dialog-panel',
+      panelClass: ['custom-adapters-dialog-panel', 'dialog-extra-large-panel'],
       data: {
         adapters: adaptersForDialog,
         networkTypes: this.networkTypes,

--- a/src/app/components/project-map/node-file-manager-page/node-file-manager-page.component.ts
+++ b/src/app/components/project-map/node-file-manager-page/node-file-manager-page.component.ts
@@ -1,4 +1,15 @@
-import { ChangeDetectionStrategy, Component, OnInit, inject, input, signal, computed, model, viewChild, ElementRef } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  OnInit,
+  inject,
+  input,
+  signal,
+  computed,
+  model,
+  viewChild,
+  ElementRef,
+} from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { MatButtonModule } from '@angular/material/button';
@@ -136,14 +147,24 @@ export class NodeFileManagerPageComponent implements OnInit {
 
   subdirs = computed(() => {
     const entries = this.getDirCache(this.currentPath());
-    return entries.filter((f: any) => f.file_type === 'directory').map((d: any) => ({
-      name: d.path.split('/').pop()!,
-      path: d.path,
-    }));
+    return entries
+      .filter((f: any) => f.file_type === 'directory')
+      .map((d: any) => ({
+        name: d.path.split('/').pop()!,
+        path: d.path,
+      }));
   });
 
   viewItems = computed(() => {
-    const dirs = this.subdirs().map(d => ({ isDir: true as const, name: d.name, path: d.path, size: 0, created_at: '', modified_at: '', file_type: 'directory' }));
+    const dirs = this.subdirs().map((d) => ({
+      isDir: true as const,
+      name: d.name,
+      path: d.path,
+      size: 0,
+      created_at: '',
+      modified_at: '',
+      file_type: 'directory',
+    }));
     const files = this.currentFiles().map((f: any) => ({ isDir: false as const, name: this.fileName(f), ...f }));
     return [...dirs, ...files];
   });
@@ -172,7 +193,7 @@ export class NodeFileManagerPageComponent implements OnInit {
 
   private addToTree(dirPath: string, entries: any[]) {
     const tree = this.treeNodes();
-    const exists = tree.some(n => n.path === dirPath);
+    const exists = tree.some((n) => n.path === dirPath);
     if (exists) return;
     const name = dirPath.split('/').pop() || dirPath;
     tree.push({ name, path: dirPath, expanded: false, loading: false });
@@ -201,7 +222,7 @@ export class NodeFileManagerPageComponent implements OnInit {
   treeIsLastChild(path: string): boolean {
     const parts = path.split('/');
     const parent = parts.slice(0, -1).join('/');
-    const siblings = this.treeNodes().filter(n => {
+    const siblings = this.treeNodes().filter((n) => {
       const np = n.path.split('/');
       np.pop();
       return np.join('/') === parent;
@@ -236,7 +257,7 @@ export class NodeFileManagerPageComponent implements OnInit {
           this.loading.set(false);
           this.toaster.error('Failed to load controller');
           this.cd.markForCheck();
-        },
+        }
       );
     }
   }
@@ -257,7 +278,11 @@ export class NodeFileManagerPageComponent implements OnInit {
         this.loading.set(false);
         this.cd.markForCheck();
       },
-      error: (err) => { this.error.set(err.error?.message || err.message || 'Failed to load files'); this.loading.set(false); this.cd.markForCheck(); },
+      error: (err) => {
+        this.error.set(err.error?.message || err.message || 'Failed to load files');
+        this.loading.set(false);
+        this.cd.markForCheck();
+      },
     });
   }
 
@@ -272,7 +297,9 @@ export class NodeFileManagerPageComponent implements OnInit {
         }
         this.cd.markForCheck();
       },
-      error: (err) => { this.toaster.error(err.error?.message || err.message || 'Failed to load directory'); },
+      error: (err) => {
+        this.toaster.error(err.error?.message || err.message || 'Failed to load directory');
+      },
     });
   }
 
@@ -339,7 +366,12 @@ export class NodeFileManagerPageComponent implements OnInit {
         this.updateLineCount(content);
         this.cd.markForCheck();
       },
-      error: (err) => { this.toaster.error(err.error?.message || err.message || 'Failed to load file'); this.loadingContent.set(false); this.cancelEdit(); this.cd.markForCheck(); },
+      error: (err) => {
+        this.toaster.error(err.error?.message || err.message || 'Failed to load file');
+        this.loadingContent.set(false);
+        this.cancelEdit();
+        this.cd.markForCheck();
+      },
     });
   }
 
@@ -349,12 +381,25 @@ export class NodeFileManagerPageComponent implements OnInit {
     this.saving.set(true);
     const ctrl = this.controller();
     this.nodeService.saveNodeFileContent(ctrl, this.projectId, this.nodeId, file.path, this.editContent()).subscribe({
-      next: () => { this.toaster.success(`File "${file.path}" saved.`); this.saving.set(false); this.editingFile.set(null); this.loadFiles(); this.cd.markForCheck(); },
-      error: (err) => { this.toaster.error(err.error?.message || err.message || 'Failed to save file'); this.saving.set(false); this.cd.markForCheck(); },
+      next: () => {
+        this.toaster.success(`File "${file.path}" saved.`);
+        this.saving.set(false);
+        this.editingFile.set(null);
+        this.loadFiles();
+        this.cd.markForCheck();
+      },
+      error: (err) => {
+        this.toaster.error(err.error?.message || err.message || 'Failed to save file');
+        this.saving.set(false);
+        this.cd.markForCheck();
+      },
     });
   }
 
-  cancelEdit() { this.editingFile.set(null); this.editContent.set(''); }
+  cancelEdit() {
+    this.editingFile.set(null);
+    this.editContent.set('');
+  }
 
   onEditorScroll(event: Event) {
     const textarea = event.target as HTMLElement;
@@ -362,7 +407,9 @@ export class NodeFileManagerPageComponent implements OnInit {
     if (gutter) gutter.scrollTop = textarea.scrollTop;
   }
 
-  updateLineCount(content: string) { this.lineCount.set((content.match(/\n/g) || []).length + 1); }
+  updateLineCount(content: string) {
+    this.lineCount.set((content.match(/\n/g) || []).length + 1);
+  }
 
   onContentChange(value: string) {
     this.editContent.set(value);
@@ -371,13 +418,16 @@ export class NodeFileManagerPageComponent implements OnInit {
   }
 
   getLineState(num: number): 'modified' | 'added' | 'unchanged' {
-    const orig = this.originalLines(), curr = this.currentLines();
+    const orig = this.originalLines(),
+      curr = this.currentLines();
     const idx = num - 1;
     if (idx < orig.length && idx < curr.length) return orig[idx] !== curr[idx] ? 'modified' : 'unchanged';
     return idx < curr.length ? 'added' : 'unchanged';
   }
 
-  lineNumbers(): number[] { return Array.from({ length: this.lineCount() }, (_, i) => i + 1); }
+  lineNumbers(): number[] {
+    return Array.from({ length: this.lineCount() }, (_, i) => i + 1);
+  }
 
   // ── Upload ──
   onUploadClick() {
@@ -385,7 +435,10 @@ export class NodeFileManagerPageComponent implements OnInit {
     input.type = 'file';
     input.style.display = 'none';
     document.body.appendChild(input);
-    input.addEventListener('change', (e) => { this.onFileSelected(e); document.body.removeChild(input); });
+    input.addEventListener('change', (e) => {
+      this.onFileSelected(e);
+      document.body.removeChild(input);
+    });
     input.click();
   }
 
@@ -428,14 +481,25 @@ export class NodeFileManagerPageComponent implements OnInit {
     // Chromium File System Access API path
     if (picker) {
       let handle: any;
-      try { handle = await picker({ suggestedName: file.path }); } catch { return; }
+      try {
+        handle = await picker({ suggestedName: file.path });
+      } catch {
+        return;
+      }
       this.downloading.set(true);
       this.downloadProgress.set(0);
       try {
-        await this.nodeService.streamNodeFileToFile(this.controller(), this.projectId, this.nodeId, file.path, handle, (d) => {
-          this.downloadProgress.set(file.size > 0 ? Math.min(Math.round(d / file.size * 100), 100) : 0);
-          this.cd.markForCheck();
-        });
+        await this.nodeService.streamNodeFileToFile(
+          this.controller(),
+          this.projectId,
+          this.nodeId,
+          file.path,
+          handle,
+          (d) => {
+            this.downloadProgress.set(file.size > 0 ? Math.min(Math.round((d / file.size) * 100), 100) : 0);
+            this.cd.markForCheck();
+          }
+        );
         this.downloading.set(false);
         this.downloadProgress.set(0);
         this.toaster.success(`File "${file.path}" downloaded.`);
@@ -476,10 +540,12 @@ export class NodeFileManagerPageComponent implements OnInit {
   deleteFile(file: any) {
     const isDir = file.isDir || file.file_type === 'directory';
     const ref = this.dialog.open(ConfirmationDialogComponent, {
-      panelClass: ['base-confirmation-dialog-panel', 'confirmation-danger-panel'],
+      panelClass: ['base-confirmation-dialog-panel', 'confirmation-danger-panel', 'dialog-small-panel'],
       data: {
         title: isDir ? 'Delete directory' : 'Delete file',
-        message: `Are you sure you want to delete "${file.path}"?${isDir ? ' This will permanently remove the directory and all its contents.' : ''}`,
+        message: `Are you sure you want to delete "${file.path}"?${
+          isDir ? ' This will permanently remove the directory and all its contents.' : ''
+        }`,
         confirmButtonText: isDir ? 'Delete directory' : 'Delete',
         cancelButtonText: 'Cancel',
       },
@@ -500,13 +566,17 @@ export class NodeFileManagerPageComponent implements OnInit {
           }
           // Remove from tree nodes
           if (file.isDir || file.file_type === 'directory') {
-            this.treeNodes.set(this.treeNodes().filter(n => n.path !== file.path && !n.path.startsWith(file.path + '/')));
+            this.treeNodes.set(
+              this.treeNodes().filter((n) => n.path !== file.path && !n.path.startsWith(file.path + '/'))
+            );
           }
           this.cd.markForCheck();
         },
-        error: (err) => { this.toaster.error(err.error?.message || err.message || 'Delete failed'); this.cd.markForCheck(); },
+        error: (err) => {
+          this.toaster.error(err.error?.message || err.message || 'Delete failed');
+          this.cd.markForCheck();
+        },
       });
     });
   }
-
 }

--- a/src/app/components/project-map/nodes-menu/nodes-menu.component.ts
+++ b/src/app/components/project-map/nodes-menu/nodes-menu.component.ts
@@ -103,7 +103,7 @@ export class NodesMenuComponent {
     const actionType = String(type);
     const actionLabel = actionType.charAt(0).toUpperCase() + actionType.slice(1);
     const dialogRef = this.dialog.open(ConfirmationDialogComponent, {
-      panelClass: ['base-confirmation-dialog-panel', 'confirmation-warning-panel'],
+      panelClass: ['base-confirmation-dialog-panel', 'confirmation-warning-panel', 'dialog-small-panel'],
       autoFocus: '.cancel-button',
       disableClose: true,
       data: {

--- a/src/app/components/project-map/project-map-menu/project-map-menu.component.ts
+++ b/src/app/components/project-map/project-map-menu/project-map-menu.component.ts
@@ -142,7 +142,7 @@ export class ProjectMapMenuComponent implements OnInit, OnDestroy {
 
   public takeScreenshot() {
     const dialogRef = this.dialog.open(ScreenshotDialogComponent, {
-      panelClass: ['base-dialog-panel', 'simple-dialog-panel'],
+      panelClass: ['base-dialog-panel', 'simple-dialog-panel', 'dialog-medium-panel'],
       autoFocus: false,
       disableClose: true,
     });
@@ -547,7 +547,7 @@ export class ProjectMapMenuComponent implements OnInit, OnDestroy {
     const shouldLock = !this.isLocked;
     const actionLabel = shouldLock ? 'Lock' : 'Unlock';
     const dialogRef = this.dialog.open(ConfirmationDialogComponent, {
-      panelClass: ['base-confirmation-dialog-panel', 'confirmation-warning-panel'],
+      panelClass: ['base-confirmation-dialog-panel', 'confirmation-warning-panel', 'dialog-small-panel'],
       autoFocus: '.cancel-button',
       disableClose: true,
       data: {
@@ -663,7 +663,7 @@ export class ProjectMapMenuComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
-    this.projectSubscriptions.forEach(subscription => subscription.unsubscribe());
+    this.projectSubscriptions.forEach((subscription) => subscription.unsubscribe());
     if (this.aiChatStateSubscription) {
       this.aiChatStateSubscription.unsubscribe();
     }
@@ -700,7 +700,7 @@ export class ProjectMapMenuComponent implements OnInit, OnDestroy {
     // Import dynamically to avoid circular dependencies
     import('../fault-injection-dialog/fault-injection-dialog.component').then(({ FaultInjectionDialogComponent }) => {
       const dialogRef = this.dialog.open(FaultInjectionDialogComponent, {
-        panelClass: ['base-dialog-panel', 'fault-injection-dialog-panel'],
+        panelClass: ['base-dialog-panel', 'fault-injection-dialog-panel', 'dialog-medium-panel'],
         backdropClass: 'fault-injection-backdrop',
         autoFocus: false,
         disableClose: true,

--- a/src/app/components/project-map/project-map.component.ts
+++ b/src/app/components/project-map/project-map.component.ts
@@ -512,7 +512,10 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
         // Only open console on the transition from non-started to started
         if (wasStarted || node.status !== 'started' || !node.console_auto_start || node.console_type === 'none') return;
         if (node.console_type === 'vnc') {
-          setTimeout(() => this.onOpenWebConsoleInline({ node, controller: this.controller, project: this.project }), 500);
+          setTimeout(
+            () => this.onOpenWebConsoleInline({ node, controller: this.controller, project: this.project }),
+            500
+          );
         } else {
           this.mapSettingsService.logConsoleSubject.next(true);
           setTimeout(() => this.nodeConsoleService.openConsoleForNode(node), 500);
@@ -566,13 +569,10 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
             this.title.setTitle(this.project.name);
 
             // Initialize visibility settings from project or fallback to localStorage/defaults
-            this.isInterfaceLabelVisible = this.project.show_interface_labels ??
-                                           this.mapSettingsService.showInterfaceLabels ??
-                                           true;
-            this.layersVisibility = this.project.show_layers ??
-                                   localStorage.getItem('layersVisibility') === 'true';
-            this.gridVisibility = this.project.show_grid ??
-                                  localStorage.getItem('gridVisibility') === 'true';
+            this.isInterfaceLabelVisible =
+              this.project.show_interface_labels ?? this.mapSettingsService.showInterfaceLabels ?? true;
+            this.layersVisibility = this.project.show_layers ?? localStorage.getItem('layersVisibility') === 'true';
+            this.gridVisibility = this.project.show_grid ?? localStorage.getItem('gridVisibility') === 'true';
 
             this.toggleShowTopologySummary(this.mapSettingsService.isTopologySummaryVisible);
             const lockKey = `itemLockStatusVisibility_${this.project.project_id}`;
@@ -707,56 +707,53 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
           }
         );
 
-        selectedNodes
-          .forEach((item: MapNode) => {
-            const node = this.mapNodeToNode.convert(item);
-            this.nodeService.delete(this.controller, node).subscribe({
-              next: () => {
-                deletedCounts.nodes++;
-                completion.succeed();
-              },
-              error: (err) => {
-                completion.fail();
-                const message = err.error?.message || err.message || 'Failed to delete node';
-                this.toasterService.error(message);
-                this.cd.markForCheck();
-              },
-            });
+        selectedNodes.forEach((item: MapNode) => {
+          const node = this.mapNodeToNode.convert(item);
+          this.nodeService.delete(this.controller, node).subscribe({
+            next: () => {
+              deletedCounts.nodes++;
+              completion.succeed();
+            },
+            error: (err) => {
+              completion.fail();
+              const message = err.error?.message || err.message || 'Failed to delete node';
+              this.toasterService.error(message);
+              this.cd.markForCheck();
+            },
           });
+        });
 
-        selectedLinks
-          .forEach((item: MapLink) => {
-            const link = this.mapLinkToLink.convert(item);
-            this.linkService.deleteLink(this.controller, link).subscribe({
-              next: () => {
-                deletedCounts.links++;
-                completion.succeed();
-              },
-              error: (err) => {
-                completion.fail();
-                const message = err.error?.message || err.message || 'Failed to delete link';
-                this.toasterService.error(message);
-                this.cd.markForCheck();
-              },
-            });
+        selectedLinks.forEach((item: MapLink) => {
+          const link = this.mapLinkToLink.convert(item);
+          this.linkService.deleteLink(this.controller, link).subscribe({
+            next: () => {
+              deletedCounts.links++;
+              completion.succeed();
+            },
+            error: (err) => {
+              completion.fail();
+              const message = err.error?.message || err.message || 'Failed to delete link';
+              this.toasterService.error(message);
+              this.cd.markForCheck();
+            },
           });
+        });
 
-        selectedDrawings
-          .forEach((item: MapDrawing) => {
-            const drawing = this.mapDrawingToDrawing.convert(item);
-            this.drawingService.delete(this.controller, drawing).subscribe({
-              next: () => {
-                deletedCounts.drawings++;
-                completion.succeed();
-              },
-              error: (err) => {
-                completion.fail();
-                const message = err.error?.message || err.message || 'Failed to delete drawing';
-                this.toasterService.error(message);
-                this.cd.markForCheck();
-              },
-            });
+        selectedDrawings.forEach((item: MapDrawing) => {
+          const drawing = this.mapDrawingToDrawing.convert(item);
+          this.drawingService.delete(this.controller, drawing).subscribe({
+            next: () => {
+              deletedCounts.drawings++;
+              completion.succeed();
+            },
+            error: (err) => {
+              completion.fail();
+              const message = err.error?.message || err.message || 'Failed to delete drawing';
+              this.toasterService.error(message);
+              this.cd.markForCheck();
+            },
           });
+        });
       }
     });
   }
@@ -779,7 +776,9 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
         this.progressService.deactivate();
       },
       error: (err) => {
-        this.toasterService.error('Failed to load project data: ' + (err.error?.message || err.message || 'Unknown error'));
+        this.toasterService.error(
+          'Failed to load project data: ' + (err.error?.message || err.message || 'Unknown error')
+        );
         this.progressService.deactivate();
         this.cd.markForCheck();
       },
@@ -1009,7 +1008,10 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
     const onNodeContextMenu = this.nodeWidget.onContextMenu.subscribe((eventNode: NodeContextMenu) => {
       const selectedItems = this.selectionManager.getSelected();
 
-      if (this.selectionManager.isSelected(eventNode.node) && this.openMenuForSelection(selectedItems, eventNode.event)) {
+      if (
+        this.selectionManager.isSelected(eventNode.node) &&
+        this.openMenuForSelection(selectedItems, eventNode.event)
+      ) {
         return;
       }
 
@@ -1152,7 +1154,9 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
                   err.error?.message || err.message || 'Failed to load nodes'
                 );
               }
-              this.toasterService.error('Failed to load nodes: ' + (err.error?.message || err.message || 'Unknown error'));
+              this.toasterService.error(
+                'Failed to load nodes: ' + (err.error?.message || err.message || 'Unknown error')
+              );
               this.cd.markForCheck();
             },
           });
@@ -1534,7 +1538,7 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
 
     // Calculate index based on position in open windows list
     const openWindows = this.getWebWiresharkInlineWindows();
-    const index = openWindows.findIndex(w => w.link_id === linkId);
+    const index = openWindows.findIndex((w) => w.link_id === linkId);
 
     // Console icon always takes first slot
     let baseOffset = this.TASKBAR_ICON_WIDTH + this.TASKBAR_ICON_GAP;
@@ -1563,7 +1567,7 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
 
     // Calculate index based on position in open windows list
     const openWindows = this.getWebConsoleInlineWindows();
-    const index = openWindows.findIndex(w => w.node_id === nodeId);
+    const index = openWindows.findIndex((w) => w.node_id === nodeId);
 
     // Console icon always takes first slot
     let baseOffset = this.TASKBAR_ICON_WIDTH + this.TASKBAR_ICON_GAP;
@@ -1580,7 +1584,7 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
    */
   public toggleWebConsoleMinimize(nodeId: string): void {
     const windowId = `console-${nodeId}`;
-    const isMinimized = this.windowManagement.minimizedWindows().some(w => w.id === windowId);
+    const isMinimized = this.windowManagement.minimizedWindows().some((w) => w.id === windowId);
     if (isMinimized) {
       this.windowManagement.restoreWindow(windowId);
     } else {
@@ -1593,7 +1597,7 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
    * Toggle console minimize/restore
    */
   public toggleConsoleMinimize(): void {
-    const isMinimized = this.windowManagement.minimizedWindows().some(w => w.id === 'console');
+    const isMinimized = this.windowManagement.minimizedWindows().some((w) => w.id === 'console');
     if (isMinimized) {
       this.windowManagement.restoreWindow('console');
     } else {
@@ -1607,7 +1611,7 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
    */
   public toggleWiresharkMinimize(linkId: string): void {
     const windowId = `wireshark-${linkId}`;
-    const isMinimized = this.windowManagement.minimizedWindows().some(w => w.id === windowId);
+    const isMinimized = this.windowManagement.minimizedWindows().some((w) => w.id === windowId);
     if (isMinimized) {
       this.windowManagement.restoreWindow(windowId);
     } else {
@@ -1782,7 +1786,7 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
     const dialogRef = this.dialog.open(EditProjectDialogComponent, {
       autoFocus: false,
       disableClose: true,
-      panelClass: ['base-dialog-panel', 'configurator-dialog-panel', 'edit-project-dialog-panel'],
+      panelClass: ['base-dialog-panel', 'configurator-dialog-panel', 'edit-project-dialog-panel', 'dialog-large-panel'],
     });
     let instance = dialogRef.componentInstance;
     instance.controller = this.controller;
@@ -2057,12 +2061,12 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
   }
 
   public isFileManagerMinimized(nodeId: string): boolean {
-    return this.windowManagement.minimizedWindows().some(w => w.id === 'filemgr-' + nodeId);
+    return this.windowManagement.minimizedWindows().some((w) => w.id === 'filemgr-' + nodeId);
   }
 
   public toggleFileManagerMinimize(nodeId: string) {
     const id = `filemgr-${nodeId}`;
-    if (this.windowManagement.minimizedWindows().some(w => w.id === id)) {
+    if (this.windowManagement.minimizedWindows().some((w) => w.id === id)) {
       this.windowManagement.restoreWindow(id);
     } else {
       this.windowManagement.minimizeWindow(id, 'filemgr');

--- a/src/app/components/projects/edit-project-dialog/edit-project-dialog.component.ts
+++ b/src/app/components/projects/edit-project-dialog/edit-project-dialog.component.ts
@@ -1,13 +1,4 @@
-import {
-  ChangeDetectionStrategy,
-  Component,
-  OnInit,
-  inject,
-  viewChild,
-  model,
-  signal,
-  computed,
-} from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit, inject, viewChild, model, signal, computed } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { MatDialogRef, MatDialog, MatDialogModule } from '@angular/material/dialog';
@@ -25,7 +16,10 @@ import { Controller } from '@models/controller';
 import { ProjectService } from '@services/project.service';
 import { ToasterService } from '@services/toaster.service';
 import { ReadmeEditorComponent } from './readme-editor/readme-editor.component';
-import { ConfirmationDialogComponent, ConfirmationDialogData } from '../../dialogs/confirmation-dialog/confirmation-dialog.component';
+import {
+  ConfirmationDialogComponent,
+  ConfirmationDialogData,
+} from '../../dialogs/confirmation-dialog/confirmation-dialog.component';
 
 @Component({
   standalone: true,
@@ -90,7 +84,13 @@ export class EditProjectDialogComponent implements OnInit {
 
   // Form validity
   readonly isFormValid = computed(() => {
-    return this.projectName().trim().length > 0 && +this.width() >= 0 && +this.height() >= 0 && +this.nodeGridSize() >= 0 && +this.drawingGridSize() >= 0;
+    return (
+      this.projectName().trim().length > 0 &&
+      +this.width() >= 0 &&
+      +this.height() >= 0 &&
+      +this.nodeGridSize() >= 0 &&
+      +this.drawingGridSize() >= 0
+    );
   });
 
   readonly isVariableFormValid = computed(() => {
@@ -135,7 +135,7 @@ export class EditProjectDialogComponent implements OnInit {
 
   deleteVariable(variable: ProjectVariable): void {
     const dialogRef = this.dialog.open(ConfirmationDialogComponent, {
-      panelClass: ['base-confirmation-dialog-panel', 'confirmation-danger-panel'],
+      panelClass: ['base-confirmation-dialog-panel', 'confirmation-danger-panel', 'dialog-small-panel'],
       autoFocus: '.cancel-button',
       data: {
         title: 'Delete variable?',
@@ -167,10 +167,7 @@ export class EditProjectDialogComponent implements OnInit {
     const originalSorted = [...this.originalVariables].sort((a, b) => a.name.localeCompare(b.name));
 
     for (let i = 0; i < currentSorted.length; i++) {
-      if (
-        currentSorted[i].name !== originalSorted[i].name ||
-        currentSorted[i].value !== originalSorted[i].value
-      ) {
+      if (currentSorted[i].name !== originalSorted[i].name || currentSorted[i].value !== originalSorted[i].value) {
         return true;
       }
     }
@@ -192,14 +189,15 @@ export class EditProjectDialogComponent implements OnInit {
     if (this.hasVariablesChanged()) {
       const dialogData: ConfirmationDialogData = {
         title: 'Global Variables Changed',
-        message: 'Adding or deleting project global variables will cause the GNS3 server to rebuild docker containers in the project to apply the new variables. If containers are running, this operation may take approximately 5-10 seconds. Do you want to continue?',
+        message:
+          'Adding or deleting project global variables will cause the GNS3 server to rebuild docker containers in the project to apply the new variables. If containers are running, this operation may take approximately 5-10 seconds. Do you want to continue?',
         confirmButtonText: 'Yes, apply',
         cancelButtonText: 'No, cancel',
       };
 
       const dialogRef = this.dialog.open(ConfirmationDialogComponent, {
         data: dialogData,
-        panelClass: ['base-confirmation-dialog-panel', 'confirmation-warning-panel'],
+        panelClass: ['base-confirmation-dialog-panel', 'confirmation-warning-panel', 'dialog-small-panel'],
       });
 
       dialogRef.afterClosed().subscribe((result) => {

--- a/src/app/components/projects/projects.component.ts
+++ b/src/app/components/projects/projects.component.ts
@@ -132,7 +132,7 @@ export class ProjectsComponent implements OnInit {
         paginator.firstPage();
       }
     },
-    { allowSignalWrites: true },
+    { allowSignalWrites: true }
   );
 
   /** Avoid destructive bulk actions retaining projects hidden by a filter. */
@@ -151,15 +151,13 @@ export class ProjectsComponent implements OnInit {
     // Filter by name or created_by
     if (search) {
       projects = projects.filter(
-        p =>
-          p.name.toLowerCase().includes(search) ||
-          (p.created_by && p.created_by.toLowerCase().includes(search)),
+        (p) => p.name.toLowerCase().includes(search) || (p.created_by && p.created_by.toLowerCase().includes(search))
       );
     }
 
     // Filter by status
     if (statusFilter !== 'all') {
-      projects = projects.filter(p => p.status === statusFilter);
+      projects = projects.filter((p) => p.status === statusFilter);
     }
 
     // Sort
@@ -234,9 +232,7 @@ export class ProjectsComponent implements OnInit {
     this.settings = this.settingsService.getAll();
 
     // Subscribe to external refresh requests
-    this.projectService.projectListSubject
-      .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe(() => this.refresh());
+    this.projectService.projectListSubject.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => this.refresh());
 
     // Subscribe to global project notifications for incremental updates
     this.notificationService.projectNotificationEmitter
@@ -324,9 +320,9 @@ export class ProjectsComponent implements OnInit {
 
   // ── WebSocket notification handler ────────────────────────────
   private handleProjectNotification(notification: ProjectNotification): void {
-    this._projects.update(projects => {
+    this._projects.update((projects) => {
       const list = [...projects];
-      const index = list.findIndex(p => p.project_id === notification.event.project_id);
+      const index = list.findIndex((p) => p.project_id === notification.event.project_id);
       switch (notification.action) {
         case 'project.created':
           if (index === -1) list.push(notification.event);
@@ -350,7 +346,7 @@ export class ProjectsComponent implements OnInit {
   }
 
   private setProjectLoading(projectId: string, loading: boolean): void {
-    this._loadingProjects.update(set => {
+    this._loadingProjects.update((set) => {
       const next = new Set(set);
       if (loading) next.add(projectId);
       else next.delete(projectId);
@@ -369,7 +365,7 @@ export class ProjectsComponent implements OnInit {
   }
 
   allChecked() {
-    this.displayProjects().forEach(row => this.selection.select(row));
+    this.displayProjects().forEach((row) => this.selection.select(row));
   }
 
   // ── CRUD operations ───────────────────────────────────────────
@@ -482,7 +478,7 @@ export class ProjectsComponent implements OnInit {
     const dialogRef = this.dialog.open(EditProjectDialogComponent, {
       autoFocus: false,
       disableClose: true,
-      panelClass: ['base-dialog-panel', 'configurator-dialog-panel', 'edit-project-dialog-panel'],
+      panelClass: ['base-dialog-panel', 'configurator-dialog-panel', 'edit-project-dialog-panel', 'dialog-large-panel'],
     });
     let instance = dialogRef.componentInstance;
     instance.controller = this.controller;
@@ -551,11 +547,13 @@ export class ProjectsComponent implements OnInit {
   deleteAllFiles() {
     const projects = this.selection.selected;
     const confirmationRef = this.dialog.open(ConfirmationDialogComponent, {
-      panelClass: ['base-confirmation-dialog-panel', 'confirmation-danger-panel'],
+      panelClass: ['base-confirmation-dialog-panel', 'confirmation-danger-panel', 'dialog-small-panel'],
       autoFocus: '.cancel-button',
       data: {
         title: 'Delete selected projects?',
-        message: `${projects.length} selected ${projects.length === 1 ? 'project' : 'projects'} will be permanently deleted.`,
+        message: `${projects.length} selected ${
+          projects.length === 1 ? 'project' : 'projects'
+        } will be permanently deleted.`,
         details: projects.map((project) => project.name || project.project_id),
         note: 'This action cannot be undone.',
         confirmButtonText: projects.length === 1 ? 'Delete project' : 'Delete projects',
@@ -573,7 +571,12 @@ export class ProjectsComponent implements OnInit {
 
   private openProjectDeletionProgress(projects: Project[]): void {
     const dialogRef = this.dialog.open(ConfirmationDeleteAllProjectsComponent, {
-      panelClass: ['base-confirmation-dialog-panel', 'confirmation-danger-panel', 'delete-all-projects-dialog-panel'],
+      panelClass: [
+        'base-confirmation-dialog-panel',
+        'confirmation-danger-panel',
+        'delete-all-projects-dialog-panel',
+        'dialog-small-panel',
+      ],
       autoFocus: false,
       disableClose: true,
       data: {

--- a/src/app/components/resource-pool-details/resource-pool-details.component.ts
+++ b/src/app/components/resource-pool-details/resource-pool-details.component.ts
@@ -114,7 +114,7 @@ export class ResourcePoolDetailsComponent implements OnInit {
   deleteResource(resource: Resource): void {
     this.dialog
       .open(ConfirmationDialogComponent, {
-        panelClass: ['base-confirmation-dialog-panel', 'confirmation-danger-panel'],
+        panelClass: ['base-confirmation-dialog-panel', 'confirmation-danger-panel', 'dialog-small-panel'],
         autoFocus: '.cancel-button',
         data: {
           title: 'Delete resource?',

--- a/src/app/components/resource-pools-management/resource-pools-management.component.ts
+++ b/src/app/components/resource-pools-management/resource-pools-management.component.ts
@@ -155,11 +155,13 @@ export class ResourcePoolsManagementComponent implements OnInit, AfterViewInit {
   onDelete(resourcePoolToDelete: ResourcePool[]) {
     this.dialog
       .open(ConfirmationDialogComponent, {
-        panelClass: ['base-confirmation-dialog-panel', 'confirmation-danger-panel'],
+        panelClass: ['base-confirmation-dialog-panel', 'confirmation-danger-panel', 'dialog-small-panel'],
         autoFocus: '.cancel-button',
         data: {
           title: resourcePoolToDelete.length === 1 ? 'Delete resource pool?' : 'Delete resource pools?',
-          message: `${resourcePoolToDelete.length} selected ${resourcePoolToDelete.length === 1 ? 'pool' : 'pools'} will be permanently deleted.`,
+          message: `${resourcePoolToDelete.length} selected ${
+            resourcePoolToDelete.length === 1 ? 'pool' : 'pools'
+          } will be permanently deleted.`,
           details: resourcePoolToDelete.map((pool) => pool.name),
           note: 'This action cannot be undone.',
           confirmButtonText: resourcePoolToDelete.length === 1 ? 'Delete pool' : 'Delete pools',
@@ -175,7 +177,9 @@ export class ResourcePoolsManagementComponent implements OnInit, AfterViewInit {
           forkJoin(observables).subscribe({
             next: () => {
               this.toasterService.success(
-                `${resourcePoolToDelete.length} resource ${resourcePoolToDelete.length === 1 ? 'pool' : 'pools'} deleted.`
+                `${resourcePoolToDelete.length} resource ${
+                  resourcePoolToDelete.length === 1 ? 'pool' : 'pools'
+                } deleted.`
               );
               this.refresh();
             },

--- a/src/app/components/role-management/role-management.component.ts
+++ b/src/app/components/role-management/role-management.component.ts
@@ -178,11 +178,13 @@ export class RoleManagementComponent implements OnInit, AfterViewInit {
   onDelete(rolesToDelete: Role[]) {
     this.dialog
       .open(ConfirmationDialogComponent, {
-        panelClass: ['base-confirmation-dialog-panel', 'confirmation-danger-panel'],
+        panelClass: ['base-confirmation-dialog-panel', 'confirmation-danger-panel', 'dialog-small-panel'],
         autoFocus: '.cancel-button',
         data: {
           title: rolesToDelete.length === 1 ? 'Delete role?' : 'Delete roles?',
-          message: `${rolesToDelete.length} selected ${rolesToDelete.length === 1 ? 'role' : 'roles'} will be permanently deleted.`,
+          message: `${rolesToDelete.length} selected ${
+            rolesToDelete.length === 1 ? 'role' : 'roles'
+          } will be permanently deleted.`,
           details: rolesToDelete.map((role) => role.name),
           note: 'This action cannot be undone.',
           confirmButtonText: rolesToDelete.length === 1 ? 'Delete role' : 'Delete roles',

--- a/src/app/components/snapshots/snapshot-dialog/snapshot-dialog.component.ts
+++ b/src/app/components/snapshots/snapshot-dialog/snapshot-dialog.component.ts
@@ -94,7 +94,7 @@ export class SnapshotDialogComponent {
 
   restoreSnapshot(snapshot: Snapshot) {
     const dialogRef = this.dialog.open(ConfirmationDialogComponent, {
-      panelClass: ['base-confirmation-dialog-panel', 'confirmation-warning-panel'],
+      panelClass: ['base-confirmation-dialog-panel', 'confirmation-warning-panel', 'dialog-small-panel'],
       autoFocus: '.cancel-button',
       data: {
         title: 'Restore snapshot?',
@@ -135,7 +135,7 @@ export class SnapshotDialogComponent {
 
   deleteSnapshot(snapshot: Snapshot) {
     const dialogRef = this.dialog.open(ConfirmationDialogComponent, {
-      panelClass: ['base-confirmation-dialog-panel', 'confirmation-danger-panel'],
+      panelClass: ['base-confirmation-dialog-panel', 'confirmation-danger-panel', 'dialog-small-panel'],
       autoFocus: '.cancel-button',
       data: {
         title: 'Delete snapshot?',

--- a/src/app/components/template/template.component.spec.ts
+++ b/src/app/components/template/template.component.spec.ts
@@ -444,7 +444,7 @@ describe('TemplateComponent', () => {
           hasBackdrop: false,
           restoreFocus: false,
           position: { top: '56px' },
-          panelClass: ['base-dialog-panel', 'template-dialog-panel', 'add-nodes-dialog-panel'],
+          panelClass: ['base-dialog-panel', 'template-dialog-panel', 'add-nodes-dialog-panel', 'dialog-small-panel'],
         })
       );
     });

--- a/src/app/components/template/template.component.ts
+++ b/src/app/components/template/template.component.ts
@@ -531,7 +531,7 @@ export class TemplateComponent implements OnInit, OnDestroy {
     const narrowViewport = this.document.defaultView?.matchMedia?.('(max-width: 720px)')?.matches ?? false;
     const projectHeaderHeight = this.document.documentElement.dataset['density'] === 'compact' ? '48px' : '56px';
     const dialogRef = this.dialog.open(TemplateListDialogComponent, {
-      panelClass: ['base-dialog-panel', 'template-dialog-panel', 'add-nodes-dialog-panel'],
+      panelClass: ['base-dialog-panel', 'template-dialog-panel', 'add-nodes-dialog-panel', 'dialog-small-panel'],
       data: {
         controller: this.controller(),
         project: this.project(),

--- a/src/app/components/user-management/user-detail-dialog/user-detail-dialog.component.ts
+++ b/src/app/components/user-management/user-detail-dialog/user-detail-dialog.component.ts
@@ -184,7 +184,7 @@ export class UserDetailDialogComponent implements OnInit {
 
   onChangePassword() {
     this.dialog.open(ChangeUserPasswordComponent, {
-      panelClass: ['base-dialog-panel', 'change-user-password-dialog-panel'],
+      panelClass: ['base-dialog-panel', 'change-user-password-dialog-panel', 'dialog-small-panel'],
       data: { user: this.user, controller: this.controller },
     });
   }

--- a/src/app/components/user-management/user-detail/ai-profile-tab/ai-profile-dialog/ai-profile-dialog.component.ts
+++ b/src/app/components/user-management/user-detail/ai-profile-tab/ai-profile-dialog/ai-profile-dialog.component.ts
@@ -252,31 +252,29 @@ export class AiProfileDialogComponent implements OnInit {
   private createForm(): FormGroup {
     this.customFieldsArray = this.fb.array([]);
 
-    return this.fb.group(
-      {
-        name: [
-          '',
-          [
-            Validators.required,
-            Validators.minLength(1),
-            Validators.maxLength(100),
-            Validators.pattern(/^[a-zA-Z0-9_-]+$/),
-            this.duplicateNameValidator(),
-          ],
+    return this.fb.group({
+      name: [
+        '',
+        [
+          Validators.required,
+          Validators.minLength(1),
+          Validators.maxLength(100),
+          Validators.pattern(/^[a-zA-Z0-9_-]+$/),
+          this.duplicateNameValidator(),
         ],
-        model_type: ['text', Validators.required],
-        provider: ['', Validators.required],
-        model: ['', Validators.required],
-        api_key: ['', [Validators.required, Validators.minLength(10)]],
-        base_url: [''],
-        temperature: [0.7, [Validators.min(0), Validators.max(2)]],
-        context_limit: [128, [Validators.required, Validators.min(1), Validators.max(10000)]],
-        context_strategy: ['balanced'],
-        copilot_mode: ['teaching_assistant'],
-        is_default: [false],
-        customFields: this.customFieldsArray,
-      },
-    );
+      ],
+      model_type: ['text', Validators.required],
+      provider: ['', Validators.required],
+      model: ['', Validators.required],
+      api_key: ['', [Validators.required, Validators.minLength(10)]],
+      base_url: [''],
+      temperature: [0.7, [Validators.min(0), Validators.max(2)]],
+      context_limit: [128, [Validators.required, Validators.min(1), Validators.max(10000)]],
+      context_strategy: ['balanced'],
+      copilot_mode: ['teaching_assistant'],
+      is_default: [false],
+      customFields: this.customFieldsArray,
+    });
   }
 
   /**
@@ -533,7 +531,7 @@ export class AiProfileDialogComponent implements OnInit {
    */
   openCustomModeHelp(): void {
     this.dialog.open(ModelTypeHelpDialogComponent, {
-      panelClass: ['base-dialog-panel', 'ai-profile-dialog-panel'],
+      panelClass: ['base-dialog-panel', 'ai-profile-dialog-panel', 'dialog-large-panel'],
     });
   }
 

--- a/src/app/components/user-management/user-detail/ai-profile-tab/ai-profile-tab.component.ts
+++ b/src/app/components/user-management/user-detail/ai-profile-tab/ai-profile-tab.component.ts
@@ -185,7 +185,7 @@ export class AiProfileTabComponent implements OnInit, OnDestroy {
    */
   openCreateDialog(): void {
     const dialogRef = this.dialog.open(AiProfileDialogComponent, {
-      panelClass: ['base-dialog-panel', 'ai-profile-dialog-panel'],
+      panelClass: ['base-dialog-panel', 'ai-profile-dialog-panel', 'dialog-large-panel'],
       data: {
         mode: 'create',
         config: null,
@@ -210,7 +210,7 @@ export class AiProfileTabComponent implements OnInit, OnDestroy {
    */
   openEditDialog(config: LLMModelConfigWithSource): void {
     const dialogRef = this.dialog.open(AiProfileDialogComponent, {
-      panelClass: ['base-dialog-panel', 'ai-profile-dialog-panel'],
+      panelClass: ['base-dialog-panel', 'ai-profile-dialog-panel', 'dialog-large-panel'],
       data: {
         mode: 'edit',
         config: { ...config },
@@ -281,7 +281,7 @@ export class AiProfileTabComponent implements OnInit, OnDestroy {
    */
   deleteConfig(config: LLMModelConfigWithSource): void {
     const dialogRef = this.dialog.open(ConfirmationDialogComponent, {
-      panelClass: ['base-confirmation-dialog-panel', 'confirmation-danger-panel'],
+      panelClass: ['base-confirmation-dialog-panel', 'confirmation-danger-panel', 'dialog-small-panel'],
       autoFocus: '.cancel-button',
       data: {
         title: 'Delete configuration?',

--- a/src/app/components/user-management/user-management.component.ts
+++ b/src/app/components/user-management/user-management.component.ts
@@ -239,7 +239,7 @@ export class UserManagementComponent implements OnInit {
 
   addUser(): void {
     const dialogRef = this.dialog.open(AddUserDialogComponent, {
-      panelClass: ['base-dialog-panel', 'add-user-dialog-panel'],
+      panelClass: ['base-dialog-panel', 'add-user-dialog-panel', 'dialog-medium-panel'],
       autoFocus: false,
       disableClose: true,
     });
@@ -257,7 +257,7 @@ export class UserManagementComponent implements OnInit {
         const data: UserDetailDialogData = { user: userData, controller: this.controller };
         this.dialog
           .open(UserDetailDialogComponent, {
-            panelClass: ['base-dialog-panel', 'configurator-dialog-panel'],
+            panelClass: ['base-dialog-panel', 'configurator-dialog-panel', 'dialog-large-panel'],
             data,
             disableClose: false,
           })
@@ -274,7 +274,7 @@ export class UserManagementComponent implements OnInit {
   openAiProfileDialog(user: User): void {
     const data: AiProfileDialogData = { user, controller: this.controller };
     this.dialog.open(AiProfileDialogComponent, {
-      panelClass: ['base-dialog-panel', 'configurator-dialog-panel'],
+      panelClass: ['base-dialog-panel', 'configurator-dialog-panel', 'dialog-large-panel'],
       data,
       disableClose: false,
     });
@@ -283,7 +283,7 @@ export class UserManagementComponent implements OnInit {
   onDelete(user: User): void {
     this.dialog
       .open(ConfirmationDialogComponent, {
-        panelClass: ['base-confirmation-dialog-panel', 'confirmation-danger-panel'],
+        panelClass: ['base-confirmation-dialog-panel', 'confirmation-danger-panel', 'dialog-small-panel'],
         autoFocus: '.cancel-button',
         data: {
           title: 'Delete user?',
@@ -318,12 +318,12 @@ export class UserManagementComponent implements OnInit {
     const users = [...this.selection.selected];
     this.dialog
       .open(ConfirmationDialogComponent, {
-        panelClass: ['base-confirmation-dialog-panel', 'confirmation-danger-panel'],
+        panelClass: ['base-confirmation-dialog-panel', 'confirmation-danger-panel', 'dialog-small-panel'],
         autoFocus: '.cancel-button',
         data: {
           title: 'Delete users?',
           message: `${users.length} selected users will be permanently deleted.`,
-          details: users.map((user) => user.full_name ? `${user.username} (${user.full_name})` : user.username),
+          details: users.map((user) => (user.full_name ? `${user.username} (${user.full_name})` : user.username)),
           note: 'This action cannot be undone.',
           confirmButtonText: 'Delete users',
           tone: 'danger',

--- a/src/app/components/user-management/user-management.component.ts
+++ b/src/app/components/user-management/user-management.component.ts
@@ -274,7 +274,7 @@ export class UserManagementComponent implements OnInit {
   openAiProfileDialog(user: User): void {
     const data: AiProfileDialogData = { user, controller: this.controller };
     this.dialog.open(AiProfileDialogComponent, {
-      panelClass: ['base-dialog-panel', 'configurator-dialog-panel', 'dialog-large-panel'],
+      panelClass: ['base-dialog-panel', 'configurator-dialog-panel', 'dialog-extra-large-panel'],
       data,
       disableClose: false,
     });

--- a/src/app/components/users/logged-user/logged-user.component.ts
+++ b/src/app/components/users/logged-user/logged-user.component.ts
@@ -31,7 +31,7 @@ export class LoggedUserComponent implements OnInit {
     private controllerService: ControllerService,
     private userService: UserService,
     private toasterService: ToasterService,
-    public dialog: MatDialog,
+    public dialog: MatDialog
   ) {}
 
   ngOnInit() {
@@ -49,7 +49,7 @@ export class LoggedUserComponent implements OnInit {
 
   changePassword(): void {
     this.dialog.open<ChangeUserPasswordComponent>(ChangeUserPasswordComponent, {
-      panelClass: ['base-dialog-panel', 'change-user-password-dialog-panel'],
+      panelClass: ['base-dialog-panel', 'change-user-password-dialog-panel', 'dialog-small-panel'],
       data: { user: this.user(), controller: this.controller, self_update: true },
     });
   }

--- a/src/app/layouts/default-layout/default-layout.component.ts
+++ b/src/app/layouts/default-layout/default-layout.component.ts
@@ -170,7 +170,7 @@ export class DefaultLayoutComponent implements OnInit, OnDestroy {
 
   openLoggedUserDialog() {
     this.dialog.open(LoggedUserComponent, {
-      panelClass: ['base-dialog-panel'],
+      panelClass: ['base-dialog-panel', 'dialog-small-panel'],
       autoFocus: false,
       data: { controllerId: +this.controllerId },
     });
@@ -179,7 +179,7 @@ export class DefaultLayoutComponent implements OnInit, OnDestroy {
   openApiKeyManagementDialog() {
     this.controllerService.get(+this.controllerId).then((controller: Controller) => {
       this.dialog.open(ApiKeyManagementDialogComponent, {
-        panelClass: ['base-dialog-panel', 'configurator-dialog-panel'],
+        panelClass: ['base-dialog-panel', 'configurator-dialog-panel', 'dialog-large-panel'],
         autoFocus: false,
         data: { controller } satisfies ApiKeyManagementDialogData,
       });
@@ -190,7 +190,7 @@ export class DefaultLayoutComponent implements OnInit, OnDestroy {
     this.controllerService.get(+this.controllerId).then((controller: Controller) => {
       this.userService.getInformationAboutLoggedUser(controller).subscribe((user) => {
         this.dialog.open(AiProfileDialogComponent, {
-          panelClass: ['base-dialog-panel', 'configurator-dialog-panel'],
+          panelClass: ['base-dialog-panel', 'configurator-dialog-panel', 'dialog-large-panel'],
           autoFocus: false,
           data: { user, controller },
         });
@@ -210,13 +210,11 @@ export class DefaultLayoutComponent implements OnInit, OnDestroy {
       localStorage.removeItem(`refresh_token_${controller.id}`);
 
       controller.authToken = null;
-      this.controllerService
-        .update(controller)
-        .then((val) => {
-          // Disconnect WebSocket connection on logout
-          this.connectionManager.disconnect();
-          this.router.navigate(['/controller', controller.id, 'login']);
-        });
+      this.controllerService.update(controller).then((val) => {
+        // Disconnect WebSocket connection on logout
+        this.connectionManager.disconnect();
+        this.router.navigate(['/controller', controller.id, 'login']);
+      });
     });
   }
 

--- a/src/app/layouts/default-layout/default-layout.component.ts
+++ b/src/app/layouts/default-layout/default-layout.component.ts
@@ -190,7 +190,7 @@ export class DefaultLayoutComponent implements OnInit, OnDestroy {
     this.controllerService.get(+this.controllerId).then((controller: Controller) => {
       this.userService.getInformationAboutLoggedUser(controller).subscribe((user) => {
         this.dialog.open(AiProfileDialogComponent, {
-          panelClass: ['base-dialog-panel', 'configurator-dialog-panel', 'dialog-large-panel'],
+          panelClass: ['base-dialog-panel', 'configurator-dialog-panel', 'dialog-extra-large-panel'],
           autoFocus: false,
           data: { user, controller },
         });

--- a/src/app/services/dialog-config.service.ts
+++ b/src/app/services/dialog-config.service.ts
@@ -94,8 +94,7 @@ export class DialogConfigService {
       panelClass: ['base-dialog-panel', 'dialog-medium-panel', 'add-controller-dialog-panel'],
     });
 
-    // Custom Adapters Dialog
-    // Size defined in CSS: .custom-adapters-dialog-panel (1000px)
+    // Custom Adapters Dialog - extra-large (1040px) adapter grid.
     this.configs.set('customAdapters', {
       ...extraLargeConfig,
       panelClass: ['base-dialog-panel', 'dialog-extra-large-panel', 'custom-adapters-dialog-panel'],
@@ -107,14 +106,13 @@ export class DialogConfigService {
       panelClass: ['base-dialog-panel', 'dialog-large-panel', 'edit-project-dialog-panel'],
     });
 
-    // Add ACE Dialog
-    // Size defined in CSS: .add-ace-dialog-panel (1000px)
+    // Add ACE Dialog - extra-large (1040px) rule editor.
     this.configs.set('addAce', {
       ...configuratorConfig,
       panelClass: ['base-dialog-panel', 'dialog-extra-large-panel', 'add-ace-dialog-panel'],
     });
 
-    // Start Capture Dialog - simple dialog (500px)
+    // Start Capture Dialog - simple dialog (medium, 720px)
     this.configs.set('startCapture', {
       ...simpleConfig,
       panelClass: ['base-dialog-panel', 'dialog-medium-panel', 'simple-dialog-panel'],
@@ -132,7 +130,7 @@ export class DialogConfigService {
       panelClass: ['base-dialog-panel', 'dialog-medium-panel', 'simple-dialog-panel'],
     });
 
-    // Help Dialog - simple dialog (500px)
+    // Help Dialog - simple dialog (medium, 720px)
     this.configs.set('helpDialog', {
       ...simpleConfig,
       panelClass: ['base-dialog-panel', 'dialog-medium-panel', 'simple-dialog-panel'],

--- a/src/app/services/info.service.spec.ts
+++ b/src/app/services/info.service.spec.ts
@@ -61,162 +61,93 @@ describe('InfoService', () => {
   });
 
   describe('getInfoAboutNode', () => {
-    describe('Cloud Node', () => {
-      it('should return info for cloud node', () => {
-        const cloudNode = { ...mockNode, node_type: 'cloud' as any, name: 'Cloud1' };
-        const result = service.getInfoAboutNode(cloudNode, mockController);
+    describe('Always-On Node Types', () => {
+      it.each([
+        ['cloud', 'Cloud'],
+        ['nat', 'NAT'],
+        ['ethernet_hub', 'Ethernet hub'],
+        ['ethernet_switch', 'Ethernet switch'],
+        ['frame_relay_switch', 'Frame relay switch'],
+        ['atm_switch', 'ATM switch'],
+        ['dynamips', 'Dynamips router'],
+        ['iou', 'IOU device'],
+      ])('should report %s as always on', (nodeType, label) => {
+        const node = { ...mockNode, node_type: nodeType };
+        const result = service.getInfoAboutNode(node, mockController);
 
-        expect(result).toContain('Cloud Cloud1 is always on.');
+        expect(result.alwaysOn).toBe(true);
+        expect(result.statusLabel).toBe('Always on');
+        expect(result.nodeType).toBe(nodeType);
+        expect(result.nodeTypeLabel).toBe(label);
       });
 
-      it('should include controller info for cloud node', () => {
-        const cloudNode = { ...mockNode, node_type: 'cloud' as any };
-        const result = service.getInfoAboutNode(cloudNode, mockController);
-
-        expect(result).toContain('Running on controller Test Controller with port 3080.');
-        expect(result).toContain('Controller ID: 1');
-      });
-    });
-
-    describe('NAT Node', () => {
-      it('should return info for NAT node', () => {
-        const natNode = { ...mockNode, node_type: 'nat' as any, name: 'NAT1' };
-        const result = service.getInfoAboutNode(natNode, mockController);
-
-        expect(result).toContain('NAT NAT1 is always on.');
-      });
-    });
-
-    describe('Ethernet Hub Node', () => {
-      it('should return info for ethernet hub node', () => {
-        const hubNode = { ...mockNode, node_type: 'ethernet-hub' as any, name: 'Hub1' };
+      it('should recognize ethernet hub with underscore spelling (regression)', () => {
+        // GNS3 API emits 'ethernet_hub'; a legacy hyphen check silently matched nothing.
+        const hubNode = { ...mockNode, node_type: 'ethernet_hub' as any, name: 'Hub1' };
         const result = service.getInfoAboutNode(hubNode, mockController);
 
-        expect(result).toContain('Ethernet hub Hub1 is always on.');
+        expect(result.alwaysOn).toBe(true);
+        expect(result.nodeTypeLabel).toBe('Ethernet hub');
       });
     });
 
-    describe('Ethernet Switch Node', () => {
-      it('should return info for ethernet switch node', () => {
-        const switchNode = { ...mockNode, node_type: 'ethernet_switch' as any, name: 'Switch1' };
-        const result = service.getInfoAboutNode(switchNode, mockController);
+    describe('Status-Bearing Node Types', () => {
+      it.each([
+        ['docker', 'Docker container'],
+        ['virtualbox', 'VirtualBox VM'],
+        ['vmware', 'VMware VM'],
+        ['qemu', 'QEMU VM'],
+        ['vpcs', 'VPCS host'],
+      ])('should report %s status', (nodeType, label) => {
+        const node = { ...mockNode, node_type: nodeType, status: 'started' };
+        const result = service.getInfoAboutNode(node, mockController);
 
-        expect(result).toContain('Ethernet switch Switch1 is always on.');
+        expect(result.alwaysOn).toBe(false);
+        expect(result.status).toBe('started');
+        expect(result.statusLabel).toBe('Started');
+        expect(result.nodeTypeLabel).toBe(label);
       });
-    });
 
-    describe('Frame Relay Switch Node', () => {
-      it('should return info for frame relay switch node', () => {
-        const frNode = { ...mockNode, node_type: 'frame_relay_switch' as any, name: 'FR1' };
-        const result = service.getInfoAboutNode(frNode, mockController);
-
-        expect(result).toContain('Frame relay switch FR1 is always on.');
-      });
-    });
-
-    describe('ATM Switch Node', () => {
-      it('should return info for ATM switch node', () => {
-        const atmNode = { ...mockNode, node_type: 'atm_switch' as any, name: 'ATM1' };
-        const result = service.getInfoAboutNode(atmNode, mockController);
-
-        expect(result).toContain('ATM switch ATM1 is always on.');
-      });
-    });
-
-    describe('Docker Node', () => {
-      it('should return info for Docker node with status', () => {
-        const dockerNode = { ...mockNode, node_type: 'docker' as any, name: 'Docker1', status: 'running' };
+      it('should show stopped status', () => {
+        const dockerNode = { ...mockNode, node_type: 'docker' as any, status: 'stopped' };
         const result = service.getInfoAboutNode(dockerNode, mockController);
 
-        expect(result).toContain('Docker Docker1 is running.');
+        expect(result.statusLabel).toBe('Stopped');
       });
 
-      it('should show different status for Docker node', () => {
-        const dockerNode = { ...mockNode, node_type: 'docker' as any, name: 'Docker2', status: 'stopped' };
-        const result = service.getInfoAboutNode(dockerNode, mockController);
-
-        expect(result).toContain('Docker Docker2 is stopped.');
-      });
-    });
-
-    describe('Dynamips Node', () => {
-      it('should return info for dynamips node', () => {
-        const dynamipsNode = { ...mockNode, node_type: 'dynamips' as any, name: 'Dynamips1' };
-        const result = service.getInfoAboutNode(dynamipsNode, mockController);
-
-        expect(result).toContain('Dynamips Dynamips1 is always on.');
-      });
-    });
-
-    describe('VirtualBox Node', () => {
-      it('should return info for VirtualBox node with status', () => {
-        const vbNode = { ...mockNode, node_type: 'virtualbox' as any, name: 'VB1', status: 'started' };
-        const result = service.getInfoAboutNode(vbNode, mockController);
-
-        expect(result).toContain('VirtualBox VM VB1 is started.');
-      });
-    });
-
-    describe('VMware Node', () => {
-      it('should return info for VMware node with status', () => {
-        const vmwareNode = { ...mockNode, node_type: 'vmware' as any, name: 'VMware1', status: 'running' };
-        const result = service.getInfoAboutNode(vmwareNode, mockController);
-
-        expect(result).toContain('VMware VM VMware1 is running.');
-      });
-    });
-
-    describe('QEMU Node', () => {
-      it('should return info for QEMU node with status', () => {
-        const qemuNode = { ...mockNode, node_type: 'qemu' as any, name: 'QEMU1', status: 'started' };
+      it('should show suspended status', () => {
+        const qemuNode = { ...mockNode, node_type: 'qemu' as any, status: 'suspended' };
         const result = service.getInfoAboutNode(qemuNode, mockController);
 
-        expect(result).toContain('QEMU VM QEMU1 is started.');
+        expect(result.statusLabel).toBe('Suspended');
       });
-    });
 
-    describe('IOU Node', () => {
-      it('should return info for IOU node', () => {
-        const iouNode = { ...mockNode, node_type: 'iou' as any, name: 'IOU1' };
-        const result = service.getInfoAboutNode(iouNode, mockController);
+      it('should fall back to the raw status string for unknown statuses', () => {
+        const vmwareNode = { ...mockNode, node_type: 'vmware' as any, status: 'running' };
+        const result = service.getInfoAboutNode(vmwareNode, mockController);
 
-        expect(result).toContain('IOU IOU1 is always on.');
-      });
-    });
-
-    describe('VPCS Node', () => {
-      it('should return info for VPCS node with status', () => {
-        const vpcsNode = { ...mockNode, node_type: 'vpcs' as any, name: 'VPCS1', status: 'started' };
-        const result = service.getInfoAboutNode(vpcsNode, mockController);
-
-        expect(result).toContain('Node VPCS1 is started.');
+        expect(result.statusLabel).toBe('running');
       });
     });
 
     describe('Controller Information', () => {
-      it('should include controller name and port', () => {
+      it('should include controller id, name and port', () => {
         const result = service.getInfoAboutNode(mockNode, mockController);
 
-        expect(result).toContain('Running on controller Test Controller with port 3080.');
+        expect(result.controller).toEqual({ id: 1, name: 'Test Controller', port: 3080 });
       });
 
       it('should include node ID', () => {
         const result = service.getInfoAboutNode(mockNode, mockController);
 
-        expect(result).toContain('Node ID: test-node-uuid');
+        expect(result.nodeId).toBe('test-node-uuid');
       });
 
-      it('should include controller ID', () => {
-        const result = service.getInfoAboutNode(mockNode, mockController);
-
-        expect(result).toContain('Controller ID: 1');
-      });
-
-      it('should work with different controller ports', () => {
+      it('should work with different controllers', () => {
         const customController = { ...mockController, port: 8080, name: 'Custom Controller' };
         const result = service.getInfoAboutNode(mockNode, customController);
 
-        expect(result).toContain('Running on controller Custom Controller with port 8080.');
+        expect(result.controller).toEqual({ id: 1, name: 'Custom Controller', port: 8080 });
       });
     });
 
@@ -224,48 +155,55 @@ describe('InfoService', () => {
       it('should include console info when console_type is telnet', () => {
         const result = service.getInfoAboutNode(mockNode, mockController);
 
-        expect(result).toContain('Console is on port 5000 and type is telnet.');
+        expect(result.console).toEqual({ port: 5000, type: 'telnet' });
       });
 
       it('should include console info when console_type is other types', () => {
         const nodeWithConsole = { ...mockNode, console_type: 'serial' };
         const result = service.getInfoAboutNode(nodeWithConsole, mockController);
 
-        expect(result).toContain('Console is on port 5000 and type is serial.');
+        expect(result.console).toEqual({ port: 5000, type: 'serial' });
       });
 
       it('should not include console info when console_type is none', () => {
         const nodeWithoutConsole = { ...mockNode, console_type: 'none' };
         const result = service.getInfoAboutNode(nodeWithoutConsole, mockController);
 
-        expect(result).not.toContain('Console is on port');
+        expect(result.console).toBeNull();
       });
 
       it('should not include console info when console_type is null', () => {
         const nodeWithoutConsole = { ...mockNode, console_type: 'null' };
         const result = service.getInfoAboutNode(nodeWithoutConsole, mockController);
 
-        expect(result).not.toContain('Console is on port');
+        expect(result.console).toBeNull();
+      });
+
+      it('should not include console info when console_type is empty', () => {
+        const nodeWithoutConsole = { ...mockNode, console_type: '' };
+        const result = service.getInfoAboutNode(nodeWithoutConsole, mockController);
+
+        expect(result.console).toBeNull();
       });
     });
 
     describe('Ports Information', () => {
-      it('should include all ports in info', () => {
+      it('should map all ports', () => {
         const result = service.getInfoAboutNode(mockNode, mockController);
 
-        expect(result).toContain('Port eth0 is ethernet.');
-        expect(result).toContain('Port eth1 is ethernet.');
-        expect(result).toContain('Port serial0 is serial.');
+        expect(result.ports).toEqual([
+          { name: 'eth0', linkType: 'ethernet' },
+          { name: 'eth1', linkType: 'ethernet' },
+          { name: 'serial0', linkType: 'serial' },
+        ]);
       });
 
       it('should handle empty ports array', () => {
         const nodeWithoutPorts = { ...mockNode, ports: [] };
         const result = service.getInfoAboutNode(nodeWithoutPorts, mockController);
 
-        // Should still have other info but no port info
-        expect(result.length).toBeGreaterThan(0);
-        // Verify controller info is present
-        expect(result.some((item) => item.includes('controller'))).toBe(true);
+        expect(result.ports).toEqual([]);
+        expect(result.nodeId).toBe('test-node-uuid');
       });
 
       it('should handle ports with different link types', () => {
@@ -276,112 +214,32 @@ describe('InfoService', () => {
         const nodeWithCustomPorts = { ...mockNode, ports: customPorts };
         const result = service.getInfoAboutNode(nodeWithCustomPorts, mockController);
 
-        expect(result).toContain('Port gi0/0 is gigabitethernet.');
-        expect(result).toContain('Port fa0/0 is fastethernet.');
+        expect(result.ports).toEqual([
+          { name: 'gi0/0', linkType: 'gigabitethernet' },
+          { name: 'fa0/0', linkType: 'fastethernet' },
+        ]);
       });
-    });
-  });
-
-  describe('getInfoAboutPorts', () => {
-    it('should return formatted port information', () => {
-      const result = service.getInfoAboutPorts(mockPorts);
-
-      expect(result).toContain('Ports:');
-      expect(result).toContain('link_type: ethernet');
-      expect(result).toContain('name: eth0');
-      expect(result).toContain('name: eth1');
-    });
-
-    it('should handle empty ports array', () => {
-      const result = service.getInfoAboutPorts([]);
-
-      // When no ports, it just returns "Ports" without colon and spaces trimmed
-      expect(result).toContain('Ports');
-    });
-
-    it('should handle single port', () => {
-      const singlePort = [mockPorts[0]];
-      const result = service.getInfoAboutPorts(singlePort);
-
-      expect(result).toContain('link_type: ethernet');
-      expect(result).toContain('name: eth0');
-    });
-
-    it('should format multiple ports correctly', () => {
-      const result = service.getInfoAboutPorts(mockPorts);
-
-      expect(result).toContain('ethernet');
-      expect(result).toContain('serial');
-    });
-
-    it('should handle ports with special characters in names', () => {
-      const specialPorts = [
-        { name: 'gi0/0.1', link_type: 'gigabitethernet' } as Port,
-        { name: 'fa0/0.100', link_type: 'fastethernet' } as Port,
-      ];
-      const result = service.getInfoAboutPorts(specialPorts);
-
-      expect(result).toContain('gi0/0.1');
-      expect(result).toContain('fa0/0.100');
     });
   });
 
   describe('getCommandLine', () => {
     describe('Unsupported Node Types', () => {
-      it('should return unsupported message for cloud node', () => {
-        const cloudNode = { ...mockNode, node_type: 'cloud' as any };
-        const result = service.getCommandLine(cloudNode);
+      it.each([
+        'cloud',
+        'nat',
+        'ethernet_hub',
+        'ethernet_switch',
+        'frame_relay_switch',
+        'atm_switch',
+        'dynamips',
+        'iou',
+      ])('should return unsupported info for %s node', (nodeType) => {
+        const node = { ...mockNode, node_type: nodeType, command_line: 'ignored' };
+        const result = service.getCommandLine(node);
 
-        expect(result).toBe('Command line information is not supported for this type of node.');
-      });
-
-      it('should return unsupported message for NAT node', () => {
-        const natNode = { ...mockNode, node_type: 'nat' as any };
-        const result = service.getCommandLine(natNode);
-
-        expect(result).toBe('Command line information is not supported for this type of node.');
-      });
-
-      it('should return unsupported message for ethernet hub node', () => {
-        const hubNode = { ...mockNode, node_type: 'ethernet_hub' as any };
-        const result = service.getCommandLine(hubNode);
-
-        expect(result).toBe('Command line information is not supported for this type of node.');
-      });
-
-      it('should return unsupported message for ethernet switch node', () => {
-        const switchNode = { ...mockNode, node_type: 'ethernet_switch' as any };
-        const result = service.getCommandLine(switchNode);
-
-        expect(result).toBe('Command line information is not supported for this type of node.');
-      });
-
-      it('should return unsupported message for frame relay switch node', () => {
-        const frNode = { ...mockNode, node_type: 'frame_relay_switch' as any };
-        const result = service.getCommandLine(frNode);
-
-        expect(result).toBe('Command line information is not supported for this type of node.');
-      });
-
-      it('should return unsupported message for ATM switch node', () => {
-        const atmNode = { ...mockNode, node_type: 'atm_switch' as any };
-        const result = service.getCommandLine(atmNode);
-
-        expect(result).toBe('Command line information is not supported for this type of node.');
-      });
-
-      it('should return unsupported message for dynamips node', () => {
-        const dynamipsNode = { ...mockNode, node_type: 'dynamips' as any };
-        const result = service.getCommandLine(dynamipsNode);
-
-        expect(result).toBe('Command line information is not supported for this type of node.');
-      });
-
-      it('should return unsupported message for IOU node', () => {
-        const iouNode = { ...mockNode, node_type: 'iou' as any };
-        const result = service.getCommandLine(iouNode);
-
-        expect(result).toBe('Command line information is not supported for this type of node.');
+        expect(result.kind).toBe('unsupported');
+        expect(result.commandLine).toBe('');
+        expect(result.message).toBe('Command line information is not supported for this type of node.');
       });
     });
 
@@ -394,7 +252,9 @@ describe('InfoService', () => {
         };
         const result = service.getCommandLine(dockerNode);
 
-        expect(result).toBe('docker run -it ubuntu');
+        expect(result.kind).toBe('available');
+        expect(result.commandLine).toBe('docker run -it ubuntu');
+        expect(result.message).toBe('');
       });
 
       it('should return start message for Docker node when command line is empty', () => {
@@ -405,51 +265,22 @@ describe('InfoService', () => {
         };
         const result = service.getCommandLine(dockerNode);
 
-        expect(result).toBe('Please start the node in order to get the command line information.');
+        expect(result.kind).toBe('not-running');
+        expect(result.commandLine).toBe('');
+        expect(result.message).toBe('Please start the node in order to get the command line information.');
       });
 
-      it('should return command line for VirtualBox node when available', () => {
-        const vbNode = {
-          ...mockNode,
-          node_type: 'virtualbox' as any,
-          command_line: 'VBoxHeadless --startvm vm1',
-        };
-        const result = service.getCommandLine(vbNode);
+      it.each([
+        ['virtualbox', 'VBoxHeadless --startvm vm1'],
+        ['vmware', 'vmrun -T ws start vm1'],
+        ['qemu', 'qemu-system-x86_64 -m 2048'],
+        ['vpcs', 'vpcs -p 5000'],
+      ])('should return command line for %s node when available', (nodeType, commandLine) => {
+        const node = { ...mockNode, node_type: nodeType, command_line: commandLine };
+        const result = service.getCommandLine(node);
 
-        expect(result).toBe('VBoxHeadless --startvm vm1');
-      });
-
-      it('should return command line for VMware node when available', () => {
-        const vmwareNode = {
-          ...mockNode,
-          node_type: 'vmware' as any,
-          command_line: 'vmrun -T ws start vm1',
-        };
-        const result = service.getCommandLine(vmwareNode);
-
-        expect(result).toBe('vmrun -T ws start vm1');
-      });
-
-      it('should return command line for QEMU node when available', () => {
-        const qemuNode = {
-          ...mockNode,
-          node_type: 'qemu' as any,
-          command_line: 'qemu-system-x86_64 -m 2048',
-        };
-        const result = service.getCommandLine(qemuNode);
-
-        expect(result).toBe('qemu-system-x86_64 -m 2048');
-      });
-
-      it('should return command line for VPCS node when available', () => {
-        const vpcsNode = {
-          ...mockNode,
-          node_type: 'vpcs' as any,
-          command_line: 'vpcs -p 5000',
-        };
-        const result = service.getCommandLine(vpcsNode);
-
-        expect(result).toBe('vpcs -p 5000');
+        expect(result.kind).toBe('available');
+        expect(result.commandLine).toBe(commandLine);
       });
 
       it('should return start message for supported nodes without command line', () => {
@@ -460,7 +291,8 @@ describe('InfoService', () => {
         };
         const result = service.getCommandLine(qemuNode);
 
-        expect(result).toBe('Please start the node in order to get the command line information.');
+        expect(result.kind).toBe('not-running');
+        expect(result.message).toBe('Please start the node in order to get the command line information.');
       });
     });
   });
@@ -470,7 +302,8 @@ describe('InfoService', () => {
       const nodeWithEmptyName = { ...mockNode, name: '' };
       const result = service.getInfoAboutNode(nodeWithEmptyName, mockController);
 
-      expect(result.length).toBeGreaterThan(0);
+      expect(result.nodeId).toBe('test-node-uuid');
+      expect(result.nodeTypeLabel).toBe('QEMU VM');
     });
 
     it('should handle controller with special characters in name', () => {
@@ -480,8 +313,7 @@ describe('InfoService', () => {
       };
       const result = service.getInfoAboutNode(mockNode, controllerWithSpecialName);
 
-      // Check that controller info is in the result
-      expect(result.some((item) => item.includes('Controller (Test) #1'))).toBe(true);
+      expect(result.controller.name).toBe('Controller (Test) #1');
     });
 
     it('should handle node with very long command line', () => {
@@ -492,7 +324,8 @@ describe('InfoService', () => {
       };
       const result = service.getCommandLine(nodeWithLongCmd);
 
-      expect(result).toBe(longCommandLine);
+      expect(result.kind).toBe('available');
+      expect(result.commandLine).toBe(longCommandLine);
     });
 
     it('should handle ports with null or undefined properties gracefully', () => {
@@ -503,9 +336,10 @@ describe('InfoService', () => {
       const nodeWithIssuePorts = { ...mockNode, ports: portsWithIssues } as unknown as Node;
       const result = service.getInfoAboutNode(nodeWithIssuePorts, mockController);
 
-      // Should include port info even with null/undefined link_type
-      expect(result.some((item) => item.includes('Port eth0'))).toBe(true);
-      expect(result.some((item) => item.includes('Port eth1'))).toBe(true);
+      expect(result.ports).toEqual([
+        { name: 'eth0', linkType: '' },
+        { name: 'eth1', linkType: '' },
+      ]);
     });
   });
 });

--- a/src/app/services/info.service.ts
+++ b/src/app/services/info.service.ts
@@ -1,80 +1,112 @@
 import { Injectable } from '@angular/core';
 import { Node } from '../cartography/models/node';
-import { Port } from '@models/port';
 import { Controller } from '@models/controller';
+
+/** Node types that have no start/stop lifecycle. Underscore spelling per GNS3 API. */
+const ALWAYS_ON_NODE_TYPES = new Set<string>([
+  'cloud',
+  'nat',
+  'ethernet_hub',
+  'ethernet_switch',
+  'frame_relay_switch',
+  'atm_switch',
+  'dynamips',
+  'iou',
+]);
+
+const NODE_TYPE_LABELS: Record<string, string> = {
+  cloud: 'Cloud',
+  nat: 'NAT',
+  ethernet_hub: 'Ethernet hub',
+  ethernet_switch: 'Ethernet switch',
+  frame_relay_switch: 'Frame relay switch',
+  atm_switch: 'ATM switch',
+  docker: 'Docker container',
+  dynamips: 'Dynamips router',
+  iou: 'IOU device',
+  qemu: 'QEMU VM',
+  virtualbox: 'VirtualBox VM',
+  vmware: 'VMware VM',
+  vpcs: 'VPCS host',
+};
+
+const STATUS_LABELS: Record<string, string> = {
+  started: 'Started',
+  stopped: 'Stopped',
+  suspended: 'Suspended',
+};
+
+export interface NodeInfoConsole {
+  port: number;
+  type: string;
+}
+
+export interface NodeInfoController {
+  id: number | string;
+  name: string;
+  port: number;
+}
+
+export interface NodeInfoPort {
+  name: string;
+  linkType: string;
+}
+
+export interface NodeInfo {
+  status: string;
+  statusLabel: string;
+  alwaysOn: boolean;
+  nodeType: string;
+  nodeTypeLabel: string;
+  nodeId: string;
+  console: NodeInfoConsole | null;
+  controller: NodeInfoController;
+  ports: NodeInfoPort[];
+}
+
+export type NodeCommandLineKind = 'available' | 'unsupported' | 'not-running';
+
+export interface NodeCommandLineInfo {
+  kind: NodeCommandLineKind;
+  commandLine: string;
+  message: string;
+}
 
 @Injectable()
 export class InfoService {
-  getInfoAboutNode(node: Node, controller: Controller): string[] {
-    let infoList: string[] = [];
-    if (node.node_type === 'cloud') {
-      infoList.push(`Cloud ${node.name} is always on.`);
-    } else if (node.node_type === 'nat') {
-      infoList.push(`NAT ${node.name} is always on.`);
-    } else if (node.node_type === 'ethernet-hub') {
-      infoList.push(`Ethernet hub ${node.name} is always on.`);
-    } else if (node.node_type === 'ethernet_switch') {
-      infoList.push(`Ethernet switch ${node.name} is always on.`);
-    } else if (node.node_type === 'frame_relay_switch') {
-      infoList.push(`Frame relay switch ${node.name} is always on.`);
-    } else if (node.node_type === 'atm_switch') {
-      infoList.push(`ATM switch ${node.name} is always on.`);
-    } else if (node.node_type === 'docker') {
-      infoList.push(`Docker ${node.name} is ${node.status}.`);
-    } else if (node.node_type === 'dynamips') {
-      infoList.push(`Dynamips ${node.name} is always on.`);
-    } else if (node.node_type === 'virtualbox') {
-      infoList.push(`VirtualBox VM ${node.name} is ${node.status}.`);
-    } else if (node.node_type === 'vmware') {
-      infoList.push(`VMware VM ${node.name} is ${node.status}.`);
-    } else if (node.node_type === 'qemu') {
-      infoList.push(`QEMU VM ${node.name} is ${node.status}.`);
-    } else if (node.node_type === 'iou') {
-      infoList.push(`IOU ${node.name} is always on.`);
-    } else if (node.node_type === 'vpcs') {
-      infoList.push(`Node ${node.name} is ${node.status}.`);
-    }
-    infoList.push(`Node ID: ${node.node_id}`);
-    infoList.push(`Running on controller ${controller.name} with port ${controller.port}.`);
-    infoList.push(`Controller ID: ${controller.id}`);
-    if (node.console_type !== 'none' && node.console_type !== 'null') {
-      infoList.push(`Console is on port ${node.console} and type is ${node.console_type}.`);
-    }
-    node.ports.forEach((port) => {
-      infoList.push(`Port ${port.name} is ${port.link_type}.`);
-    });
-    //infoList = infoList.concat(this.getInfoAboutPorts(node.ports));
-    return infoList;
+  getInfoAboutNode(node: Node, controller: Controller): NodeInfo {
+    const alwaysOn = ALWAYS_ON_NODE_TYPES.has(node.node_type);
+    return {
+      status: node.status,
+      statusLabel: alwaysOn ? 'Always on' : STATUS_LABELS[node.status] ?? node.status,
+      alwaysOn,
+      nodeType: node.node_type,
+      nodeTypeLabel: NODE_TYPE_LABELS[node.node_type] ?? node.node_type,
+      nodeId: node.node_id,
+      console:
+        node.console_type && node.console_type !== 'none' && node.console_type !== 'null'
+          ? { port: node.console, type: node.console_type }
+          : null,
+      controller: { id: controller.id, name: controller.name, port: controller.port },
+      ports: node.ports.map((port) => ({ name: port.name, linkType: port.link_type ?? '' })),
+    };
   }
 
-  getInfoAboutPorts(ports: Port[]): string {
-    let response: string = `Ports: `;
-    ports.forEach((port) => {
-      response += `link_type: ${port.link_type},\n
-                        name: ${port.name}; `;
-    });
-    response = response.substring(0, response.length - 2);
-    return response;
-  }
-
-  getCommandLine(node: Node): string {
-    if (
-      node.node_type === 'cloud' ||
-      node.node_type === 'nat' ||
-      node.node_type === 'ethernet_hub' ||
-      node.node_type === 'ethernet_switch' ||
-      node.node_type === 'frame_relay_switch' ||
-      node.node_type === 'atm_switch' ||
-      node.node_type === 'dynamips' ||
-      node.node_type === 'iou'
-    ) {
-      return 'Command line information is not supported for this type of node.';
-    } else {
-      if (node.command_line) {
-        return node.command_line;
-      } else {
-        return 'Please start the node in order to get the command line information.';
-      }
+  getCommandLine(node: Node): NodeCommandLineInfo {
+    if (ALWAYS_ON_NODE_TYPES.has(node.node_type)) {
+      return {
+        kind: 'unsupported',
+        commandLine: '',
+        message: 'Command line information is not supported for this type of node.',
+      };
     }
+    if (node.command_line) {
+      return { kind: 'available', commandLine: node.command_line, message: '' };
+    }
+    return {
+      kind: 'not-running',
+      commandLine: '',
+      message: 'Please start the node in order to get the command line information.',
+    };
   }
 }

--- a/src/styles/_dialogs.scss
+++ b/src/styles/_dialogs.scss
@@ -117,24 +117,6 @@
 // Configurator Dialog Styles - Main config pages
 // ============================================= */
 .configurator-dialog-panel {
-  --mat-dialog-container-max-width: 800px;
-
-  mat-dialog-container,
-  .mat-mdc-dialog-container {
-    width: 800px;
-    max-width: 800px;
-    max-height: 80vh;
-
-    .mat-mdc-dialog-surface {
-      border-radius: 16px;
-    }
-  }
-
-  /* Dialog content - with max-height for scroll */
-  .mat-mdc-dialog-content {
-    max-height: calc(80vh - 140px);
-  }
-
   /* Loading state - centered spinner while node data is fetched */
   .configurator-dialog-loading {
     display: flex;
@@ -276,24 +258,6 @@
 // Simple Dialog Styles - Sub dialogs like Image Creator
 // ============================================= */
 .simple-dialog-panel {
-  --mat-dialog-container-max-width: 500px;
-
-  mat-dialog-container,
-  .mat-mdc-dialog-container {
-    width: 500px;
-    max-width: 500px;
-    max-height: 80vh;
-
-    .mat-mdc-dialog-surface {
-      border-radius: 16px;
-    }
-  }
-
-  /* Dialog content - with max-height for scroll */
-  .mat-mdc-dialog-content {
-    max-height: calc(80vh - 140px);
-  }
-
   /* Format options styling */
   .format-options {
     margin: 16px 0;
@@ -406,19 +370,6 @@
 // Custom Adapters Dialog
 // ============================================= */
 .custom-adapters-dialog-panel {
-  --mat-dialog-container-max-width: 1000px;
-
-  mat-dialog-container,
-  .mat-mdc-dialog-container {
-    width: 1000px;
-    max-width: 1000px;
-  }
-
-  .mat-mdc-dialog-content {
-    max-height: 600px;
-    overflow-y: auto;
-  }
-
   /* Add adapter row with note */
   .add-adapter-row {
     display: grid;
@@ -439,34 +390,9 @@
 }
 
 /* =============================================
-// Edit Project Dialog
-// Inherits from base-dialog-panel + configurator-dialog-panel
-// Only overrides width (700px) and max-height (600px)
-// ============================================= */
-.edit-project-dialog-panel {
-  mat-dialog-container,
-  .mat-mdc-dialog-container {
-    width: 700px;
-    max-width: 700px;
-  }
-
-  .mat-mdc-dialog-content {
-    max-height: 600px;
-  }
-}
-
-/* =============================================
 // Add ACE Dialog
 // ============================================= */
 .add-ace-dialog-panel {
-  --mat-dialog-container-max-width: 1000px;
-
-  mat-dialog-container,
-  .mat-mdc-dialog-container {
-    width: 1000px;
-    max-width: 1000px;
-  }
-
   .mat-mdc-dialog-content {
     overflow: visible;
     flex: none;
@@ -497,14 +423,9 @@
 // Inherits from base-dialog-panel + configurator-dialog-panel
 // ============================================= */
 .change-symbol-dialog-panel {
-  --mat-dialog-container-max-width: 800px;
-
   mat-dialog-container,
   .mat-mdc-dialog-container {
-    width: 800px;
-    max-width: 800px;
     height: 600px;
-    max-height: 600px;
   }
 }
 
@@ -570,14 +491,6 @@ body .cdk-overlay-container .mat-mdc-dialog-title::before {
 // For general information and MD5 confirmation
 // ============================================= */
 .information-dialog-panel {
-  --mat-dialog-container-max-width: 500px;
-
-  mat-dialog-container,
-  .mat-mdc-dialog-container {
-    width: 500px;
-    max-width: 500px;
-  }
-
   .mat-mdc-dialog-content {
     color: var(--mat-sys-on-surface-variant);
     font-size: 14px;
@@ -644,86 +557,12 @@ body .cdk-overlay-container .mat-mdc-dialog-title::before {
 // Project Management Dialogs
 // ============================================= */
 
-// Choose Name Dialog - 400px
-.choose-name-dialog-panel {
-  --mat-dialog-container-max-width: 400px;
-
-  mat-dialog-container,
-  .mat-mdc-dialog-container {
-    width: 400px;
-    max-width: 400px;
-  }
-}
-
-// Add Blank Project Dialog - 400px
-.add-blank-project-dialog-panel {
-  --mat-dialog-container-max-width: 400px;
-
-  mat-dialog-container,
-  .mat-mdc-dialog-container {
-    width: 400px;
-    max-width: 400px;
-  }
-}
-
-// Import Project Dialog - 400px
-.import-project-dialog-panel {
-  --mat-dialog-container-max-width: 400px;
-
-  mat-dialog-container,
-  .mat-mdc-dialog-container {
-    width: 400px;
-    max-width: 400px;
-  }
-}
-
-// Delete All Projects Confirmation - 550px x 650px
-.delete-all-projects-dialog-panel {
-  --mat-dialog-container-max-width: 550px;
-
-  mat-dialog-container,
-  .mat-mdc-dialog-container {
-    width: 550px;
-    max-width: 550px;
-    max-height: 650px;
-  }
-
-  .mat-mdc-dialog-content {
-    max-height: calc(650px - 140px);
-    overflow-y: auto;
-  }
-}
-
 /* =============================================
 // Image Manager Dialogs
 // ============================================= */
 
-// Question Dialog - 450px
-.question-dialog-panel {
-  --mat-dialog-container-max-width: 450px;
-
-  mat-dialog-container,
-  .mat-mdc-dialog-container {
-    width: 450px;
-    max-width: 450px;
-  }
-}
-
 // Add Image Dialog - 600px
 .add-image-dialog-panel {
-  --mat-dialog-container-max-width: 600px;
-
-  mat-dialog-container,
-  .mat-mdc-dialog-container {
-    width: 600px;
-    max-width: 600px;
-  }
-
-  .mat-mdc-dialog-content {
-    max-height: none;
-    overflow: visible;
-  }
-
   /* Dialog hint */
   .add-image-dialog-hint {
     display: flex;
@@ -759,74 +598,15 @@ body .cdk-overlay-container .mat-mdc-dialog-title::before {
   }
 }
 
-// Delete All Images Dialog - 550px x 650px
-.delete-all-images-dialog-panel {
-  --mat-dialog-container-max-width: 550px;
-
-  mat-dialog-container,
-  .mat-mdc-dialog-container {
-    width: 550px;
-    max-width: 550px;
-    max-height: 650px;
-  }
-
-  .mat-mdc-dialog-content {
-    max-height: calc(650px - 140px);
-    overflow-y: auto;
-  }
-}
-
 /* =============================================
 // User/Role/Group Management Dialogs
 // ============================================= */
 
 // Add User Dialog - 600px (2-column form layout)
 .add-user-dialog-panel {
-  --mat-dialog-container-max-width: 600px;
-
-  mat-dialog-container,
-  .mat-mdc-dialog-container {
-    width: 600px;
-    max-width: 600px;
-  }
-
   .mat-mdc-dialog-content {
     overflow: visible;
     flex: none;
-  }
-}
-
-// Change User Password Dialog - 400px wide, content-sized height
-.change-user-password-dialog-panel {
-  --mat-dialog-container-max-width: 400px;
-
-  mat-dialog-container,
-  .mat-mdc-dialog-container {
-    width: 400px;
-    max-width: 400px;
-  }
-}
-
-// AI Profile Dialog - 700px
-// Inherits from base-dialog-panel
-// Similar to simple-dialog-panel but with 700px width
-.ai-profile-dialog-panel {
-  --mat-dialog-container-max-width: 700px;
-
-  mat-dialog-container,
-  .mat-mdc-dialog-container {
-    width: 700px;
-    max-width: 700px;
-    max-height: 80vh;
-
-    .mat-mdc-dialog-surface {
-      border-radius: 16px;
-    }
-  }
-
-  /* Dialog content - with max-height for scroll */
-  .mat-mdc-dialog-content {
-    max-height: calc(80vh - 140px);
   }
 }
 
@@ -1691,17 +1471,6 @@ html[data-density='compact'] .node-configurator-dialog-panel {
   }
 }
 
-// QEMU Configurator - 500px
-.qemu-configurator-dialog-panel {
-  --mat-dialog-container-max-width: 500px;
-
-  mat-dialog-container,
-  .mat-mdc-dialog-container {
-    width: 500px;
-    max-width: 500px;
-  }
-}
-
 // Docker Configurator - 800px
 .docker-configurator-dialog-panel:not(.node-configurator-dialog-panel) {
   --mat-dialog-container-max-width: 800px;
@@ -1729,66 +1498,8 @@ html[data-density='compact'] .node-configurator-dialog-panel {
 // Context Menu Action Dialogs
 // ============================================= */
 
-// Idle PC Action - 500px
-.idle-pc-action-dialog-panel {
-  --mat-dialog-container-max-width: 500px;
-
-  mat-dialog-container,
-  .mat-mdc-dialog-container {
-    width: 500px;
-    max-width: 500px;
-  }
-}
-
-// Export Config Action - 500px
-.export-config-action-dialog-panel {
-  --mat-dialog-container-max-width: 500px;
-
-  mat-dialog-container,
-  .mat-mdc-dialog-container {
-    width: 500px;
-    max-width: 500px;
-  }
-}
-
-// Import Config Action - 500px
-.import-config-action-dialog-panel {
-  --mat-dialog-container-max-width: 500px;
-
-  mat-dialog-container,
-  .mat-mdc-dialog-container {
-    width: 500px;
-    max-width: 500px;
-  }
-}
-
-// Show Node Action - 600px x 600px
-.show-node-action-dialog-panel {
-  --mat-dialog-container-max-width: 600px;
-
-  mat-dialog-container,
-  .mat-mdc-dialog-container {
-    width: 600px;
-    max-width: 600px;
-    max-height: 600px;
-  }
-
-  .mat-mdc-dialog-content {
-    max-height: calc(600px - 140px);
-    overflow-y: auto;
-  }
-}
-
 // Edit Text Action - 700px (text editor with multiple columns)
 .edit-text-action-dialog-panel {
-  --mat-dialog-container-max-width: 700px;
-
-  mat-dialog-container,
-  .mat-mdc-dialog-container {
-    width: 700px;
-    max-width: 700px;
-  }
-
   /* Grid layout for form controls - 2 rows x 3 columns */
   .text-editor-grid {
     display: grid;
@@ -1810,26 +1521,10 @@ html[data-density='compact'] .node-configurator-dialog-panel {
 
 // Edit Config Action - 600px x 500px
 .edit-config-action-dialog-panel {
-  --mat-dialog-container-max-width: 600px;
-
   mat-dialog-container,
   .mat-mdc-dialog-container {
-    width: 600px;
-    max-width: 600px;
     height: 500px;
-    max-height: 500px;
   }
-
-  .mat-mdc-dialog-content {
-    max-height: calc(500px - 140px);
-    overflow-y: auto;
-  }
-}
-
-// Edit Style Action - 500px
-// Inherits from base-dialog-panel + simple-dialog-panel
-.edit-style-action-dialog-panel {
-  --mat-dialog-container-max-width: 500px;
 }
 
 /* =============================================
@@ -1857,37 +1552,8 @@ html[data-density='compact'] .node-configurator-dialog-panel {
   }
 }
 
-// Controller Dialogs - 350px/400px
-.controller-dialog-panel {
-  --mat-dialog-container-max-width: 400px;
-
-  mat-dialog-container,
-  .mat-mdc-dialog-container {
-    width: 400px;
-    max-width: 400px;
-  }
-}
-
-.controller-small-dialog-panel {
-  --mat-dialog-container-max-width: 350px;
-
-  mat-dialog-container,
-  .mat-mdc-dialog-container {
-    width: 350px;
-    max-width: 350px;
-  }
-}
-
 // Add ACE Dialog - 1000px
 .add-ace-dialog-panel {
-  --mat-dialog-container-max-width: 1000px;
-
-  mat-dialog-container,
-  .mat-mdc-dialog-container {
-    width: 1000px;
-    max-width: 1000px;
-  }
-
   .mat-mdc-dialog-content {
     overflow: visible;
     flex: none;
@@ -1898,14 +1564,9 @@ html[data-density='compact'] .node-configurator-dialog-panel {
 // Inherits from base-dialog-panel + simple-dialog-panel
 // Only overrides width (700px) and height (500px)
 .add-user-to-group-dialog-panel {
-  --mat-dialog-container-max-width: 700px;
-
   mat-dialog-container,
   .mat-mdc-dialog-container {
-    width: 700px;
-    max-width: 700px;
     height: 500px;
-    max-height: 500px;
 
     .mat-mdc-dialog-surface {
       border-radius: 16px;
@@ -1941,14 +1602,6 @@ html[data-density='compact'] .node-configurator-dialog-panel {
 // Inherits from base-dialog-panel, only overrides width
 // ============================================= */
 .code-block-dialog-panel {
-  --mat-dialog-container-max-width: 1200px;
-
-  mat-dialog-container,
-  .mat-mdc-dialog-container {
-    width: 1200px;
-    max-width: 1200px;
-  }
-
   /* Override content padding for code display */
   .mat-mdc-dialog-content {
     padding: 0;
@@ -2266,6 +1919,11 @@ html[data-density='compact'] .node-configurator-dialog-panel {
   --gns3-dialog-width: 880px;
 }
 
+// Node info dialog - read-only key/value content fits 600px.
+.show-node-action-dialog-panel {
+  --gns3-dialog-width: 600px;
+}
+
 :is(
     .simple-dialog-panel,
     .change-symbol-dialog-panel,
@@ -2274,7 +1932,6 @@ html[data-density='compact'] .node-configurator-dialog-panel {
     .edit-controller-dialog-panel,
     .add-controller-dialog-panel,
     .add-user-dialog-panel,
-    .show-node-action-dialog-panel,
     .edit-text-action-dialog-panel,
     .edit-style-action-dialog-panel,
     .edit-config-action-dialog-panel,

--- a/src/styles/_dialogs.scss
+++ b/src/styles/_dialogs.scss
@@ -1774,11 +1774,19 @@ html[data-density='compact'] .node-configurator-dialog-panel {
     .custom-adapters-dialog-panel
   ):not(.node-configurator-dialog-panel):not(.docker-network-config-dialog-panel) {
   --gns3-dialog-max-height: calc(100vh - 32px);
+  // The viewport cap lives in its own custom property on purpose: the CSS
+  // pipeline strips calc() from min() arguments, and Chrome drops the whole
+  // declaration when a var() shares a min() with the resulting bare sum.
+  --gns3-dialog-viewport-cap: calc(100vw - 32px);
+  // Material caps the overlay pane itself at --mat-dialog-container-max-width
+  // (560px fallback) and the pane constrains the whole flex chain, so the SDS
+  // must feed its width into that token or every dialog collapses to 560px.
+  --mat-dialog-container-max-width: min(var(--gns3-dialog-width, 440px), var(--gns3-dialog-viewport-cap));
 
   mat-dialog-container,
   .mat-mdc-dialog-container {
-    width: min(var(--gns3-dialog-width, 440px), calc(100vw - 32px));
-    max-width: min(var(--gns3-dialog-width, 440px), calc(100vw - 32px));
+    width: min(var(--gns3-dialog-width, 440px), var(--gns3-dialog-viewport-cap));
+    max-width: min(var(--gns3-dialog-width, 440px), var(--gns3-dialog-viewport-cap));
     max-height: var(--gns3-dialog-max-height);
   }
 

--- a/src/styles/_dialogs.scss
+++ b/src/styles/_dialogs.scss
@@ -487,25 +487,6 @@ body .cdk-overlay-container .mat-mdc-dialog-title::before {
 }
 
 /* =============================================
-// Information Dialog Panel
-// For general information and MD5 confirmation
-// ============================================= */
-.information-dialog-panel {
-  .mat-mdc-dialog-content {
-    color: var(--mat-sys-on-surface-variant);
-    font-size: 14px;
-    line-height: 1.6;
-  }
-
-  .information-dialog__message {
-    margin: 0;
-    color: var(--mat-sys-on-surface-variant);
-    font-size: 14px;
-    line-height: 1.6;
-  }
-}
-
-/* =============================================
 // Confirmation Danger Panel
 // For dangerous operations (delete, remove, etc.)
 // ============================================= */
@@ -534,22 +515,6 @@ body .cdk-overlay-container .mat-mdc-dialog-title::before {
   button.mat-mdc-raised-button {
     background-color: var(--mat-sys-tertiary);
     color: var(--mat-sys-on-tertiary);
-  }
-}
-
-/* =============================================
-// Confirmation Info Panel
-// For informational confirmations
-// ============================================= */
-.confirmation-info-panel {
-  .mat-mdc-dialog-surface {
-    border: 1px solid var(--mat-sys-primary-container);
-  }
-
-  .confirm-button,
-  button.mat-mdc-raised-button {
-    background-color: var(--mat-sys-primary);
-    color: var(--mat-sys-on-primary);
   }
 }
 
@@ -1471,16 +1436,8 @@ html[data-density='compact'] .node-configurator-dialog-panel {
   }
 }
 
-// Docker Configurator - 800px
+// Docker Configurator (standalone template-details shell)
 .docker-configurator-dialog-panel:not(.node-configurator-dialog-panel) {
-  --mat-dialog-container-max-width: 800px;
-
-  mat-dialog-container,
-  .mat-mdc-dialog-container {
-    width: 800px;
-    max-width: 800px;
-  }
-
   /* Two column grid layout for form fields */
   .two-column-grid {
     display: grid;
@@ -1530,14 +1487,6 @@ html[data-density='compact'] .node-configurator-dialog-panel {
 /* =============================================
 // Other Component Dialogs
 // ============================================= */
-
-// Template Dialog - 600px
-// The old explicit width rules never won against the Standard Dialog System
-// (which resolved --gns3-dialog-width to 720px via the legacy group below);
-// set the variable instead so 600px actually applies.
-.template-dialog-panel {
-  --gns3-dialog-width: 600px;
-}
 
 // Add-nodes dialog: the collapsed "Advanced options" expansion panel lies flat
 // on the dialog surface; body content is inset and given vertical breathing
@@ -1899,66 +1848,8 @@ html[data-density='compact'] .node-configurator-dialog-panel {
   }
 }
 
-// Legacy assignments kept as compatibility aliases while callers migrate to
-// dialog-small-panel, dialog-medium-panel, dialog-large-panel, and
-// dialog-extra-large-panel.
-:is(.configurator-dialog-panel:not(.node-configurator-dialog-panel), .edit-project-dialog-panel) {
-  --gns3-dialog-width: 880px;
-}
-
-:is(
-    .custom-adapters-dialog-panel,
-    .add-ace-dialog-panel,
-    .docker-configurator-dialog-panel:not(.node-configurator-dialog-panel),
-    .code-block-dialog-panel
-  ) {
-  --gns3-dialog-width: 1040px;
-}
-
-.ai-profile-dialog-panel {
-  --gns3-dialog-width: 880px;
-}
-
-// Node info dialog - read-only key/value content fits 600px.
-.show-node-action-dialog-panel {
-  --gns3-dialog-width: 600px;
-}
-
-:is(
-    .simple-dialog-panel,
-    .change-symbol-dialog-panel,
-    .controller-dialog-panel,
-    .controller-small-dialog-panel,
-    .edit-controller-dialog-panel,
-    .add-controller-dialog-panel,
-    .add-user-dialog-panel,
-    .edit-text-action-dialog-panel,
-    .edit-style-action-dialog-panel,
-    .edit-config-action-dialog-panel,
-    .export-config-action-dialog-panel,
-    .import-config-action-dialog-panel,
-    .qemu-configurator-dialog-panel,
-    .fault-injection-dialog-panel
-  ) {
-  --gns3-dialog-width: 720px;
-}
-
-:is(
-    .base-confirmation-dialog-panel,
-    .information-dialog-panel,
-    .question-dialog-panel,
-    .choose-name-dialog-panel,
-    .add-blank-project-dialog-panel,
-    .import-project-dialog-panel,
-    .add-image-dialog-panel,
-    .delete-all-images-dialog-panel,
-    .delete-all-projects-dialog-panel,
-    .change-user-password-dialog-panel,
-    .idle-pc-action-dialog-panel
-  ) {
-  --gns3-dialog-width: 440px;
-}
-
+// The four standard sizes are the single width source for the SDS shell;
+// every dialog call site declares exactly one of them.
 .dialog-small-panel {
   --gns3-dialog-width: 440px;
 }
@@ -1973,6 +1864,13 @@ html[data-density='compact'] .node-configurator-dialog-panel {
 
 .dialog-extra-large-panel {
   --gns3-dialog-width: 1040px;
+}
+
+// Width deviations from the four standard sizes. Declared AFTER the size
+// classes so the override wins regardless of class order on the panel element.
+// Template gallery and read-only node info fit 600px.
+:is(.template-dialog-panel, .show-node-action-dialog-panel) {
+  --gns3-dialog-width: 600px;
 }
 
 // Shared destructive actions use semantic error tokens in every dialog size.
@@ -1996,19 +1894,7 @@ button.destructive-icon-button {
 
 // Short dialogs still need a clear content area between their title and
 // action row. This also covers legacy forms without mat-dialog-content.
-:is(
-    .dialog-small-panel,
-    .information-dialog-panel,
-    .question-dialog-panel,
-    .choose-name-dialog-panel,
-    .add-blank-project-dialog-panel,
-    .import-project-dialog-panel,
-    .add-image-dialog-panel,
-    .delete-all-images-dialog-panel,
-    .delete-all-projects-dialog-panel,
-    .change-user-password-dialog-panel,
-    .idle-pc-action-dialog-panel
-  ) {
+.dialog-small-panel {
   .mat-mdc-dialog-content,
   .modal-form-container {
     padding-block: 24px;
@@ -2076,20 +1962,7 @@ html[data-density='compact'] .mat-mdc-dialog-actions {
   }
 }
 
-html[data-density='compact']
-  :is(
-    .dialog-small-panel,
-    .information-dialog-panel,
-    .question-dialog-panel,
-    .choose-name-dialog-panel,
-    .add-blank-project-dialog-panel,
-    .import-project-dialog-panel,
-    .add-image-dialog-panel,
-    .delete-all-images-dialog-panel,
-    .delete-all-projects-dialog-panel,
-    .change-user-password-dialog-panel,
-    .idle-pc-action-dialog-panel
-  ) {
+html[data-density='compact'] .dialog-small-panel {
   .mat-mdc-dialog-content,
   .modal-form-container {
     padding-block: 16px;

--- a/src/styles/_dialogs.scss
+++ b/src/styles/_dialogs.scss
@@ -1866,6 +1866,25 @@ html[data-density='compact'] .node-configurator-dialog-panel {
   --gns3-dialog-width: 1040px;
 }
 
+// Optional viewport-ratio height tiers. Opt-in modifiers combined with a
+// size class: dialogs stay content-sized unless they declare one. Height is
+// scoped to the tier (not the SDS core) so purpose-built fixed-height rules
+// elsewhere keep winning. The core max-height still clamps against the
+// viewport.
+.dialog-height-60-panel {
+  mat-dialog-container,
+  .mat-mdc-dialog-container {
+    height: 60vh;
+  }
+}
+
+.dialog-height-80-panel {
+  mat-dialog-container,
+  .mat-mdc-dialog-container {
+    height: 80vh;
+  }
+}
+
 // Width deviations from the four standard sizes. Declared AFTER the size
 // classes so the override wins regardless of class order on the panel element.
 // Template gallery and read-only node info fit 600px.

--- a/src/styles/_markdown.scss
+++ b/src/styles/_markdown.scss
@@ -198,10 +198,134 @@ app-chat-message-list {
         border-color: var(--mat-sys-primary);
 
         &::after {
-          background: linear-gradient(transparent, color-mix(in srgb, var(--mat-sys-primary) 20%, var(--mat-sys-surface-container-highest)));
+          background: linear-gradient(
+            transparent,
+            color-mix(in srgb, var(--mat-sys-primary) 20%, var(--mat-sys-surface-container-highest))
+          );
           color: var(--mat-sys-on-primary-container);
         }
       }
+    }
+  }
+}
+
+/* =============================================
+// Node Info Dialog Markdown Styles
+// (Usage instructions tab)
+// ============================================= */
+markdown.info-dialog__usage {
+  display: block;
+  line-height: 1.6;
+  word-wrap: break-word;
+  font-size: 14px;
+  color: var(--mat-sys-on-surface);
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    color: var(--mat-sys-on-surface);
+    font-weight: 600;
+  }
+
+  h1 {
+    font-size: 16px;
+    margin: 12px 0 8px;
+  }
+
+  h2 {
+    font-size: 15px;
+    margin: 10px 0 6px;
+  }
+
+  h3,
+  h4,
+  h5,
+  h6 {
+    font-size: 14px;
+    margin: 8px 0 4px;
+  }
+
+  p {
+    margin: 8px 0;
+  }
+
+  a {
+    color: var(--mat-sys-primary);
+    text-decoration: underline;
+
+    &:hover {
+      text-decoration: none;
+    }
+  }
+
+  ul,
+  ol {
+    padding-left: 24px;
+    margin: 4px 0;
+  }
+
+  li {
+    margin: 4px 0;
+  }
+
+  blockquote {
+    border-left: 3px solid var(--mat-sys-outline);
+    padding-left: 12px;
+    margin: 8px 0;
+    color: var(--mat-sys-on-surface-variant);
+  }
+
+  table {
+    border-collapse: collapse;
+    margin: 8px 0;
+
+    th,
+    td {
+      border: 1px solid var(--mat-sys-outline);
+      padding: 6px 12px;
+      text-align: left;
+    }
+
+    th {
+      background-color: var(--mat-sys-surface-container);
+      color: var(--mat-sys-on-surface);
+    }
+  }
+
+  hr {
+    border: none;
+    border-top: 1px solid var(--mat-sys-outline);
+    margin: 12px 0;
+  }
+
+  img {
+    max-width: 100%;
+    height: auto;
+  }
+
+  code {
+    background-color: color-mix(in srgb, var(--mat-sys-on-surface) 15%, transparent);
+    padding: 2px 6px;
+    border-radius: 4px;
+    font-family: monospace;
+    font-size: 13px;
+  }
+
+  pre {
+    background-color: color-mix(in srgb, var(--mat-sys-surface-container-high) 80%, transparent);
+    padding: 12px;
+    border-radius: 4px;
+    overflow-x: auto;
+    margin: 8px 0;
+    border: 1px solid var(--mat-sys-outline-variant);
+
+    code {
+      background-color: transparent;
+      padding: 0;
+      font-size: 13px;
     }
   }
 }


### PR DESCRIPTION
## Summary

Two related dialog improvements:

1. **Node info dialog restructured into structured tabs** — the read-only node information dialog now organizes content into three tabs (**General information**, **Usage instructions**, **Command line**) with a stable `60vh` height, so the dialog no longer resizes on tab switches and long ports tables / markdown usage scroll in place.
2. **Declarative SDS size classes** — all 131 dialog call sites now declare exactly one Standard Dialog System (SDS) size class, making the four size classes the single width source for the dialog shell.

## Size classes

| Class | Width | Typical use |
|---|---|---|
| `dialog-small-panel` | 440px | confirmations, short forms |
| `dialog-medium-panel` | 720px | editors, sub-dialogs |
| `dialog-large-panel` | 880px | configurators |
| `dialog-extra-large-panel` | 1040px | dense management tables |

Non-standard widths (template gallery and read-only node info at 600px) live in a deviations section placed *after* the size classes, so the override wins regardless of class order on the panel element.

## Height tiers (new, opt-in)

- `dialog-height-60-panel` / `dialog-height-80-panel` set a fixed 60vh/80vh container height on top of any size class.
- Dialogs stay content-sized unless they declare a tier; the core max-height still clamps against the viewport.
- Height lives in the tier scope rather than the SDS core, so existing purpose-built fixed-height rules keep winning the cascade.

## Fix: bridge SDS width into Material's pane max-width token

After the size-class migration, every SDS dialog silently collapsed to 560px. Material's dialog theme emits `--mat-dialog-container-max-width: 560px` on `.mat-mdc-dialog-panel`, and the overlay pane is the shrink-to-fit root of the dialog chain, so that token capped everything downstream (the legacy per-panel width groups removed by the migration always co-set it).

The SDS shell now bridges `--mat-dialog-container-max-width` to the size-class width. The viewport clamp also moves into its own `--gns3-dialog-viewport-cap` custom property so width declarations keep `min()` arguments `var()`-only — the CSS pipeline strips `calc()` from `min()` arguments, and `var()`-only args are immune to that transform.

## Other changes

- AI profiles list dialogs (topbar entry, per-user action, group variant) widened to extra-large — the profiles list is a dense management table; nested add/edit form dialogs stay at large.
- Legacy per-panel width groups deleted from `_dialogs.scss` (~520 lines) now that sizing is declared per call site.
- Dialog skill docs (`gns3-angular-material-dialog`) rewritten around the size classes and height tiers.

## Testing

Specs updated alongside the affected components: `show-node-action`, `info-dialog`, `info.service`, `group-detail-dialog`, `delete-template`, `edit-config` / `export-config` / `idle-pc` / `import-config` / `lock` actions, `template`.