### PR TITLE
fix(templates): keep create button in sync when the name check is re-run silently

### DIFF
--- a/src/app/components/project-map/new-template-dialog/new-template-dialog.component.spec.ts
+++ b/src/app/components/project-map/new-template-dialog/new-template-dialog.component.spec.ts
@@ -486,6 +486,22 @@ describe('NewTemplateDialogComponent', () => {
       expect(component.selectedVersion()).toBeNull();
       expect(component.selectedImage()).toBeNull();
     });
+
+    it('should keep nameValid in sync when Angular re-runs the name check silently', async () => {
+      vi.useFakeTimers();
+      try {
+        component.selectAppliance(createDockerAppliance());
+        // Simulate the review step's input binding for the first time: Angular
+        // cancels the in-flight check and re-runs it with emitEvent: false, so
+        // the final VALID status is never reported through statusChanges.
+        component.templateNameControl.updateValueAndValidity({ emitEvent: false });
+        await vi.runAllTimersAsync();
+        expect(component.templateNameControl.status).toBe('VALID');
+        expect(component.nameValid()).toBe(true);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
   });
 
   describe('requiresImages and lastStepIndex', () => {

--- a/src/app/components/project-map/new-template-dialog/new-template-dialog.component.ts
+++ b/src/app/components/project-map/new-template-dialog/new-template-dialog.component.ts
@@ -33,7 +33,8 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FileItem, FileUploader, ParsedResponseHeaders, FileUploadModule } from 'ng2-file-upload';
 import * as SparkMD5 from 'spark-md5';
-import { timer } from 'rxjs';
+import { Subject, timer } from 'rxjs';
+import { tap } from 'rxjs/operators';
 import { v4 as uuid } from 'uuid';
 import { ProgressService } from '../../../common/progress/progress.service';
 import { ConfirmationDialogComponent } from '@components/dialogs/confirmation-dialog/confirmation-dialog.component';
@@ -309,16 +310,32 @@ export class NewTemplateDialogComponent implements OnInit {
   }
 
   private onControllerReady(): void {
+    // When the review step's input binds for the first time, Angular cancels
+    // the in-flight name check and re-runs it silently (emitEvent: false), so
+    // statusChanges never reports the final status and nameValid would stay
+    // stuck on its initial false value. The completion subject below mirrors
+    // the outcome of every check, including those silent rounds.
+    const nameCheckCompleted = new Subject<boolean>();
+
     this.templateNameControl = new UntypedFormControl(
       '',
       [Validators.required, this.projectNameValidator.get],
-      [templateNameAsyncValidator(this.controller, this.templateService)]
+      [
+        (control: UntypedFormControl) =>
+          templateNameAsyncValidator(this.controller, this.templateService)(control).pipe(
+            tap((result) => nameCheckCompleted.next(result === null))
+          ),
+      ]
     );
     this.templateNameControl.statusChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
       // Do not allow submission while the duplicate-name check is pending.
       // Otherwise a fast click can create a duplicate before the async
       // validator has had a chance to report the error.
       this.nameValid.set(this.templateNameControl.status === 'VALID');
+    });
+    nameCheckCompleted.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((isValid) => {
+      this.nameValid.set(isValid);
+      this.cd.markForCheck();
     });
 
     this.loadAppliances();


### PR DESCRIPTION
## Problem

In the new-template wizard (`/controller/:id/preferences/new-template`), selecting an appliance prefills the template name, but the **Create template** button stays disabled even though the name is valid. Manually retyping the name enables the button, which makes the prefilled flow look broken.

## Root cause

`selectAppliance()` calls `setValue(appliance.name)`, starting the async duplicate-name check with `statusChanges` emissions. On the routed wizard the review step's `<input [formControl]>` binds for the first time only after that click, and `FormControlDirective.ngOnChanges` then calls `updateValueAndValidity({ emitEvent: false })`:

- the in-flight check is cancelled and re-run silently,
- the re-run completes without emitting `statusChanges`,
- so the `nameValid` mirror signal stays `false` and the button never enables.

Typing manually always goes through the emitting path, which is why retyping the same name works.

## Fix

Tap a completion subject onto the async validator so the component learns the outcome of **every** validation round, including the silent re-runs, and re-asserts `nameValid` (+ `markForCheck()` for the zoneless OnPush view). The existing `statusChanges` subscription is kept to hold the button down while a check is pending.

## Testing

- New regression test simulates the silent `emitEvent: false` re-run and asserts `nameValid` recovers (fails on the old code, passes with the fix).
- Full wizard spec: 104/104 passing; lint clean.

Manual verification: select an appliance with a unique name → the Create template button enables ~300 ms after reaching the review step, without retyping the name.