### PR TITLE
fix(templates): normalize v8 appliances returned by registry update

### DIFF
--- a/src/app/services/appliances.service.spec.ts
+++ b/src/app/services/appliances.service.spec.ts
@@ -115,5 +115,35 @@ describe('ApplianceService', () => {
 
       expect(result).toBeInstanceOf(Observable);
     });
+
+    it('should normalize v8 appliances like getAppliances does', () => {
+      const v8Appliance = {
+        name: 'v8 Appliance',
+        category: 'router',
+        settings: [
+          {
+            name: 'Default',
+            default: true,
+            template_type: 'qemu',
+            template_properties: { ram: 2048, adapters: 2 },
+          },
+        ],
+      } as unknown as Appliance;
+      mockHttpController.get.mockReturnValue(of([v8Appliance]));
+
+      const emitted: Appliance[] = [];
+      service.updateAppliances(mockController).subscribe((appliances) => emitted.push(...appliances));
+
+      expect(emitted[0].qemu).toEqual({ ram: 2048, adapters: 2 });
+    });
+
+    it('should tolerate a null response', () => {
+      mockHttpController.get.mockReturnValue(of(null));
+
+      const emitted: Appliance[] = [];
+      service.updateAppliances(mockController).subscribe((appliances) => emitted.push(...appliances));
+
+      expect(emitted).toEqual([]);
+    });
   });
 });

--- a/src/app/services/appliances.service.ts
+++ b/src/app/services/appliances.service.ts
@@ -28,6 +28,8 @@ export class ApplianceService {
   }
 
   updateAppliances(controller: Controller): Observable<Appliance[]> {
-    return this.httpController.get<Appliance[]>(controller, '/appliances?update=yes') as Observable<Appliance[]>;
+    return (this.httpController.get<Appliance[]>(controller, '/appliances?update=yes') as Observable<Appliance[]>).pipe(
+      map((appliances) => (appliances || []).map((appliance) => normalizeAppliance(appliance)))
+    );
   }
 }


### PR DESCRIPTION
## Problem

Clicking the "update registry" button in the new-template wizard refreshes the appliance list via `GET /appliances?update=yes`. Unlike the initial load, the refreshed appliances skipped the v8→legacy normalization introduced in #1784, so v8 appliances from the registry came back with no top-level `qemu`/`docker`/`iou`/`dynamips` block. Selecting such an appliance in the wizard produced a template with `undefined` properties (ram, adapters, …).

## Root cause

`ApplianceService.updateAppliances()` returned the raw response, while `getAppliances()` / `getAppliance()` map it through `normalizeAppliance()`. The mapping was simply missed on the update path in #1784.

## Fix

Apply the same `normalizeAppliance` mapping in `updateAppliances()` (including the null-response tolerance used by `getAppliances()`).

Follow-up to #1784.

## Testing

- New unit tests: v8 appliance is flattened identically on the update path; null response tolerated.
- `yarn test --include='**/appliances.service.spec.ts' --watch=false` — 12/12 pass
- `yarn lint` — pass