### PR TITLE
feat(projects): static topology preview from the raw .gns3 file

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -5,6 +5,7 @@ Project-specific memory and context for GNS3 Web UI.
 ## Cartography & Coordinate System
 
 - [Canvas Coordinate System](canvas-coordinate-system.md) — Left-handed Cartesian coordinate system (centered origin) used by D3.js map canvas
+- [Topology Preview Pitfalls](topology-preview-pitfalls.md) — .gns3 static preview: convert eagerly in DrawingToMapDrawingConverter (getSize runs before widget draw, else silent no-op); drawing (x,y)=top-left with svg-root box; fit g.canvas getBBox, not the padded canvas; canvas color var scope; gns3file needs Cache-Control: no-cache
 - [show_filters_icon Implementation](show-filters-icon-implementation.md) — Complete guide: data models, icon display logic, context menu state management, and memory leak fixes
 
 ## Error Handling & UI

--- a/.claude/memory/topology-preview-pitfalls.md
+++ b/.claude/memory/topology-preview-pitfalls.md
@@ -1,0 +1,60 @@
+# Static Topology Preview — Implementation Pitfalls
+
+The static `.gns3` topology preview (projects list detail panel + 70vw×70vh enlarge
+dialog; commits through `bb5be9f0d`). The non-obvious traps hit during implementation,
+recorded so they don't have to be re-derived.
+
+## Render pipeline timing (the expensive one)
+
+`redraw()` runs `setNodes/setLinks/setDrawings` → `getSize()` → `graphLayout.draw()`.
+`MapDrawing.element` (width/height parsed from the drawing's svg root) used to be
+assigned lazily inside `DrawingsWidget.draw()`'s data-join accessor — i.e. AFTER
+`getSize()`. Any fix that feeds `getSize()` must convert eagerly in
+`DrawingToMapDrawingConverter` (the setDrawings path), not in the widget. Symptom of
+getting it wrong: the fix compiles, looks correct, and is a silent no-op.
+
+## Drawing bbox semantics
+
+Drawing `(x, y)` is the TOP-LEFT of its box; the box size is the svg root
+`width`/`height` persisted by the GUI (often 100×100 regardless of glyph size — an
+18pt text can render ~190px wide). `getSize()` counted nodes as boxes but drawings as
+points → the canvas edge clipped bottom/right overhang. Fix:
+`maxX = max(maxX, x + element.width)` with `element?.width ?? 0` (an unsupported svg
+leaves `element` undefined and renders nothing; both `getSize()` and the
+DrawingWidget's instanceof guards tolerate that).
+
+## Canvas ≠ content bbox
+
+`getSize()` pads each side to `max(browserViewport/2, content + 30)` — measured
+against `document.documentElement`, NOT the host container — so the canvas is
+asymmetric and viewport-floored. Fitting the svg element shrinks small topologies
+into padding and leaves content off-center. The preview instead fits
+`g.canvas.getBBox()` (grid rects and tool overlays live on the svg ROOT, so this is
+pure content, in scene coords), maps it to svg coordinates via
+`canvas.transform.baseVal` (translate+scale, see `GraphLayout.canvasTransform`), and
+re-centers with `translate(calc(-50% + Xpx), calc(-50% + Ypx)) scale(s)` where
+`X = (svgW/2 − bboxCenterX)·s`.
+
+## Canvas color var scope
+
+`--gns3-canvas-link-color` / `--gns3-canvas-label-color` are defined only on
+`.project-map--light-bg/--dark-bg` (now also `.topology-preview__viewport--*`).
+Outside that scope a `var()` in an SVG stroke attribute resolves to nothing → links
+render invisible. The screenshot pipeline's `applyCanvasColors` inlines computed
+colors for the same reason.
+
+## gns3file browser cache
+
+The server's FileResponse carries ETag/Last-Modified but no Cache-Control → Chrome
+heuristically caches it for ~hours, and F5 revalidates only the main document, NOT
+XHR subresources → a stale `.gns3` preview survives reloads and mimics an app bug.
+Fix: send a `Cache-Control: no-cache` request header (revalidates via ETag, 304 when
+unchanged). An incognito window is the fastest differential diagnosis.
+
+## Singleton map
+
+Context / GraphDataManager / LayersManager are app singletons — only ONE
+`<app-d3-map>` may be mounted at a time (panel ↔ dialog swap via `@if`). The loader
+must emit asynchronously (`subscribeOn(asyncScheduler, 1)` — delay-0 actions run
+synchronously) so the loading frame renders and the remount resets the canvas origin.
+See also `canvas-coordinate-system.md` in this directory.

--- a/src/app/cartography/components/d3-map/d3-map.component.ts
+++ b/src/app/cartography/components/d3-map/d3-map.component.ts
@@ -400,6 +400,11 @@ export class D3MapComponent implements OnInit, OnChanges, OnDestroy {
     // over the previous project's nodes/links/drawings, which graphLayout.draw
     // would render as a ghost frame before the first data redraw clears them.
     this.layersManager.clear();
+    // GraphDataManager equally outlives the component: without a reset, a new
+    // mount fed the same items (preview thumbnail ↔ dialog share one cached
+    // dataset) diffs them as unchanged, never rebuilds the layers and draws
+    // an empty canvas.
+    this.graphDataManager.reset();
     this.context.size = new Size(0, 0);
     this.graphLayout.connect(this.svg, this.context);
     this.graphLayout.draw(this.svg, this.context);

--- a/src/app/cartography/components/d3-map/d3-map.component.ts
+++ b/src/app/cartography/components/d3-map/d3-map.component.ts
@@ -472,10 +472,16 @@ export class D3MapComponent implements OnInit, OnChanges, OnDestroy {
     }
 
     for (const drawing of mapDrawings) {
+      // Count the drawing's box (parsed from its svg root), not just the
+      // origin point — text/shapes extend right/down from (x, y) and a
+      // point-only bbox lets the canvas edge clip them (e.g. multi-line text
+      // at the bottom of the content).
+      const drawingWidth = (drawing.element?.width ?? 0) * scale;
+      const drawingHeight = (drawing.element?.height ?? 0) * scale;
       minX = Math.min(minX, drawing.x * scale);
-      maxX = Math.max(maxX, drawing.x * scale);
+      maxX = Math.max(maxX, drawing.x * scale + drawingWidth);
       minY = Math.min(minY, drawing.y * scale);
-      maxY = Math.max(maxY, drawing.y * scale);
+      maxY = Math.max(maxY, drawing.y * scale + drawingHeight);
     }
 
     // Asymmetric canvas: allocate exactly the space needed on each side of the

--- a/src/app/cartography/converters/map/drawing-to-map-drawing-converter.ts
+++ b/src/app/cartography/converters/map/drawing-to-map-drawing-converter.ts
@@ -2,10 +2,11 @@ import { Injectable } from '@angular/core';
 import { Drawing } from '../../models/drawing';
 import { MapDrawing } from '../../models/map/map-drawing';
 import { Converter } from '../converter';
+import { SvgToDrawingConverter } from '../../helpers/svg-to-drawing-converter';
 
 @Injectable()
 export class DrawingToMapDrawingConverter implements Converter<Drawing, MapDrawing> {
-  constructor() {}
+  constructor(private svgToDrawingConverter: SvgToDrawingConverter) {}
 
   convert(drawing: Drawing) {
     const mapDrawing = new MapDrawing();
@@ -17,6 +18,18 @@ export class DrawingToMapDrawingConverter implements Converter<Drawing, MapDrawi
     mapDrawing.x = drawing.x;
     mapDrawing.y = drawing.y;
     mapDrawing.z = drawing.z;
+    // Parse the element eagerly: getSize() reads element.width/height to
+    // reserve the drawing's box on the canvas, and it runs between
+    // setDrawings() and the widget draw — the lazy conversion inside
+    // DrawingsWidget.draw comes too late for the first sizing pass, so the
+    // canvas clipped drawings at its edge (e.g. bottom-row text). Unsupported
+    // svg leaves element undefined, which both getSize (?? 0 fallback) and
+    // DrawingWidget (instanceof guards) already tolerate.
+    try {
+      mapDrawing.element = this.svgToDrawingConverter.convert(drawing.svg);
+    } catch {
+      // same as the widget's lazy path: render nothing for this drawing
+    }
     return mapDrawing;
   }
 }

--- a/src/app/cartography/managers/graph-data-manager.ts
+++ b/src/app/cartography/managers/graph-data-manager.ts
@@ -84,6 +84,24 @@ export class GraphDataManager {
   public getDrawings() { return this.mapDrawingsDataSource.getItems(); }
   public getSymbols() { return this.mapSymbolsDataSource.getItems(); }
 
+  /**
+   * Clear all singleton state. Called from D3MapComponent.createGraph: the
+   * manager outlives the component, and a fresh mount that receives the SAME
+   * items (e.g. preview thumbnail ↔ dialog passing one cached dataset) would
+   * diff them as "no change" — no additions, no layers rebuild — and render
+   * an empty canvas even though layersManager was cleared.
+   */
+  public reset() {
+    this.mapNodesDataSource.set([]);
+    this.mapLinksDataSource.set([]);
+    this.mapDrawingsDataSource.set([]);
+    this.nodeSig.clear();
+    this.linkSig.clear();
+    this.drawingSig.clear();
+    this.nodeToLinks.clear();
+    this.draggingIds.clear();
+  }
+
   // ── Incremental setters (return AffectedIds for dom-patcher) ───
 
   public setNodes(nodes: Node[]): AffectedIds {

--- a/src/app/components/project-map/project-map.component.ts
+++ b/src/app/components/project-map/project-map.component.ts
@@ -17,9 +17,9 @@ import { MatTooltipModule } from '@angular/material/tooltip';
 import { Title } from '@angular/platform-browser';
 import { ActivatedRoute, ParamMap, Router, RouterModule } from '@angular/router';
 import { ExportPortableProjectComponent } from '@components/export-portable-project/export-portable-project.component';
-import { environment } from 'environments/environment';
+
 import * as Mousetrap from 'mousetrap';
-import { forkJoin, from, Observable, Subscription } from 'rxjs';
+import { from, Observable, Subscription } from 'rxjs';
 import { map, mergeMap, tap } from 'rxjs/operators';
 import { D3MapComponent } from '../../cartography/components/d3-map/d3-map.component';
 import * as d3 from 'd3';
@@ -83,6 +83,7 @@ import { RecentlyOpenedProjectService } from '@services/recentlyOpenedProject.se
 import { ControllerService } from '@services/controller.service';
 import { Settings, SettingsService } from '@services/settings.service';
 import { SymbolService } from '@services/symbol.service';
+import { NodeSymbolResolverService } from '@services/node-symbol-resolver.service';
 import { ToasterService } from '@services/toaster.service';
 import { ToolsService } from '@services/tools.service';
 import { ThemeService } from '@services/theme.service';
@@ -323,6 +324,7 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
   private mapLinksDataSource = inject(MapLinksDataSource);
   private markerRegistryService = inject(MarkerRegistryService);
   private markerFlashService = inject(MarkerFlashService);
+  private nodeSymbolResolver = inject(NodeSymbolResolverService);
   private mapDrawingsDataSource = inject(MapDrawingsDataSource);
   private mapSymbolsDataSource = inject(MapSymbolsDataSource);
   private mapSettingsService = inject(MapSettingsService);
@@ -415,57 +417,13 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
           nodeSymbolCache.set(node.node_id, node.symbol);
         }
 
-        const nodesToLoad = nodes.filter((node: Node) => !node.symbol_url);
-
-        // Fetch dimensions for any node with unknown size
-        nodesToLoad.forEach((node: Node) => {
-          if (node.width == 0 && node.height == 0) {
-            this.symbolService.getDimensions(this.controller, node.symbol).subscribe({
-              next: (symbolDimensions) => {
-                node.width = symbolDimensions.width;
-                node.height = symbolDimensions.height;
-              },
-              error: (err) => {
-                console.error('Failed to get symbol dimensions:', err);
-              },
-            });
-          }
-        });
-
-        if (nodesToLoad.length === 0) {
-          this.nodes.set(nodes);
+        // Resolve symbol URLs / dimensions in one pass, then publish. The
+        // resolver completes only after dimensions are applied, so the first
+        // render already has correct label centering.
+        this.nodeSymbolResolver.resolve(this.controller, nodes).subscribe((resolved: Node[]) => {
+          this.nodes.set(resolved);
           if (this.mapSettingsService.getSymbolScaling()) this.applyScalingOfNodeSymbols();
-          return;
-        }
-
-        // Build a map from node -> rawUrl for all nodes that need loading
-        const nodeRawUrlMap = new Map<Node, string>();
-        nodesToLoad.forEach((node: Node) => {
-          nodeRawUrlMap.set(node, `/symbols/${node.symbol}/raw`);
         });
-
-        // Deduplicate: only 1 fetch per unique symbol URL (shareReplay(1) in getSymbolBlobUrl handles concurrent callers)
-        const uniqueRawUrls = Array.from(new Set(nodeRawUrlMap.values()));
-        forkJoin(uniqueRawUrls.map((url) => this.symbolService.getSymbolBlobUrl(this.controller, url))).subscribe(
-          (blobUrls: string[]) => {
-            const blobUrlMap = new Map(uniqueRawUrls.map((url, i) => [url, blobUrls[i]]));
-            nodesToLoad.forEach((node: Node) => {
-              node.symbol_url = blobUrlMap.get(nodeRawUrlMap.get(node));
-            });
-            this.nodes.set(nodes);
-            if (this.mapSettingsService.getSymbolScaling()) this.applyScalingOfNodeSymbols();
-          },
-          () => {
-            // Fallback to raw URLs if blob fetch fails
-            nodesToLoad.forEach((node: Node) => {
-              node.symbol_url = `${this.controller.protocol}//${this.controller.host}:${this.controller.port}/${
-                environment.current_version
-              }${nodeRawUrlMap.get(node)}`;
-            });
-            this.nodes.set(nodes);
-            if (this.mapSettingsService.getSymbolScaling()) this.applyScalingOfNodeSymbols();
-          }
-        );
       })
     );
 

--- a/src/app/components/projects/projects.component.html
+++ b/src/app/components/projects/projects.component.html
@@ -460,8 +460,9 @@
             </div>
           </div>
 
-          <!-- Nodes & Links (from stats) share one line -->
-          @if (projectStats(); as stats) {
+          <!-- Nodes & Links share one line — counts come from the .gns3 file
+               when the preview is loaded (closed projects have zero server stats) -->
+          @if (displayStats(); as stats) {
           <div class="projects__detail-row">
             <div class="projects__detail-item">
               <span class="projects__detail-icon"><mat-icon>device_hub</mat-icon></span>

--- a/src/app/components/projects/projects.component.html
+++ b/src/app/components/projects/projects.component.html
@@ -460,10 +460,11 @@
             </div>
           </div>
 
-          <!-- Nodes & Links share one line — counts come from the .gns3 file
-               when the preview is loaded (closed projects have zero server stats) -->
+          <!-- Node / link / drawing counts share one line — counts come from the
+               .gns3 file when the preview is loaded (closed projects have zero
+               server stats) -->
           @if (displayStats(); as stats) {
-          <div class="projects__detail-row">
+          <div class="projects__detail-row projects__detail-row--stats">
             <div class="projects__detail-item">
               <span class="projects__detail-icon"><mat-icon>device_hub</mat-icon></span>
               <span class="projects__detail-label">Nodes</span>
@@ -475,15 +476,15 @@
               <span class="projects__detail-label">Links</span>
               <span class="projects__detail-value">{{ stats.links }}</span>
             </div>
-          </div>
 
-          @if (stats.drawings > 0) {
-          <div class="projects__detail-item">
-            <span class="projects__detail-icon"><mat-icon>draw</mat-icon></span>
-            <span class="projects__detail-label">Drawings</span>
-            <span class="projects__detail-value">{{ stats.drawings }}</span>
+            @if (stats.drawings > 0) {
+            <div class="projects__detail-item">
+              <span class="projects__detail-icon"><mat-icon>draw</mat-icon></span>
+              <span class="projects__detail-label">Drawings</span>
+              <span class="projects__detail-value">{{ stats.drawings }}</span>
+            </div>
+            }
           </div>
-          }
 
           @if (stats.snapshots > 0) {
           <div class="projects__detail-item">
@@ -520,69 +521,68 @@
           }
         </div>
 
-        <!-- Details Action Buttons -->
+        <!-- Details Action Buttons — one compact icon row (tooltips carry the
+             labels; five text buttons don't fit the panel width) -->
         <div class="projects__details-actions">
           @if (project.status === 'closed') {
           <button
-            mat-raised-button
-            color="primary"
+            mat-icon-button
             class="projects__details-action-btn projects__details-action-btn--start"
             (click)="open(project); closeDetails()"
             matTooltip="Start project"
+            aria-label="Start project"
           >
             <mat-icon>play_arrow</mat-icon>
-            Start
           </button>
           } @if (project.status === 'opened') {
           <button
-            mat-raised-button
+            mat-icon-button
             class="projects__details-action-btn projects__details-action-btn--stop"
             (click)="close(project)"
             matTooltip="Stop project"
+            aria-label="Stop project"
           >
             <mat-icon>pause</mat-icon>
-            Stop
           </button>
           }
           <button
-            mat-stroked-button
+            mat-icon-button
             class="projects__details-action-btn projects__details-action-btn--edit"
             (click)="editProject(project)"
             matTooltip="Edit project"
+            aria-label="Edit project"
           >
             <mat-icon>edit</mat-icon>
-            Edit
           </button>
           @if (project.status === 'closed') {
           <button
-            mat-stroked-button
+            mat-icon-button
             class="projects__details-action-btn projects__details-action-btn--duplicate"
             (click)="duplicate(project)"
             matTooltip="Duplicate project"
+            aria-label="Duplicate project"
           >
             <mat-icon>content_copy</mat-icon>
-            Duplicate
           </button>
           }
           <button
-            mat-stroked-button
+            mat-icon-button
             class="projects__details-action-btn projects__details-action-btn--export"
             (click)="exportSelectProject(project)"
             matTooltip="Export project"
+            aria-label="Export project"
           >
             <mat-icon>file_download</mat-icon>
-            Export
           </button>
           @if (project.status === 'closed') {
           <button
-            mat-stroked-button
-            color="warn"
+            mat-icon-button
             class="projects__details-action-btn projects__details-action-btn--delete"
             (click)="delete(project); closeDetails()"
             matTooltip="Delete project"
+            aria-label="Delete project"
           >
             <mat-icon>delete</mat-icon>
-            Delete
           </button>
           }
         </div>

--- a/src/app/components/projects/projects.component.html
+++ b/src/app/components/projects/projects.component.html
@@ -387,6 +387,47 @@
         </div>
 
         <div class="projects__details-body">
+          <!-- Static topology preview from the raw .gns3 file (works for closed projects) -->
+          @switch (previewState()) {
+            @case ('loading') {
+              <div class="projects__preview">
+                <mat-spinner class="projects__preview-spinner" [diameter]="24"></mat-spinner>
+              </div>
+            }
+            @case ('error') {
+              <div class="projects__preview">
+                <span class="projects__preview-note">Topology preview unavailable</span>
+              </div>
+            }
+            @case ('empty') {
+              <div class="projects__preview">
+                <span class="projects__preview-note">Empty topology</span>
+              </div>
+            }
+            @default {
+              @if (!previewEnlarged()) {
+                <button
+                  type="button"
+                  class="projects__preview-thumb"
+                  (click)="openTopologyPreview()"
+                  matTooltip="Enlarge topology preview"
+                  matTooltipClass="custom-tooltip"
+                  matTooltipPosition="below"
+                  aria-label="Enlarge topology preview"
+                >
+                  <app-topology-preview
+                    variant="panel"
+                    [controller]="controller"
+                    [project]="project"
+                    [nodes]="previewTopology()!.nodes"
+                    [links]="previewTopology()!.links"
+                    [drawings]="previewTopology()!.drawings"
+                  />
+                </button>
+              }
+            }
+          }
+
           <!-- Status / Owner / Access share one line -->
           <div class="projects__detail-row">
             <!-- Status -->

--- a/src/app/components/projects/projects.component.scss
+++ b/src/app/components/projects/projects.component.scss
@@ -761,6 +761,17 @@ mat-cell {
   text-align: left;
 }
 
+/* Count triplet (Nodes/Links/Drawings): equal thirds so the row never wraps,
+   with content-sized labels — "Drawings" overflows the shared 60px column */
+.projects__detail-row--stats .projects__detail-item {
+  flex: 1 1 0;
+}
+
+.projects__detail-row--stats .projects__detail-label {
+  width: auto;
+  margin-right: 6px;
+}
+
 /* Icon column — fixed width */
 .projects__detail-icon {
   width: 22px;
@@ -902,28 +913,22 @@ mat-cell {
   box-shadow: 0 0 6px color-mix(in srgb, var(--mat-sys-error) 50%, transparent);
 }
 
-/* Details action buttons */
+/* Details action buttons — single centered icon row; tooltips carry the
+   labels (five text buttons overflow the panel width) */
 .projects__details-actions {
-  padding: 14px 20px 18px;
+  padding: 12px 20px 16px;
   border-top: 1px solid var(--mat-sys-outline-variant);
   background: color-mix(in srgb, var(--mat-sys-surface-container) 72%, transparent);
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  display: flex;
+  align-items: center;
+  justify-content: center;
   gap: var(--gns3-density-space-2);
 }
 
 button.projects__details-action-btn {
   --projects-details-action-color: var(--mat-sys-on-surface-variant);
-  width: 100%;
-  border-radius: 12px;
-  text-transform: none;
-  font-size: 14px;
-  font-weight: 500;
-  letter-spacing: 0.3px;
-  height: 40px;
 
   mat-icon {
-    margin-right: 4px;
     color: var(--projects-details-action-color);
   }
 }

--- a/src/app/components/projects/projects.component.scss
+++ b/src/app/components/projects/projects.component.scss
@@ -836,6 +836,54 @@ mat-cell {
   // HTML carries no encapsulation attribute); the token scales it to 13px.
 }
 
+/* ── Static topology preview card (top of the details panel) ── */
+/* Placeholder (loading / error / empty) and the clickable thumbnail share
+   the same card look; the card sits above the metadata rows so the map and
+   the description never stack into one visual blob. */
+.projects__preview,
+.projects__preview-thumb {
+  box-sizing: border-box;
+  width: 100%;
+  margin-bottom: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  border: 1px solid var(--mat-sys-outline-variant);
+  border-radius: 10px;
+  background: var(--mat-sys-surface-container-low);
+}
+
+/* Placeholder states keep a fixed height. */
+.projects__preview {
+  flex-shrink: 0;
+  height: 200px;
+}
+
+.projects__preview-note {
+  font-size: 13px;
+  color: var(--mat-sys-on-surface-variant);
+}
+
+/* The thumbnail's height follows the map's rendered aspect ratio (set by
+   TopologyPreviewComponent). flex-shrink: 0 is essential — the details body
+   is a column flex container and the absolutely-positioned svg has no
+   intrinsic min-height, so shrink would collapse the card to a sliver. */
+.projects__preview-thumb {
+  flex-shrink: 0;
+  height: auto;
+  min-height: 160px;
+  padding: 0;
+  cursor: zoom-in;
+  text-align: inherit;
+
+  app-topology-preview {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+  }
+}
+
 /* Status dot in the icon column */
 .projects__detail-status-dot {
   width: 10px;

--- a/src/app/components/projects/projects.component.spec.ts
+++ b/src/app/components/projects/projects.component.spec.ts
@@ -91,7 +91,6 @@ describe('ProjectsComponent', () => {
 
     mockTopologyPreviewService = {
       load: vi.fn().mockReturnValue(of({ nodes: [], links: [], drawings: [] })),
-      invalidate: vi.fn(),
     };
 
     mockThemeService = {

--- a/src/app/components/projects/projects.component.spec.ts
+++ b/src/app/components/projects/projects.component.spec.ts
@@ -11,6 +11,7 @@ import { ProjectService } from '@services/project.service';
 import { SettingsService, Settings } from '@services/settings.service';
 import { ProgressService } from '../../common/progress/progress.service';
 import { RecentlyOpenedProjectService } from '@services/recentlyOpenedProject.service';
+import { TopologyPreviewService } from '@services/topology-preview.service';
 import { ThemeService } from '@services/theme.service';
 import { ToasterService } from '@services/toaster.service';
 import { NotificationService, ProjectNotification } from '@services/notification.service';
@@ -26,6 +27,7 @@ describe('ProjectsComponent', () => {
   let mockSettingsService: any;
   let mockProgressService: any;
   let mockRecentlyOpenedProjectService: any;
+  let mockTopologyPreviewService: any;
   let mockThemeService: any;
   let mockToasterService: any;
   let mockNotificationService: any;
@@ -87,6 +89,11 @@ describe('ProjectsComponent', () => {
       setcontrollerIdProjectList: vi.fn(),
     };
 
+    mockTopologyPreviewService = {
+      load: vi.fn().mockReturnValue(of({ nodes: [], links: [], drawings: [] })),
+      invalidate: vi.fn(),
+    };
+
     mockThemeService = {
       getActualTheme: vi.fn().mockReturnValue('dark'),
       darkMode$: of(false),
@@ -126,6 +133,7 @@ describe('ProjectsComponent', () => {
         { provide: SettingsService, useValue: mockSettingsService },
         { provide: ProgressService, useValue: mockProgressService },
         { provide: RecentlyOpenedProjectService, useValue: mockRecentlyOpenedProjectService },
+        { provide: TopologyPreviewService, useValue: mockTopologyPreviewService },
         { provide: ThemeService, useValue: mockThemeService },
         { provide: ToasterService, useValue: mockToasterService },
         { provide: NotificationService, useValue: mockNotificationService },

--- a/src/app/components/projects/projects.component.ts
+++ b/src/app/components/projects/projects.component.ts
@@ -113,6 +113,22 @@ export class ProjectsComponent implements OnInit {
   // only one <app-d3-map> exists at a time (its state managers are singletons).
   readonly previewEnlarged = signal(false);
 
+  /**
+   * Nodes/Links/Drawings counts shown in the details panel. For closed
+   * projects getStatistics reports zeros — count them from the .gns3 file
+   * data instead. Snapshots are server-only and keep the stats value.
+   */
+  readonly displayStats = computed<ProjectStatistics | null>(() => {
+    const topology = this.previewTopology();
+    if (!topology) return this.projectStats();
+    return {
+      ...(this.projectStats() ?? ({} as ProjectStatistics)),
+      nodes: topology.nodes.length,
+      links: topology.links.length,
+      drawings: topology.drawings.length,
+    };
+  });
+
   // ── Status filter ─────────────────────────────────────────────
   readonly filterStatus = signal<string>('all');
 
@@ -376,9 +392,14 @@ export class ProjectsComponent implements OnInit {
 
   // ── WebSocket notification handler ────────────────────────────
   private handleProjectNotification(notification: ProjectNotification): void {
-    // A closed project's file may have changed while open; a deleted one is gone.
-    if (notification.action === 'project.closed' || notification.action === 'project.deleted') {
-      this.topologyPreviewService.invalidate(notification.event.project_id);
+    // The .gns3 file is rewritten when a project is edited or closed
+    // elsewhere — reload the preview of the currently selected project so the
+    // panel always reflects the file on disk.
+    if (
+      (notification.action === 'project.closed' || notification.action === 'project.updated') &&
+      this.selectedProject()?.project_id === notification.event.project_id
+    ) {
+      this.loadProjectTopology(notification.event);
     }
     this._projects.update((projects) => {
       const list = [...projects];

--- a/src/app/components/projects/projects.component.ts
+++ b/src/app/components/projects/projects.component.ts
@@ -46,6 +46,13 @@ import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { version } from '../../version';
 import { MarkdownViewerComponent } from '../../common/markdown-viewer/markdown-viewer.component';
+import { TopologyPreviewComponent } from './topology-preview/topology-preview.component';
+import {
+  TopologyPreviewDialogComponent,
+  TopologyPreviewDialogData,
+} from './topology-preview/topology-preview-dialog.component';
+import { TopologyPreviewService } from '@services/topology-preview.service';
+import { TopologyPreviewData } from '@services/gns3-file.mapper';
 
 @Component({
   selector: 'app-projects',
@@ -68,6 +75,7 @@ import { MarkdownViewerComponent } from '../../common/markdown-viewer/markdown-v
     MatProgressSpinnerModule,
     MatPaginatorModule,
     MatTooltipModule,
+    TopologyPreviewComponent,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
@@ -97,6 +105,13 @@ export class ProjectsComponent implements OnInit {
   readonly selectedProject = signal<Project | null>(null);
   readonly projectStats = signal<ProjectStatistics | null>(null);
   readonly projectDescription = signal('');
+
+  // ── Static topology preview (from the raw .gns3 file) ────────
+  readonly previewTopology = signal<TopologyPreviewData | null>(null);
+  readonly previewState = signal<'loading' | 'ready' | 'empty' | 'error'>('loading');
+  // True while the enlarged dialog is open — unmounts the panel thumbnail so
+  // only one <app-d3-map> exists at a time (its state managers are singletons).
+  readonly previewEnlarged = signal(false);
 
   // ── Status filter ─────────────────────────────────────────────
   readonly filterStatus = signal<string>('all');
@@ -216,6 +231,7 @@ export class ProjectsComponent implements OnInit {
   private toasterService = inject(ToasterService);
   private recentlyOpenedProjectService = inject(RecentlyOpenedProjectService);
   private themeService = inject(ThemeService);
+  private topologyPreviewService = inject(TopologyPreviewService);
 
   ngOnInit() {
     this.controller = this.route.snapshot.data['controller'];
@@ -266,12 +282,16 @@ export class ProjectsComponent implements OnInit {
     this.projectDescription.set('');
     this.loadProjectStats(project);
     this.loadProjectDescription(project);
+    this.loadProjectTopology(project);
   }
 
   closeDetails() {
     this.selectedProject.set(null);
     this.projectStats.set(null);
     this.projectDescription.set('');
+    this.previewTopology.set(null);
+    this.previewState.set('loading');
+    this.previewEnlarged.set(false);
   }
 
   private loadProjectStats(project: Project) {
@@ -306,6 +326,40 @@ export class ProjectsComponent implements OnInit {
     });
   }
 
+  /** Load the static topology preview from the raw .gns3 file (cached per project). */
+  private loadProjectTopology(project: Project) {
+    this.previewTopology.set(null);
+    this.previewState.set('loading');
+    this.topologyPreviewService.load(this.controller, project).subscribe({
+      next: (topology: TopologyPreviewData) => {
+        if (this.selectedProject()?.project_id !== project.project_id) return;
+        this.previewTopology.set(topology);
+        const empty =
+          topology.nodes.length === 0 && topology.links.length === 0 && topology.drawings.length === 0;
+        this.previewState.set(empty ? 'empty' : 'ready');
+      },
+      error: () => {
+        if (this.selectedProject()?.project_id !== project.project_id) return;
+        this.previewState.set('error');
+      },
+    });
+  }
+
+  /** Enlarge the panel thumbnail to a 70% viewport dialog. */
+  openTopologyPreview(): void {
+    const project = this.selectedProject();
+    const topology = this.previewTopology();
+    if (!project || !topology || this.previewState() !== 'ready') return;
+    this.previewEnlarged.set(true);
+    this.dialog
+      .open(TopologyPreviewDialogComponent, {
+        panelClass: ['base-dialog-panel', 'dialog-large-panel', 'topology-preview-dialog-panel'],
+        data: { controller: this.controller, project, topology } satisfies TopologyPreviewDialogData,
+      })
+      .afterClosed()
+      .subscribe(() => this.previewEnlarged.set(false));
+  }
+
   // ── Data fetching ─────────────────────────────────────────────
   refresh() {
     this.projectService.list(this.controller).subscribe({
@@ -322,6 +376,10 @@ export class ProjectsComponent implements OnInit {
 
   // ── WebSocket notification handler ────────────────────────────
   private handleProjectNotification(notification: ProjectNotification): void {
+    // A closed project's file may have changed while open; a deleted one is gone.
+    if (notification.action === 'project.closed' || notification.action === 'project.deleted') {
+      this.topologyPreviewService.invalidate(notification.event.project_id);
+    }
     this._projects.update((projects) => {
       const list = [...projects];
       const index = list.findIndex((p) => p.project_id === notification.event.project_id);

--- a/src/app/components/projects/topology-preview/topology-preview-dialog.component.html
+++ b/src/app/components/projects/topology-preview/topology-preview-dialog.component.html
@@ -1,0 +1,16 @@
+<h2 mat-dialog-title>{{ data.project.name }}</h2>
+
+<mat-dialog-content class="topology-preview-dialog__content">
+  <app-topology-preview
+    variant="dialog"
+    [controller]="data.controller"
+    [project]="data.project"
+    [nodes]="data.topology.nodes"
+    [links]="data.topology.links"
+    [drawings]="data.topology.drawings"
+  />
+</mat-dialog-content>
+
+<mat-dialog-actions align="end">
+  <button mat-button (click)="dialogRef.close()">Close</button>
+</mat-dialog-actions>

--- a/src/app/components/projects/topology-preview/topology-preview-dialog.component.ts
+++ b/src/app/components/projects/topology-preview/topology-preview-dialog.component.ts
@@ -1,0 +1,30 @@
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { Controller } from '@models/controller';
+import { Project } from '@models/project';
+import { TopologyPreviewData } from '@services/gns3-file.mapper';
+import { TopologyPreviewComponent } from './topology-preview.component';
+
+export interface TopologyPreviewDialogData {
+  controller: Controller;
+  project: Project;
+  topology: TopologyPreviewData;
+}
+
+/**
+ * Enlarged (70vw × 70vh, via .topology-preview-dialog-panel) static topology
+ * preview. The data arrives pre-resolved from the caller's cache — this
+ * dialog never fetches.
+ */
+@Component({
+  selector: 'app-topology-preview-dialog',
+  standalone: true,
+  imports: [MatDialogModule, MatButtonModule, TopologyPreviewComponent],
+  templateUrl: './topology-preview-dialog.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class TopologyPreviewDialogComponent {
+  readonly dialogRef = inject(MatDialogRef<TopologyPreviewDialogComponent>);
+  readonly data = inject<TopologyPreviewDialogData>(MAT_DIALOG_DATA);
+}

--- a/src/app/components/projects/topology-preview/topology-preview.component.html
+++ b/src/app/components/projects/topology-preview/topology-preview.component.html
@@ -2,6 +2,8 @@
   #viewport
   class="topology-preview__viewport"
   [class.topology-preview__viewport--panel]="variant() === 'panel'"
+  [class.topology-preview__viewport--light-bg]="mapBgClass()['topology-preview__viewport--light-bg']"
+  [class.topology-preview__viewport--dark-bg]="mapBgClass()['topology-preview__viewport--dark-bg']"
 >
   <app-d3-map
     class="topology-preview__map"

--- a/src/app/components/projects/topology-preview/topology-preview.component.html
+++ b/src/app/components/projects/topology-preview/topology-preview.component.html
@@ -1,0 +1,18 @@
+<div
+  #viewport
+  class="topology-preview__viewport"
+  [class.topology-preview__viewport--panel]="variant() === 'panel'"
+>
+  <app-d3-map
+    class="topology-preview__map"
+    [controller]="controller()"
+    [project]="project()"
+    [nodes]="nodes()"
+    [links]="links()"
+    [drawings]="drawings()"
+    [width]="project().scene_width || 2000"
+    [height]="project().scene_height || 1000"
+    [show-interface-labels]="true"
+    [readonly]="true"
+  />
+</div>

--- a/src/app/components/projects/topology-preview/topology-preview.component.scss
+++ b/src/app/components/projects/topology-preview/topology-preview.component.scss
@@ -1,0 +1,33 @@
+:host {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  width: 100%;
+}
+
+.topology-preview__viewport {
+  position: relative;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+
+/* Panel thumbnail: pointer events fall through to the enlarge button. The
+   viewport height is set from the map's rendered aspect ratio by
+   recomputeScale() (inline style wins over this initial fallback). */
+.topology-preview__viewport--panel {
+  pointer-events: none;
+  flex: none;
+  height: 200px;
+}
+
+/* d3-map sizes the svg imperatively to the (content-centered) canvas; scale
+   it uniformly into the viewport instead of fighting those attributes. */
+.topology-preview__map {
+  display: block;
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%) scale(var(--topology-preview-scale, 1));
+}

--- a/src/app/components/projects/topology-preview/topology-preview.component.scss
+++ b/src/app/components/projects/topology-preview/topology-preview.component.scss
@@ -23,11 +23,18 @@
 }
 
 /* d3-map sizes the svg imperatively to the (content-centered) canvas; scale
-   it uniformly into the viewport instead of fighting those attributes. */
+   it uniformly into the viewport instead of fighting those attributes. The
+   shift vars re-center on the measured content bbox — the canvas padding is
+   asymmetric whenever content extends past the half-viewport floor on one
+   side only, so centering the svg box alone leaves content off-center. */
 .topology-preview__map {
   display: block;
   position: absolute;
   left: 50%;
   top: 50%;
-  transform: translate(-50%, -50%) scale(var(--topology-preview-scale, 1));
+  transform: translate(
+      calc(-50% + var(--topology-preview-shift-x, 0px)),
+      calc(-50% + var(--topology-preview-shift-y, 0px))
+    )
+    scale(var(--topology-preview-scale, 1));
 }

--- a/src/app/components/projects/topology-preview/topology-preview.component.ts
+++ b/src/app/components/projects/topology-preview/topology-preview.component.ts
@@ -89,30 +89,77 @@ export class TopologyPreviewComponent {
     });
   }
 
-  /** Uniformly scale the svg (already content-centered) to fit the viewport. Idempotent and cheap. */
+  /**
+   * Uniformly scale the rendered content to fit the viewport. Idempotent and
+   * cheap.
+   *
+   * The fit box is the measured content bbox (g.canvas getBBox mapped into
+   * svg coordinates), not the svg canvas itself: getSize() pads the canvas to
+   * at least half the browser viewport per side, so fitting the canvas would
+   * shrink small topologies into their padding and report the padded aspect
+   * ratio as the topology's. Falls back to the whole svg until the first
+   * draw populates the canvas group.
+   */
   private recomputeScale(): void {
     const viewport = this.viewport()?.nativeElement;
     if (!viewport) return;
     const svg = viewport.querySelector('svg');
     if (!svg) return;
-    const width = parseFloat(svg.getAttribute('width') ?? '');
-    const height = parseFloat(svg.getAttribute('height') ?? '');
-    if (!width || !height) return;
+    const svgWidth = parseFloat(svg.getAttribute('width') ?? '');
+    const svgHeight = parseFloat(svg.getAttribute('height') ?? '');
+    if (!svgWidth || !svgHeight) return;
+
+    const fit = this.measureContentBox(svg) ?? { x: 0, y: 0, width: svgWidth, height: svgHeight };
 
     if (this.variant() === 'panel') {
-      // The thumbnail card follows the map's actually-rendered aspect ratio
-      // (width fills the panel, height = width × svgH/svgW), clamped so an
-      // extreme topology cannot blow up the details panel. The dialog variant
-      // instead fills whatever height its container gives it.
+      // The thumbnail card follows the content's aspect ratio (width fills the
+      // panel, height = width × contentH/contentW), clamped so an extreme
+      // topology cannot blow up the details panel. The dialog variant instead
+      // fills whatever height its container gives it.
       const maxHeight = Math.min(PANEL_MAX_HEIGHT, Math.round(window.innerHeight * 0.45));
-      const heightByRatio = Math.round((viewport.clientWidth * height) / width);
+      const heightByRatio = Math.round((viewport.clientWidth * fit.height) / fit.width);
       viewport.style.height = `${Math.max(PANEL_MIN_HEIGHT, Math.min(heightByRatio, maxHeight))}px`;
     }
 
-    // Uniformly scale the svg into the viewport. The svg (with its imperative
-    // width/height attributes) sizes the absolutely-positioned host, so the
-    // CSS transform is purely visual and nothing collapses.
-    const scale = Math.min(viewport.clientWidth / width, viewport.clientHeight / height);
+    const padding = 16;
+    const scale = Math.min(
+      viewport.clientWidth / (fit.width + 2 * padding),
+      viewport.clientHeight / (fit.height + 2 * padding)
+    );
+
+    // The host CSS centers the svg box at the viewport center; re-center on
+    // the content bbox center, which differs from the svg center whenever the
+    // canvas padding is asymmetric (left/right space are computed
+    // independently in getSize()).
+    const shiftX = (svgWidth / 2 - (fit.x + fit.width / 2)) * scale;
+    const shiftY = (svgHeight / 2 - (fit.y + fit.height / 2)) * scale;
+
     viewport.style.setProperty('--topology-preview-scale', String(scale));
+    viewport.style.setProperty('--topology-preview-shift-x', `${shiftX}px`);
+    viewport.style.setProperty('--topology-preview-shift-y', `${shiftY}px`);
+  }
+
+  /**
+   * Content bbox in svg coordinates, or null when the canvas group has not
+   * been drawn yet. g.canvas holds only rendered content (grid rects and
+   * tool overlays live on the svg root), and its transform
+   * (translate + scale, GraphLayout.canvasTransform) maps scene coords to
+   * svg coords.
+   */
+  private measureContentBox(svg: SVGElement): { x: number; y: number; width: number; height: number } | null {
+    const canvas = svg.querySelector<SVGGElement>('g.canvas');
+    if (!canvas) return null;
+    const bbox = canvas.getBBox();
+    if (!bbox.width || !bbox.height) return null;
+
+    const transforms = canvas.transform.baseVal;
+    const translate = transforms.numberOfItems > 0 ? transforms.getItem(0).matrix : null;
+    const k = transforms.numberOfItems > 1 ? transforms.getItem(1).matrix.a || 1 : 1;
+    return {
+      x: bbox.x * k + (translate?.e ?? 0),
+      y: bbox.y * k + (translate?.f ?? 0),
+      width: bbox.width * k,
+      height: bbox.height * k,
+    };
   }
 }

--- a/src/app/components/projects/topology-preview/topology-preview.component.ts
+++ b/src/app/components/projects/topology-preview/topology-preview.component.ts
@@ -1,0 +1,97 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  ElementRef,
+  afterNextRender,
+  inject,
+  input,
+  viewChild,
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Project } from '@models/project';
+import { Controller } from '@models/controller';
+import { Link } from '@models/link';
+import { Drawing } from '../../../cartography/models/drawing';
+import { Node } from '../../../cartography/models/node';
+import { D3MapComponent } from '../../../cartography/components/d3-map/d3-map.component';
+import { MapSettingsService } from '@services/mapsettings.service';
+
+// Height clamp (px) for the panel thumbnail's aspect-driven height.
+const PANEL_MIN_HEIGHT = 160;
+const PANEL_MAX_HEIGHT = 400;
+
+/**
+ * Static, readonly topology preview rendered from the raw `.gns3` file —
+ * the project does not need to be open.
+ *
+ * The map is uniformly scaled to fit the viewport (no pan/zoom): d3-map
+ * sizes its svg imperatively to the content-centered canvas, so the scale is
+ * applied as a CSS transform on the map host rather than fighting those
+ * attributes with a viewBox.
+ */
+@Component({
+  selector: 'app-topology-preview',
+  standalone: true,
+  imports: [D3MapComponent],
+  templateUrl: './topology-preview.component.html',
+  styleUrl: './topology-preview.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class TopologyPreviewComponent {
+  readonly controller = input.required<Controller>();
+  readonly project = input.required<Project>();
+  readonly nodes = input<Node[]>([]);
+  readonly links = input<Link[]>([]);
+  readonly drawings = input<Drawing[]>([]);
+  /** 'panel' disables pointer events so clicks reach the enlarge button. */
+  readonly variant = input<'panel' | 'dialog'>('panel');
+
+  private readonly viewport = viewChild.required<ElementRef<HTMLElement>>('viewport');
+  private readonly mapSettingsService = inject(MapSettingsService);
+  private readonly destroyRef = inject(DestroyRef);
+  private resizeObserver: ResizeObserver | null = null;
+
+  constructor() {
+    // Every d3-map redraw (data arrival, window resize, settings) rewrites
+    // the svg width/height attributes — refit after each one.
+    this.mapSettingsService.mapRenderedEmitter
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => this.recomputeScale());
+
+    afterNextRender(() => {
+      this.resizeObserver = new ResizeObserver(() => this.recomputeScale());
+      this.resizeObserver.observe(this.viewport().nativeElement);
+      this.recomputeScale();
+    });
+
+    this.destroyRef.onDestroy(() => {
+      this.resizeObserver?.disconnect();
+      this.resizeObserver = null;
+    });
+  }
+
+  /** Uniformly scale the svg (already content-centered) to fit the viewport. Idempotent and cheap. */
+  private recomputeScale(): void {
+    const viewport = this.viewport()?.nativeElement;
+    if (!viewport) return;
+    const svg = viewport.querySelector('svg');
+    if (!svg) return;
+    const width = parseFloat(svg.getAttribute('width') ?? '');
+    const height = parseFloat(svg.getAttribute('height') ?? '');
+    if (!width || !height) return;
+
+    if (this.variant() === 'panel') {
+      // The thumbnail card follows the map's actually-rendered aspect ratio
+      // (width fills the panel, height = width × svgH/svgW), clamped so an
+      // extreme topology cannot blow up the details panel. The dialog variant
+      // instead fills whatever height its container gives it.
+      const maxHeight = Math.min(PANEL_MAX_HEIGHT, Math.round(window.innerHeight * 0.45));
+      const heightByRatio = Math.round((viewport.clientWidth * height) / width);
+      viewport.style.height = `${Math.max(PANEL_MIN_HEIGHT, Math.min(heightByRatio, maxHeight))}px`;
+    }
+
+    const scale = Math.min(viewport.clientWidth / width, viewport.clientHeight / height);
+    viewport.style.setProperty('--topology-preview-scale', String(scale));
+  }
+}

--- a/src/app/components/projects/topology-preview/topology-preview.component.ts
+++ b/src/app/components/projects/topology-preview/topology-preview.component.ts
@@ -1,6 +1,7 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  computed,
   DestroyRef,
   ElementRef,
   afterNextRender,
@@ -16,6 +17,7 @@ import { Drawing } from '../../../cartography/models/drawing';
 import { Node } from '../../../cartography/models/node';
 import { D3MapComponent } from '../../../cartography/components/d3-map/d3-map.component';
 import { MapSettingsService } from '@services/mapsettings.service';
+import { ThemeService } from '@services/theme.service';
 
 // Height clamp (px) for the panel thumbnail's aspect-driven height.
 const PANEL_MIN_HEIGHT = 160;
@@ -49,8 +51,24 @@ export class TopologyPreviewComponent {
 
   private readonly viewport = viewChild.required<ElementRef<HTMLElement>>('viewport');
   private readonly mapSettingsService = inject(MapSettingsService);
+  private readonly themeService = inject(ThemeService);
   private readonly destroyRef = inject(DestroyRef);
   private resizeObserver: ResizeObserver | null = null;
+
+  /**
+   * The map's canvas-element color variables (--gns3-canvas-link-color etc.)
+   * are scoped to .project-map--light-bg/--dark-bg. The preview hosts the
+   * same svg#map, so it must apply the same light/dark class — otherwise
+   * var() resolves to nothing and link strokes render as `none`.
+   */
+  readonly mapBgClass = computed(() => {
+    const mapTheme = this.themeService.savedMapTheme;
+    const isDark = mapTheme === 'auto' ? this.themeService.isDarkMode() : mapTheme.startsWith('dark-');
+    return {
+      'topology-preview__viewport--dark-bg': isDark,
+      'topology-preview__viewport--light-bg': !isDark,
+    };
+  });
 
   constructor() {
     // Every d3-map redraw (data arrival, window resize, settings) rewrites
@@ -91,6 +109,9 @@ export class TopologyPreviewComponent {
       viewport.style.height = `${Math.max(PANEL_MIN_HEIGHT, Math.min(heightByRatio, maxHeight))}px`;
     }
 
+    // Uniformly scale the svg into the viewport. The svg (with its imperative
+    // width/height attributes) sizes the absolutely-positioned host, so the
+    // CSS transform is purely visual and nothing collapses.
     const scale = Math.min(viewport.clientWidth / width, viewport.clientHeight / height);
     viewport.style.setProperty('--topology-preview-scale', String(scale));
   }

--- a/src/app/models/gns3-file.ts
+++ b/src/app/models/gns3-file.ts
@@ -1,0 +1,92 @@
+import { Filter } from './filter';
+import { LinkStyle } from './link-style';
+import { Properties } from '../cartography/models/node';
+
+/**
+ * Shape of the raw `.gns3` topology file served by
+ * `GET /projects/{project_id}/gns3file`.
+ *
+ * The file mirrors the server API schema but omits runtime-only fields
+ * (status, ports, width/height, symbol_url, project_id) — those are filled
+ * in by `mapGns3FileTopology` (services/gns3-file.mapper.ts). Old file
+ * revisions may miss further fields, so everything except identifiers is
+ * optional.
+ */
+
+export interface Gns3FileLabel {
+  rotation?: number;
+  style?: string;
+  text?: string;
+  // null means "auto-position" — the map converters center these labels.
+  x?: number | null;
+  y?: number | null;
+}
+
+export interface Gns3FileNode {
+  node_id: string;
+  name?: string;
+  node_type?: string;
+  compute_id?: string;
+  x?: number;
+  y?: number;
+  z?: number;
+  locked?: boolean;
+  label?: Gns3FileLabel;
+  symbol?: string;
+  template_id?: string;
+  // Normally absent from the file (server-computed); tolerated if present.
+  width?: number;
+  height?: number;
+  console_auto_start?: boolean;
+  custom_adapters?: any[];
+  first_port_name?: string | null;
+  port_name_format?: string;
+  port_segment_size?: number;
+  properties?: Properties;
+}
+
+export interface Gns3FileLinkNode {
+  node_id: string;
+  adapter_number?: number;
+  port_number?: number;
+  label?: Gns3FileLabel;
+}
+
+export interface Gns3FileLink {
+  link_id: string;
+  link_type?: string;
+  nodes?: Gns3FileLinkNode[];
+  suspend?: boolean;
+  filters?: Filter;
+  link_style?: LinkStyle;
+}
+
+export interface Gns3FileDrawing {
+  drawing_id: string;
+  rotation?: number;
+  svg?: string;
+  locked?: boolean;
+  x?: number;
+  y?: number;
+  z?: number;
+}
+
+export interface Gns3FileTopology {
+  nodes?: Gns3FileNode[];
+  links?: Gns3FileLink[];
+  drawings?: Gns3FileDrawing[];
+  computes?: any[];
+}
+
+export interface Gns3ProjectFile {
+  project_id?: string;
+  name?: string;
+  revision?: number;
+  zoom?: number;
+  scene_width?: number;
+  scene_height?: number;
+  grid_size?: number;
+  show_grid?: boolean;
+  snap_to_grid?: boolean;
+  topology?: Gns3FileTopology;
+}

--- a/src/app/services/gns3-file.mapper.spec.ts
+++ b/src/app/services/gns3-file.mapper.spec.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest';
+import { mapGns3FileTopology } from './gns3-file.mapper';
+import { Gns3ProjectFile } from '../models/gns3-file';
+
+describe('mapGns3FileTopology', () => {
+  const file: Gns3ProjectFile = {
+    project_id: 'proj-1',
+    name: 'Test project',
+    scene_width: 2000,
+    scene_height: 1000,
+    topology: {
+      nodes: [
+        {
+          node_id: 'node-1',
+          name: 'R1',
+          node_type: 'qemu',
+          compute_id: 'local',
+          x: -100,
+          y: 50,
+          z: 1,
+          symbol: ':/symbols/router.svg',
+          label: { rotation: 0, style: 'font-size: 10;', text: 'R1', x: 3, y: -8 },
+        },
+        {
+          // No label — must be synthesized with null x/y (auto-center).
+          node_id: 'node-2',
+          name: 'SW1',
+          node_type: 'ethernet_switch',
+          compute_id: 'local',
+          x: 100,
+          y: 50,
+          symbol: ':/symbols/ethernet_switch.svg',
+        },
+      ],
+      links: [
+        {
+          link_id: 'link-1',
+          link_type: 'ethernet',
+          nodes: [
+            { node_id: 'node-1', adapter_number: 0, port_number: 0, label: { text: 'e0', x: 10, y: 0 } },
+            // No label / no port_number — defaults must be synthesized.
+            { node_id: 'node-2', adapter_number: 0 },
+          ],
+        },
+      ],
+      drawings: [{ drawing_id: 'drawing-1', svg: '<rect></rect>', x: 0, y: 0 }],
+    },
+  };
+
+  it('passes file node fields through and fills rendering defaults', () => {
+    const { nodes } = mapGns3FileTopology(file, 'proj-1');
+    const node = nodes[0] as any;
+
+    expect(node.node_id).toBe('node-1');
+    expect(node.name).toBe('R1');
+    expect(node.symbol).toBe(':/symbols/router.svg');
+    expect(node.x).toBe(-100);
+    expect(node.label.text).toBe('R1');
+    expect(node.label.x).toBe(3);
+    // Runtime fields the file does not store
+    expect(node.project_id).toBe('proj-1');
+    expect(node.status).toBe('stopped');
+    expect(node.width).toBe(0);
+    expect(node.height).toBe(0);
+    expect(node.ports).toEqual([]);
+    expect(node.symbol_url).toBeNull();
+  });
+
+  it('synthesizes a centered label for nodes missing one', () => {
+    const { nodes } = mapGns3FileTopology(file, 'proj-1');
+    const label = (nodes[1] as any).label;
+
+    expect(label.text).toBe('SW1');
+    // null x/y → NodeToMapNodeConverter centers the label over the node
+    expect(label.x).toBeNull();
+    expect(label.y).toBeNull();
+    expect(label.rotation).toBe(0);
+  });
+
+  it('applies safe link defaults and maps link nodes', () => {
+    const { links } = mapGns3FileTopology(file, 'proj-1');
+    const link = links[0] as any;
+
+    expect(link.project_id).toBe('proj-1');
+    expect(link.capturing).toBe(false);
+    expect(link.show_filters_icon).toBe(false);
+    expect(link.wireshark).toBe(false);
+    expect(link.suspend).toBe(false);
+    expect(link.filters).toEqual({});
+    expect(link.nodes[0].label.text).toBe('e0');
+    expect(link.nodes[1].node_id).toBe('node-2');
+    expect(link.nodes[1].adapter_number).toBe(0);
+    expect(link.nodes[1].port_number).toBe(0);
+    expect(link.nodes[1].label.text).toBe('');
+  });
+
+  it('maps drawings with tolerant defaults', () => {
+    const { drawings } = mapGns3FileTopology(file, 'proj-1');
+    const drawing = drawings[0] as any;
+
+    expect(drawing.drawing_id).toBe('drawing-1');
+    expect(drawing.svg).toBe('<rect></rect>');
+    expect(drawing.project_id).toBe('proj-1');
+    expect(drawing.rotation).toBe(0);
+    expect(drawing.locked).toBe(false);
+    expect(drawing.z).toBe(0);
+  });
+
+  it('returns empty arrays for a file without topology', () => {
+    const result = mapGns3FileTopology({ project_id: 'proj-1' }, 'proj-1');
+
+    expect(result.nodes).toEqual([]);
+    expect(result.links).toEqual([]);
+    expect(result.drawings).toEqual([]);
+  });
+
+  it('does not mutate the input file', () => {
+    const snapshot = JSON.stringify(file);
+    mapGns3FileTopology(file, 'proj-1');
+
+    expect(JSON.stringify(file)).toBe(snapshot);
+  });
+});

--- a/src/app/services/gns3-file.mapper.ts
+++ b/src/app/services/gns3-file.mapper.ts
@@ -1,0 +1,125 @@
+import { Drawing } from '../cartography/models/drawing';
+import { Node } from '../cartography/models/node';
+import { Link } from '../models/link';
+import { LinkNode } from '../models/link-node';
+import {
+  Gns3FileLabel,
+  Gns3FileLink,
+  Gns3FileLinkNode,
+  Gns3FileNode,
+  Gns3ProjectFile,
+} from '../models/gns3-file';
+
+export interface TopologyPreviewData {
+  nodes: Node[];
+  links: Link[];
+  drawings: Drawing[];
+}
+
+// Mirrors the style the server persists for freshly created node labels so
+// synthesized labels (files missing the label field) render identically.
+// Deliberately no fill: LabelWidget.applyLabelColorMode strips fill from
+// non-custom labels anyway, and the font metrics are what the label bbox
+// calculation actually uses.
+const DEFAULT_NODE_LABEL_STYLE = 'font-family: TypeWriter;font-size: 10;font-weight: bold;';
+
+function toLabel(label: Gns3FileLabel | undefined, fallbackText: string) {
+  if (label) {
+    return {
+      rotation: label.rotation ?? 0,
+      style: label.style ?? DEFAULT_NODE_LABEL_STYLE,
+      text: label.text ?? fallbackText,
+      x: label.x ?? null,
+      y: label.y ?? null,
+    };
+  }
+  // null x/y → NodeToMapNodeConverter centers the label over the node.
+  return { rotation: 0, style: DEFAULT_NODE_LABEL_STYLE, text: fallbackText, x: null, y: null };
+}
+
+function toNode(fileNode: Gns3FileNode, projectId: string): Node {
+  const name = fileNode.name ?? fileNode.node_id;
+  return {
+    ...fileNode,
+    name,
+    project_id: projectId,
+    // The file has no runtime state — render everything as stopped.
+    status: 'stopped',
+    // Filled by NodeSymbolResolverService before the map mounts (a static
+    // preview gets no WS-driven redraw that could fix these later).
+    width: fileNode.width ?? 0,
+    height: fileNode.height ?? 0,
+    symbol_url: null,
+    ports: [],
+    label: toLabel(fileNode.label, name),
+    console: null,
+    console_host: null,
+    console_type: null,
+    command_line: null,
+    node_directory: null,
+    x: fileNode.x ?? 0,
+    y: fileNode.y ?? 0,
+    z: fileNode.z ?? 0,
+    locked: fileNode.locked ?? false,
+    compute_id: fileNode.compute_id ?? null,
+    node_type: fileNode.node_type ?? '',
+    first_port_name: fileNode.first_port_name ?? null,
+    port_name_format: fileNode.port_name_format ?? '{0}',
+    port_segment_size: fileNode.port_segment_size ?? 0,
+    properties: fileNode.properties ?? ({} as any),
+  } as Node;
+}
+
+function toLinkNode(fileLinkNode: Gns3FileLinkNode): LinkNode {
+  return {
+    node_id: fileLinkNode.node_id,
+    adapter_number: fileLinkNode.adapter_number ?? 0,
+    port_number: fileLinkNode.port_number ?? 0,
+    label: toLabel(fileLinkNode.label, '') as any,
+  };
+}
+
+function toLink(fileLink: Gns3FileLink, projectId: string): Link {
+  return {
+    ...fileLink,
+    project_id: projectId,
+    link_id: fileLink.link_id,
+    link_type: fileLink.link_type ?? 'ethernet',
+    nodes: (fileLink.nodes ?? []).map(toLinkNode),
+    // capturing:false gates the filters deref in the link widget;
+    // show_filters_icon must be explicitly false (the widget shows on !== false).
+    capturing: false,
+    show_filters_icon: false,
+    wireshark: false,
+    suspend: fileLink.suspend ?? false,
+    filters: fileLink.filters ?? {},
+    capture_file_name: null,
+    capture_file_path: null,
+  } as Link;
+}
+
+function toDrawing(fileDrawing: any, projectId: string): Drawing {
+  return {
+    ...fileDrawing,
+    project_id: projectId,
+    rotation: fileDrawing.rotation ?? 0,
+    svg: fileDrawing.svg ?? '',
+    locked: fileDrawing.locked ?? false,
+    x: fileDrawing.x ?? 0,
+    y: fileDrawing.y ?? 0,
+    z: fileDrawing.z ?? 0,
+  } as Drawing;
+}
+
+/**
+ * Map a raw `.gns3` topology file onto the server-API-shaped models the map
+ * renders from (`Node`/`Link`/`Drawing`). Pure — does not mutate the input.
+ */
+export function mapGns3FileTopology(file: Gns3ProjectFile, projectId: string): TopologyPreviewData {
+  const topology = file?.topology ?? {};
+  return {
+    nodes: (topology.nodes ?? []).map((n) => toNode(n, projectId)),
+    links: (topology.links ?? []).map((l) => toLink(l, projectId)),
+    drawings: (topology.drawings ?? []).map((d) => toDrawing(d, projectId)),
+  };
+}

--- a/src/app/services/gns3-preview-pipeline.spec.ts
+++ b/src/app/services/gns3-preview-pipeline.spec.ts
@@ -1,0 +1,123 @@
+import { TestBed } from '@angular/core/testing';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { CartographyModule } from '../cartography/cartography.module';
+import { GraphDataManager } from '../cartography/managers/graph-data-manager';
+import { LayersManager } from '../cartography/managers/layers-manager';
+import { MarkerFlashService } from './marker-flash.service';
+import { SelectionManager } from '../cartography/managers/selection-manager';
+import { mapGns3FileTopology } from './gns3-file.mapper';
+import { Gns3ProjectFile } from '../models/gns3-file';
+
+// Mirrors the on-disk .gns3 structure (verified against a real project file:
+// nodes carry width/height, links carry link_style: {} and endpoint labels
+// with concrete x/y).
+const file: Gns3ProjectFile = {
+  project_id: 'p1',
+  topology: {
+    nodes: [
+      {
+        node_id: 'n1',
+        name: 'R-1',
+        node_type: 'iou',
+        compute_id: 'local',
+        x: 0,
+        y: 0,
+        z: 0,
+        width: 60,
+        height: 60,
+        symbol: ':/symbols/router.svg',
+        label: { rotation: 0, style: 'font-family: TypeWriter;font-size: 10.0;', text: 'R-1', x: 18, y: -25 },
+      },
+      {
+        node_id: 'n2',
+        name: 'R-2',
+        node_type: 'iou',
+        compute_id: 'local',
+        x: 300,
+        y: 0,
+        z: 0,
+        width: 60,
+        height: 60,
+        symbol: ':/symbols/router.svg',
+        label: { rotation: 0, style: 'font-family: TypeWriter;font-size: 10.0;', text: 'R-2', x: 18, y: -25 },
+      },
+    ],
+    links: [
+      {
+        link_id: 'l1',
+        link_style: {},
+        filters: {},
+        nodes: [
+          {
+            node_id: 'n1',
+            adapter_number: 0,
+            port_number: 0,
+            label: { rotation: 0, style: 'font-size: 10; font-style: Verdana', text: 'e0/0', x: 80, y: 35 },
+          },
+          {
+            node_id: 'n2',
+            adapter_number: 0,
+            port_number: 0,
+            label: { rotation: 0, style: 'font-size: 10; font-style: Verdana', text: 'e0/0', x: -20, y: 35 },
+          },
+        ],
+      },
+    ],
+    drawings: [],
+  },
+};
+
+describe('GNS3 file → map pipeline (static preview path)', () => {
+  let graphDataManager: GraphDataManager;
+  let layersManager: LayersManager;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [CartographyModule],
+      providers: [MarkerFlashService, SelectionManager],
+    });
+    graphDataManager = TestBed.inject(GraphDataManager);
+    layersManager = TestBed.inject(LayersManager);
+  });
+
+  it('resolves link source/target and lands links in layers from mapped file data', () => {
+    const data = mapGns3FileTopology(file, 'p1');
+    graphDataManager.setNodes(data.nodes);
+    const affected = graphDataManager.setLinks(data.links);
+
+    expect(affected.additions.links).toHaveLength(1);
+    const link = graphDataManager.getLinks()[0] as any;
+    expect(link.source?.id).toBe('n1');
+    expect(link.target?.id).toBe('n2');
+
+    const layers = layersManager.getLayersList() as any[];
+    const layerLinks = layers.flatMap((l) => l.links || []);
+    expect(layerLinks).toHaveLength(1);
+  });
+
+  it('re-diffs the same data as additions after a remount reset (GraphDataManager survives the component)', () => {
+    // First mount (e.g. panel thumbnail)
+    const data = mapGns3FileTopology(file, 'p1');
+    graphDataManager.setNodes(data.nodes);
+    graphDataManager.setLinks(data.links);
+    expect(graphDataManager.getLinks()).toHaveLength(1);
+
+    // Remount (e.g. thumbnail → dialog): createGraph clears the layers and
+    // (bug fix) resets the manager. Without the reset, the identical cached
+    // dataset diffs as unchanged, the cleared layers are never rebuilt and
+    // the new map renders blank.
+    graphDataManager.reset();
+    layersManager.clear();
+
+    const affectedNodes = graphDataManager.setNodes(data.nodes);
+    const affectedLinks = graphDataManager.setLinks(data.links);
+
+    expect(affectedNodes.additions.nodes).toHaveLength(2);
+    expect(affectedLinks.additions.links).toHaveLength(1);
+    const link = graphDataManager.getLinks()[0] as any;
+    expect(link.source?.id).toBe('n1');
+    expect(link.target?.id).toBe('n2');
+    const layers = layersManager.getLayersList() as any[];
+    expect(layers.flatMap((l) => l.links || [])).toHaveLength(1);
+  });
+});

--- a/src/app/services/node-symbol-resolver.service.spec.ts
+++ b/src/app/services/node-symbol-resolver.service.spec.ts
@@ -1,0 +1,119 @@
+import { TestBed } from '@angular/core/testing';
+import { of, throwError } from 'rxjs';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { NodeSymbolResolverService } from './node-symbol-resolver.service';
+import { SymbolService } from './symbol.service';
+import { Node } from '../cartography/models/node';
+import { Controller } from '@models/controller';
+import { environment } from 'environments/environment';
+
+describe('NodeSymbolResolverService', () => {
+  let service: NodeSymbolResolverService;
+  let mockSymbolService: any;
+  const controller = {
+    id: 1,
+    authToken: '',
+    name: 'Test Controller',
+    location: 'local',
+    host: '127.0.0.1',
+    port: 3080,
+    path: '',
+    ubridge_path: '',
+    status: 'running',
+    protocol: 'http:',
+    username: '',
+    password: '',
+    tokenExpired: false,
+  } as Controller;
+
+  const node = (overrides: Partial<Node>): Node =>
+    ({ symbol_url: null, width: 0, height: 0, symbol: ':/symbols/router.svg', ...overrides } as Node);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockSymbolService = {
+      getDimensions: vi.fn().mockReturnValue(of({ width: 70, height: 30 })),
+      getSymbolBlobUrl: vi.fn().mockReturnValue(of('blob:symbol')),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        NodeSymbolResolverService,
+        { provide: SymbolService, useValue: mockSymbolService },
+      ],
+    });
+    service = TestBed.inject(NodeSymbolResolverService);
+  });
+
+  it('returns the nodes untouched when every symbol_url is already set', async () => {
+    const nodes = [node({ symbol_url: 'blob:existing' })];
+
+    const result = await new Promise<Node[]>((resolve) => service.resolve(controller, nodes).subscribe(resolve));
+
+    expect(result).toBe(nodes);
+    expect(mockSymbolService.getDimensions).not.toHaveBeenCalled();
+    expect(mockSymbolService.getSymbolBlobUrl).not.toHaveBeenCalled();
+  });
+
+  it('fetches dimensions only for nodes with unknown size', async () => {
+    const nodes = [node({}), node({ width: 60, height: 60 })];
+
+    await new Promise<void>((resolve) => service.resolve(controller, nodes).subscribe(() => resolve()));
+
+    expect(mockSymbolService.getDimensions).toHaveBeenCalledTimes(1);
+    expect(mockSymbolService.getDimensions).toHaveBeenCalledWith(controller, ':/symbols/router.svg');
+  });
+
+  it('fetches one blob URL per unique symbol and shares it', async () => {
+    const nodes = [
+      node({ node_id: 'a' }),
+      node({ node_id: 'b' }),
+      node({ node_id: 'c', symbol: ':/symbols/cloud.svg' }),
+    ];
+    mockSymbolService.getSymbolBlobUrl.mockImplementation((_: Controller, url: string) => of(`blob:${url}`));
+
+    await new Promise<void>((resolve) => service.resolve(controller, nodes).subscribe(() => resolve()));
+
+    expect(mockSymbolService.getSymbolBlobUrl).toHaveBeenCalledTimes(2);
+    expect(mockSymbolService.getSymbolBlobUrl).toHaveBeenCalledWith(controller, '/symbols/:/symbols/router.svg/raw');
+    expect(nodes[0].symbol_url).toBe('blob:/symbols/:/symbols/router.svg/raw');
+    expect(nodes[1].symbol_url).toBe('blob:/symbols/:/symbols/router.svg/raw');
+    expect(nodes[2].symbol_url).toBe('blob:/symbols/:/symbols/cloud.svg/raw');
+  });
+
+  it('emits only after dimensions are applied', async () => {
+    const nodes = [node({})];
+
+    await new Promise<void>((resolve) =>
+      service.resolve(controller, nodes).subscribe(() => {
+        expect(nodes[0].width).toBe(70);
+        expect(nodes[0].height).toBe(30);
+        expect(nodes[0].symbol_url).toBe('blob:symbol');
+        resolve();
+      })
+    );
+  });
+
+  it('falls back to the raw controller URL when the blob fetch fails', async () => {
+    const nodes = [node({})];
+    mockSymbolService.getSymbolBlobUrl = vi.fn().mockReturnValue(throwError(() => new Error('blob failed')));
+
+    await new Promise<void>((resolve) => service.resolve(controller, nodes).subscribe(() => resolve()));
+
+    expect(nodes[0].symbol_url).toBe(
+      `http://127.0.0.1:3080/${environment.current_version}/symbols/:/symbols/router.svg/raw`
+    );
+  });
+
+  it('still completes when a dimensions fetch fails', async () => {
+    const nodes = [node({})];
+    mockSymbolService.getDimensions = vi.fn().mockReturnValue(throwError(() => new Error('dimensions failed')));
+
+    await new Promise<void>((resolve) => service.resolve(controller, nodes).subscribe(() => resolve()));
+
+    // Dimensions left untouched, but the blob URL is still assigned.
+    expect(nodes[0].width).toBe(0);
+    expect(nodes[0].symbol_url).toBe('blob:symbol');
+  });
+});

--- a/src/app/services/node-symbol-resolver.service.ts
+++ b/src/app/services/node-symbol-resolver.service.ts
@@ -1,0 +1,80 @@
+import { Injectable } from '@angular/core';
+import { forkJoin, of, Observable } from 'rxjs';
+import { catchError, map, tap } from 'rxjs/operators';
+import { Node } from '../cartography/models/node';
+import { Controller } from '@models/controller';
+import { environment } from 'environments/environment';
+import { SymbolService } from './symbol.service';
+
+/**
+ * Fills symbol_url (and width/height when unknown) on nodes that lack them.
+ *
+ * Extracted from project-map's nodesDataSource.changes handler so the static
+ * topology preview can share it. Both symbol dimensions and blob URLs are in
+ * place before the single emission: a static preview gets no WS-driven
+ * redraw that could fix them afterwards (label centering reads node.width).
+ */
+@Injectable({ providedIn: 'root' })
+export class NodeSymbolResolverService {
+  constructor(private symbolService: SymbolService) {}
+
+  resolve(controller: Controller, nodes: Node[]): Observable<Node[]> {
+    const nodesToLoad = nodes.filter((node: Node) => !node.symbol_url);
+    if (nodesToLoad.length === 0) {
+      return of(nodes);
+    }
+
+    // Fetch dimensions for any node with unknown size. Per-call catchError
+    // keeps one failing symbol from killing the join (log and continue).
+    const dimensions$ = forkJoin(
+      nodesToLoad.map((node: Node) => {
+        if (node.width == 0 && node.height == 0) {
+          return this.symbolService.getDimensions(controller, node.symbol).pipe(
+            map((dimensions) => ({ node, dimensions })),
+            catchError(() => {
+              console.error('Failed to get symbol dimensions:', node.symbol);
+              return of(null);
+            })
+          );
+        }
+        return of(null);
+      })
+    ).pipe(
+      tap((results) => {
+        for (const result of results) {
+          if (result) {
+            result.node.width = result.dimensions.width;
+            result.node.height = result.dimensions.height;
+          }
+        }
+      })
+    );
+
+    // Deduplicate: only 1 fetch per unique symbol URL (shareReplay(1) in
+    // getSymbolBlobUrl handles concurrent callers). Fall back to raw URLs if
+    // the blob fetch fails.
+    const rawUrlByNode = new Map<Node, string>();
+    nodesToLoad.forEach((node: Node) => {
+      rawUrlByNode.set(node, `/symbols/${node.symbol}/raw`);
+    });
+    const uniqueRawUrls = Array.from(new Set(rawUrlByNode.values()));
+    const blobs$ = forkJoin(uniqueRawUrls.map((url) => this.symbolService.getSymbolBlobUrl(controller, url))).pipe(
+      map((blobUrls: string[]) => {
+        const blobUrlMap = new Map(uniqueRawUrls.map((url, i) => [url, blobUrls[i]]));
+        nodesToLoad.forEach((node: Node) => {
+          node.symbol_url = blobUrlMap.get(rawUrlByNode.get(node));
+        });
+      }),
+      catchError(() => {
+        nodesToLoad.forEach((node: Node) => {
+          node.symbol_url = `${controller.protocol}//${controller.host}:${controller.port}/${
+            environment.current_version
+          }${rawUrlByNode.get(node)}`;
+        });
+        return of(null);
+      })
+    );
+
+    return forkJoin([dimensions$, blobs$]).pipe(map(() => nodes));
+  }
+}

--- a/src/app/services/project.service.ts
+++ b/src/app/services/project.service.ts
@@ -5,6 +5,7 @@ import { Drawing } from '../cartography/models/drawing';
 import { Node } from '../cartography/models/node';
 import { Link } from '@models/link';
 import { Project } from '@models/project';
+import { Gns3ProjectFile } from '@models/gns3-file';
 import { Controller } from '@models/controller';
 import { HttpController } from './http-controller.service';
 import { RecentlyOpenedProjectService } from './recentlyOpenedProject.service';
@@ -79,6 +80,11 @@ export class ProjectService {
 
   drawings(controller: Controller, project_id: string) {
     return this.httpController.get<Drawing[]>(controller, `/projects/${project_id}/drawings`);
+  }
+
+  // Raw .gns3 topology file from disk — works for closed projects too.
+  gns3file(controller: Controller, project_id: string) {
+    return this.httpController.get<Gns3ProjectFile>(controller, `/projects/${project_id}/gns3file`);
   }
 
   add(controller: Controller, project_name: string, project_id: string): Observable<any> {

--- a/src/app/services/project.service.ts
+++ b/src/app/services/project.service.ts
@@ -84,7 +84,14 @@ export class ProjectService {
 
   // Raw .gns3 topology file from disk — works for closed projects too.
   gns3file(controller: Controller, project_id: string) {
-    return this.httpController.get<Gns3ProjectFile>(controller, `/projects/${project_id}/gns3file`);
+    // The FileResponse carries ETag/Last-Modified but no Cache-Control, so
+    // browsers heuristically cache it for hours and a normal reload (F5) never
+    // revalidates — the topology preview would keep rendering a stale file
+    // after the project is edited elsewhere. `no-cache` forces revalidation:
+    // an unchanged file answers 304 via the ETag, a changed one comes fresh.
+    return this.httpController.get<Gns3ProjectFile>(controller, `/projects/${project_id}/gns3file`, {
+      headers: { 'Cache-Control': 'no-cache' },
+    });
   }
 
   add(controller: Controller, project_name: string, project_id: string): Observable<any> {

--- a/src/app/services/topology-preview.service.spec.ts
+++ b/src/app/services/topology-preview.service.spec.ts
@@ -1,0 +1,124 @@
+import { TestBed } from '@angular/core/testing';
+import { of, throwError } from 'rxjs';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { TopologyPreviewService } from './topology-preview.service';
+import { ProjectService } from './project.service';
+import { NodeSymbolResolverService } from './node-symbol-resolver.service';
+import { Gns3ProjectFile } from '../models/gns3-file';
+import { Controller } from '@models/controller';
+import { Project } from '@models/project';
+
+describe('TopologyPreviewService', () => {
+  let service: TopologyPreviewService;
+  let mockProjectService: any;
+  let mockResolver: any;
+
+  const controller = {
+    id: 1,
+    authToken: '',
+    name: 'Test Controller',
+    location: 'local',
+    host: '127.0.0.1',
+    port: 3080,
+    path: '',
+    ubridge_path: '',
+    status: 'running',
+    protocol: 'http:',
+    username: '',
+    password: '',
+    tokenExpired: false,
+  } as Controller;
+  const otherController = { ...controller, port: 3081 } as Controller;
+  const project = { project_id: 'proj-1' } as Project;
+
+  const file: Gns3ProjectFile = {
+    project_id: 'proj-1',
+    topology: {
+      nodes: [{ node_id: 'node-1', name: 'R1', symbol: ':/symbols/router.svg' }],
+      links: [],
+      drawings: [],
+    },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockProjectService = {
+      gns3file: vi.fn().mockReturnValue(of(file)),
+    };
+    // Identity resolver that marks the nodes as resolved.
+    mockResolver = {
+      resolve: vi.fn((_: Controller, nodes: any[]) => of(nodes.map((n) => ({ ...n, symbol_url: 'blob:x' })))),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        TopologyPreviewService,
+        { provide: ProjectService, useValue: mockProjectService },
+        { provide: NodeSymbolResolverService, useValue: mockResolver },
+      ],
+    });
+    service = TestBed.inject(TopologyPreviewService);
+  });
+
+  it('maps the file and resolves symbols before emitting', async () => {
+    const result = await new Promise<any>((resolve) => service.load(controller, project).subscribe(resolve));
+
+    expect(mockProjectService.gns3file).toHaveBeenCalledWith(controller, 'proj-1');
+    expect(mockResolver.resolve).toHaveBeenCalledWith(controller, expect.anything());
+    expect(result.nodes[0].node_id).toBe('node-1');
+    expect(result.nodes[0].symbol_url).toBe('blob:x');
+    expect(result.nodes[0].project_id).toBe('proj-1');
+  });
+
+  it('caches per controller+project — second load does not refetch', async () => {
+    await new Promise<void>((resolve) => service.load(controller, project).subscribe(() => resolve()));
+    await new Promise<void>((resolve) => service.load(controller, project).subscribe(() => resolve()));
+
+    expect(mockProjectService.gns3file).toHaveBeenCalledTimes(1);
+  });
+
+  it('keys the cache per controller port', async () => {
+    await new Promise<void>((resolve) => service.load(controller, project).subscribe(() => resolve()));
+    await new Promise<void>((resolve) => service.load(otherController, project).subscribe(() => resolve()));
+
+    expect(mockProjectService.gns3file).toHaveBeenCalledTimes(2);
+  });
+
+  it('evicts failed loads so a retry refetches', async () => {
+    mockProjectService.gns3file.mockReturnValueOnce(throwError(() => new Error('boom')));
+    await new Promise<void>((resolve) =>
+      service.load(controller, project).subscribe({ error: () => resolve() })
+    );
+
+    // The failed entry must not be replayed.
+    await new Promise<void>((resolve) => service.load(controller, project).subscribe(() => resolve()));
+
+    expect(mockProjectService.gns3file).toHaveBeenCalledTimes(2);
+  });
+
+  it('invalidate(projectId) drops only matching entries', async () => {
+    service.load(controller, project).subscribe();
+    service.load(controller, { project_id: 'proj-2' } as Project).subscribe();
+
+    service.invalidate('proj-1');
+
+    await new Promise<void>((resolve) => service.load(controller, project).subscribe(() => resolve()));
+    await new Promise<void>((resolve) =>
+      service.load(controller, { project_id: 'proj-2' } as Project).subscribe(() => resolve())
+    );
+
+    // proj-1 evicted → refetch; proj-2 still cached.
+    expect(mockProjectService.gns3file).toHaveBeenCalledTimes(3);
+  });
+
+  it('invalidate() clears everything', async () => {
+    service.load(controller, project).subscribe();
+
+    service.invalidate();
+
+    await new Promise<void>((resolve) => service.load(controller, project).subscribe(() => resolve()));
+
+    expect(mockProjectService.gns3file).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/app/services/topology-preview.service.spec.ts
+++ b/src/app/services/topology-preview.service.spec.ts
@@ -31,7 +31,6 @@ describe('TopologyPreviewService', () => {
     password: '',
     tokenExpired: false,
   } as Controller;
-  const otherController = { ...controller, port: 3081 } as Controller;
   const project = { project_id: 'proj-1' } as Project;
 
   const file: Gns3ProjectFile = {
@@ -44,18 +43,12 @@ describe('TopologyPreviewService', () => {
   };
 
   /** Subscribe, flush the asyncScheduler timer, and resolve with the emission. */
-  async function loadOnce(ctrl: Controller = controller, proj: Project = project): Promise<any> {
+  async function loadOnce(): Promise<any> {
     const promise = new Promise<any>((resolve, reject) =>
-      service.load(ctrl, proj).subscribe({ next: resolve, error: reject })
+      service.load(controller, project).subscribe({ next: resolve, error: reject })
     );
     await vi.runAllTimersAsync();
     return promise;
-  }
-
-  /** Fire-and-forget load with the scheduler flushed. */
-  async function loadBackground(ctrl: Controller = controller, proj: Project = project): Promise<void> {
-    service.load(ctrl, proj).subscribe();
-    await vi.runAllTimersAsync();
   }
 
   beforeEach(() => {
@@ -89,56 +82,24 @@ describe('TopologyPreviewService', () => {
     expect(result.nodes[0].project_id).toBe('proj-1');
   });
 
-  it('caches per controller+project — second load does not refetch', async () => {
-    await loadOnce();
-    await loadOnce();
-
-    expect(mockProjectService.gns3file).toHaveBeenCalledTimes(1);
-  });
-
-  it('keys the cache per controller port', async () => {
-    await loadOnce();
-    await loadOnce(otherController);
-
-    expect(mockProjectService.gns3file).toHaveBeenCalledTimes(2);
-  });
-
-  it('evicts failed loads so a retry refetches', async () => {
+  it('propagates load errors to the consumer', async () => {
     mockProjectService.gns3file.mockReturnValueOnce(throwError(() => new Error('boom')));
-    await loadOnce().catch(() => undefined);
 
-    // The failed entry must not be replayed.
-    await loadOnce();
+    // Handler attached at subscribe time — a later `.rejects` would miss the
+    // fake-timer flush window and surface as an unhandled rejection.
+    const outcome = new Promise<unknown>((resolve) => {
+      service.load(controller, project).subscribe({
+        next: (value) => resolve(value),
+        error: (err) => resolve(err),
+      });
+    });
+    const result = await vi.runAllTimersAsync().then(() => outcome);
 
-    expect(mockProjectService.gns3file).toHaveBeenCalledTimes(2);
+    expect(result).toBeInstanceOf(Error);
+    expect((result as Error).message).toBe('boom');
   });
 
-  it('invalidate(projectId) drops only matching entries', async () => {
-    await loadBackground();
-    await loadBackground(controller, { project_id: 'proj-2' } as Project);
-
-    service.invalidate('proj-1');
-
-    await loadOnce();
-    await loadOnce(controller, { project_id: 'proj-2' } as Project);
-
-    // proj-1 evicted → refetch; proj-2 still cached.
-    expect(mockProjectService.gns3file).toHaveBeenCalledTimes(3);
-  });
-
-  it('invalidate() clears everything', async () => {
-    await loadBackground();
-
-    service.invalidate();
-
-    await loadOnce();
-
-    expect(mockProjectService.gns3file).toHaveBeenCalledTimes(2);
-  });
-
-  it('always emits asynchronously, even on a cache hit', async () => {
-    await loadOnce();
-
+  it('always emits asynchronously', async () => {
     let emitted = false;
     service.load(controller, project).subscribe(() => {
       emitted = true;

--- a/src/app/services/topology-preview.service.spec.ts
+++ b/src/app/services/topology-preview.service.spec.ts
@@ -8,6 +8,9 @@ import { Gns3ProjectFile } from '../models/gns3-file';
 import { Controller } from '@models/controller';
 import { Project } from '@models/project';
 
+// The test setup installs fake timers and the service subscribes on the
+// asyncScheduler (so the loading → ready transition always renders) — every
+// load must be drained with runAllTimersAsync.
 describe('TopologyPreviewService', () => {
   let service: TopologyPreviewService;
   let mockProjectService: any;
@@ -40,6 +43,21 @@ describe('TopologyPreviewService', () => {
     },
   };
 
+  /** Subscribe, flush the asyncScheduler timer, and resolve with the emission. */
+  async function loadOnce(ctrl: Controller = controller, proj: Project = project): Promise<any> {
+    const promise = new Promise<any>((resolve, reject) =>
+      service.load(ctrl, proj).subscribe({ next: resolve, error: reject })
+    );
+    await vi.runAllTimersAsync();
+    return promise;
+  }
+
+  /** Fire-and-forget load with the scheduler flushed. */
+  async function loadBackground(ctrl: Controller = controller, proj: Project = project): Promise<void> {
+    service.load(ctrl, proj).subscribe();
+    await vi.runAllTimersAsync();
+  }
+
   beforeEach(() => {
     vi.clearAllMocks();
 
@@ -62,7 +80,7 @@ describe('TopologyPreviewService', () => {
   });
 
   it('maps the file and resolves symbols before emitting', async () => {
-    const result = await new Promise<any>((resolve) => service.load(controller, project).subscribe(resolve));
+    const result = await loadOnce();
 
     expect(mockProjectService.gns3file).toHaveBeenCalledWith(controller, 'proj-1');
     expect(mockResolver.resolve).toHaveBeenCalledWith(controller, expect.anything());
@@ -72,53 +90,62 @@ describe('TopologyPreviewService', () => {
   });
 
   it('caches per controller+project — second load does not refetch', async () => {
-    await new Promise<void>((resolve) => service.load(controller, project).subscribe(() => resolve()));
-    await new Promise<void>((resolve) => service.load(controller, project).subscribe(() => resolve()));
+    await loadOnce();
+    await loadOnce();
 
     expect(mockProjectService.gns3file).toHaveBeenCalledTimes(1);
   });
 
   it('keys the cache per controller port', async () => {
-    await new Promise<void>((resolve) => service.load(controller, project).subscribe(() => resolve()));
-    await new Promise<void>((resolve) => service.load(otherController, project).subscribe(() => resolve()));
+    await loadOnce();
+    await loadOnce(otherController);
 
     expect(mockProjectService.gns3file).toHaveBeenCalledTimes(2);
   });
 
   it('evicts failed loads so a retry refetches', async () => {
     mockProjectService.gns3file.mockReturnValueOnce(throwError(() => new Error('boom')));
-    await new Promise<void>((resolve) =>
-      service.load(controller, project).subscribe({ error: () => resolve() })
-    );
+    await loadOnce().catch(() => undefined);
 
     // The failed entry must not be replayed.
-    await new Promise<void>((resolve) => service.load(controller, project).subscribe(() => resolve()));
+    await loadOnce();
 
     expect(mockProjectService.gns3file).toHaveBeenCalledTimes(2);
   });
 
   it('invalidate(projectId) drops only matching entries', async () => {
-    service.load(controller, project).subscribe();
-    service.load(controller, { project_id: 'proj-2' } as Project).subscribe();
+    await loadBackground();
+    await loadBackground(controller, { project_id: 'proj-2' } as Project);
 
     service.invalidate('proj-1');
 
-    await new Promise<void>((resolve) => service.load(controller, project).subscribe(() => resolve()));
-    await new Promise<void>((resolve) =>
-      service.load(controller, { project_id: 'proj-2' } as Project).subscribe(() => resolve())
-    );
+    await loadOnce();
+    await loadOnce(controller, { project_id: 'proj-2' } as Project);
 
     // proj-1 evicted → refetch; proj-2 still cached.
     expect(mockProjectService.gns3file).toHaveBeenCalledTimes(3);
   });
 
   it('invalidate() clears everything', async () => {
-    service.load(controller, project).subscribe();
+    await loadBackground();
 
     service.invalidate();
 
-    await new Promise<void>((resolve) => service.load(controller, project).subscribe(() => resolve()));
+    await loadOnce();
 
     expect(mockProjectService.gns3file).toHaveBeenCalledTimes(2);
+  });
+
+  it('always emits asynchronously, even on a cache hit', async () => {
+    await loadOnce();
+
+    let emitted = false;
+    service.load(controller, project).subscribe(() => {
+      emitted = true;
+    });
+    // Before the scheduler fires, the loading state must still be observable.
+    expect(emitted).toBe(false);
+    await vi.runAllTimersAsync();
+    expect(emitted).toBe(true);
   });
 });

--- a/src/app/services/topology-preview.service.ts
+++ b/src/app/services/topology-preview.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
-import { Observable } from 'rxjs';
-import { map, mergeMap, shareReplay, tap } from 'rxjs/operators';
+import { asyncScheduler, Observable } from 'rxjs';
+import { map, mergeMap, shareReplay, subscribeOn, tap } from 'rxjs/operators';
 import { Controller } from '@models/controller';
 import { Project } from '@models/project';
 import { ProjectService } from './project.service';
@@ -27,8 +27,10 @@ export class TopologyPreviewService {
 
   load(controller: Controller, project: Project): Observable<TopologyPreviewData> {
     const key = `${controller.host}:${controller.port}:${project.project_id}`;
+    // Both paths (fresh and cached) go through the deferred return below —
+    // a synchronous cache replay would skip the consumer's loading frame.
     const cached = this.cache.get(key);
-    if (cached) return cached;
+    if (cached) return cached.pipe(subscribeOn(asyncScheduler, 1));
 
     const load$ = this.projectService.gns3file(controller, project.project_id).pipe(
       map((file) => mapGns3FileTopology(file, project.project_id)),
@@ -40,7 +42,12 @@ export class TopologyPreviewService {
       shareReplay(1)
     );
     this.cache.set(key, load$);
-    return load$;
+    // Always deliver asynchronously (also on cache hits): the consumer drives
+    // a loading → ready state machine whose loading frame must actually render
+    // — a synchronous replay skips it, the map never remounts, and the canvas
+    // origin stays locked to the previous project's content center. Note the
+    // explicit delay: asyncScheduler executes delay-0 actions synchronously.
+    return load$.pipe(subscribeOn(asyncScheduler, 1));
   }
 
   /** Drop cached entries — for a projectId, or everything when omitted. */

--- a/src/app/services/topology-preview.service.ts
+++ b/src/app/services/topology-preview.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { asyncScheduler, Observable } from 'rxjs';
-import { map, mergeMap, shareReplay, subscribeOn, tap } from 'rxjs/operators';
+import { map, mergeMap, subscribeOn } from 'rxjs/operators';
 import { Controller } from '@models/controller';
 import { Project } from '@models/project';
 import { ProjectService } from './project.service';
@@ -12,52 +12,31 @@ import { mapGns3FileTopology, TopologyPreviewData } from './gns3-file.mapper';
  * (`GET /projects/{id}/gns3file` — available for closed projects) and maps it
  * onto the models the map renders from.
  *
- * Results are cached per controller+project (shareReplay): switching between
- * the panel thumbnail and the enlarged dialog remounts the map but never
- * refetches. Failed loads are evicted so a later selection retries.
+ * Every call fetches fresh (the request revalidates via ETag — an unchanged
+ * file answers 304): the file changes whenever the project is edited
+ * elsewhere, and holding a cached copy would silently drop those changes.
+ * GraphDataManager diff-renders identical content as a no-op, so a
+ * same-content refetch stays cheap.
  */
 @Injectable({ providedIn: 'root' })
 export class TopologyPreviewService {
-  private cache = new Map<string, Observable<TopologyPreviewData>>();
-
   constructor(
     private projectService: ProjectService,
     private nodeSymbolResolver: NodeSymbolResolverService
   ) {}
 
   load(controller: Controller, project: Project): Observable<TopologyPreviewData> {
-    const key = `${controller.host}:${controller.port}:${project.project_id}`;
-    // Both paths (fresh and cached) go through the deferred return below —
-    // a synchronous cache replay would skip the consumer's loading frame.
-    const cached = this.cache.get(key);
-    if (cached) return cached.pipe(subscribeOn(asyncScheduler, 1));
-
-    const load$ = this.projectService.gns3file(controller, project.project_id).pipe(
+    // Deliver asynchronously: the consumer drives a loading → ready state
+    // machine whose loading frame must actually render — a synchronous
+    // emission skips it, the map never remounts, and the canvas origin stays
+    // locked to the previous project's content center. Note the explicit
+    // delay: asyncScheduler executes delay-0 actions synchronously.
+    return this.projectService.gns3file(controller, project.project_id).pipe(
       map((file) => mapGns3FileTopology(file, project.project_id)),
       mergeMap((data) =>
         this.nodeSymbolResolver.resolve(controller, data.nodes).pipe(map((nodes) => ({ ...data, nodes })))
       ),
-      // Evict failures before shareReplay caches them, so a retry refetches.
-      tap({ error: () => this.cache.delete(key) }),
-      shareReplay(1)
+      subscribeOn(asyncScheduler, 1)
     );
-    this.cache.set(key, load$);
-    // Always deliver asynchronously (also on cache hits): the consumer drives
-    // a loading → ready state machine whose loading frame must actually render
-    // — a synchronous replay skips it, the map never remounts, and the canvas
-    // origin stays locked to the previous project's content center. Note the
-    // explicit delay: asyncScheduler executes delay-0 actions synchronously.
-    return load$.pipe(subscribeOn(asyncScheduler, 1));
-  }
-
-  /** Drop cached entries — for a projectId, or everything when omitted. */
-  invalidate(projectId?: string): void {
-    if (projectId === undefined) {
-      this.cache.clear();
-      return;
-    }
-    for (const key of Array.from(this.cache.keys())) {
-      if (key.endsWith(`:${projectId}`)) this.cache.delete(key);
-    }
   }
 }

--- a/src/app/services/topology-preview.service.ts
+++ b/src/app/services/topology-preview.service.ts
@@ -1,0 +1,56 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { map, mergeMap, shareReplay, tap } from 'rxjs/operators';
+import { Controller } from '@models/controller';
+import { Project } from '@models/project';
+import { ProjectService } from './project.service';
+import { NodeSymbolResolverService } from './node-symbol-resolver.service';
+import { mapGns3FileTopology, TopologyPreviewData } from './gns3-file.mapper';
+
+/**
+ * Loads a static topology preview from the raw `.gns3` file
+ * (`GET /projects/{id}/gns3file` — available for closed projects) and maps it
+ * onto the models the map renders from.
+ *
+ * Results are cached per controller+project (shareReplay): switching between
+ * the panel thumbnail and the enlarged dialog remounts the map but never
+ * refetches. Failed loads are evicted so a later selection retries.
+ */
+@Injectable({ providedIn: 'root' })
+export class TopologyPreviewService {
+  private cache = new Map<string, Observable<TopologyPreviewData>>();
+
+  constructor(
+    private projectService: ProjectService,
+    private nodeSymbolResolver: NodeSymbolResolverService
+  ) {}
+
+  load(controller: Controller, project: Project): Observable<TopologyPreviewData> {
+    const key = `${controller.host}:${controller.port}:${project.project_id}`;
+    const cached = this.cache.get(key);
+    if (cached) return cached;
+
+    const load$ = this.projectService.gns3file(controller, project.project_id).pipe(
+      map((file) => mapGns3FileTopology(file, project.project_id)),
+      mergeMap((data) =>
+        this.nodeSymbolResolver.resolve(controller, data.nodes).pipe(map((nodes) => ({ ...data, nodes })))
+      ),
+      // Evict failures before shareReplay caches them, so a retry refetches.
+      tap({ error: () => this.cache.delete(key) }),
+      shareReplay(1)
+    );
+    this.cache.set(key, load$);
+    return load$;
+  }
+
+  /** Drop cached entries — for a projectId, or everything when omitted. */
+  invalidate(projectId?: string): void {
+    if (projectId === undefined) {
+      this.cache.clear();
+      return;
+    }
+    for (const key of Array.from(this.cache.keys())) {
+      if (key.endsWith(`:${projectId}`)) this.cache.delete(key);
+    }
+  }
+}

--- a/src/styles/_dialogs.scss
+++ b/src/styles/_dialogs.scss
@@ -1900,6 +1900,27 @@ html[data-density='compact'] .node-configurator-dialog-panel {
   --gns3-dialog-width: 600px;
 }
 
+// Static topology preview: 70% of the viewport in both axes. Width flows
+// through the SDS (--gns3-dialog-width is auto-capped by the viewport cap);
+// 70vh sits between the 60/80 tiers, so it is set here like the other
+// deviations.
+.topology-preview-dialog-panel {
+  --gns3-dialog-width: 70vw;
+
+  mat-dialog-container,
+  .mat-mdc-dialog-container {
+    height: 70vh;
+  }
+
+  .mat-mdc-dialog-content {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    padding: 0;
+    overflow: hidden;
+  }
+}
+
 // Shared destructive actions use semantic error tokens in every dialog size.
 button.destructive-button {
   color: var(--mat-sys-on-error);

--- a/src/styles/_map.scss
+++ b/src/styles/_map.scss
@@ -82,6 +82,16 @@ svg#map {
   background: var(--gns3-map-bg, var(--mat-sys-surface));
 }
 
+/* Static topology preview: the whole map is CSS-scaled to fit its viewport;
+   keep link strokes at their designed width so they stay visible at thumbnail
+   scales (a 2px stroke at 0.1 scale would vanish, looking like "links are
+   not rendered"). Scoped to the preview viewport — the live project map is
+   untouched. Runtime-created elements carry no encapsulation attribute, so
+   this must live in a global stylesheet. */
+.topology-preview__viewport g.link path {
+  vector-effect: non-scaling-stroke;
+}
+
 /* Node selection grayscale effect: keep status badges colored */
 svg#map g.node_body.selected > image {
   filter: grayscale(100%);

--- a/src/styles/_map.scss
+++ b/src/styles/_map.scss
@@ -82,12 +82,11 @@ svg#map {
   background: var(--gns3-map-bg, var(--mat-sys-surface));
 }
 
-/* Static topology preview: the whole map is CSS-scaled to fit its viewport;
-   keep link strokes at their designed width so they stay visible at thumbnail
-   scales (a 2px stroke at 0.1 scale would vanish, looking like "links are
-   not rendered"). Scoped to the preview viewport — the live project map is
-   untouched. Runtime-created elements carry no encapsulation attribute, so
-   this must live in a global stylesheet. */
+/* Static topology preview: the whole map is CSS-scaled to fit its viewport.
+   Link strokes keep their designed width (e.g. 2px) instead of shrinking with
+   the scale, matching the live project map look. Scoped to the preview
+   viewport — the live project map is untouched. Runtime-created elements
+   carry no encapsulation attribute, so this lives in a global stylesheet. */
 .topology-preview__viewport g.link path {
   vector-effect: non-scaling-stroke;
 }
@@ -112,10 +111,15 @@ svg#map g.selection-line-tool path.selection {
 // =============================================
 // Colors for text labels and links that adapt to
 // the canvas background (light vs dark).
-// Usage: .project-map--light-bg or .project-map--dark-bg
+// Usage: .project-map--light-bg / .project-map--dark-bg on the live map,
+// .topology-preview__viewport--light-bg / --dark-bg on the static preview.
+// The static preview hosts the same <svg id="map"> (via d3-map) — without
+// these variables there, var(--gns3-canvas-link-color) resolves to nothing
+// and link strokes fall back to `none`, i.e. links are invisible.
 // ============================================= */
 
-.project-map {
+.project-map,
+.topology-preview__viewport {
   /* Default (light) colors */
   --gns3-canvas-label-color: #000000;
   --gns3-canvas-link-color: #000000;


### PR DESCRIPTION
## Summary

Renders a static topology preview for any project directly from its raw `.gns3` file — works for closed projects, no compute or opened map needed. Surfaced as an inline map in the projects list detail panel plus a 70vw × 70vh enlarge dialog.

Rebased onto the current `3.1` tip (after #1787), so only the six topology-preview commits remain.

## Data pipeline

- `TopologyPreviewService` fetches `GET /projects/{id}/gns3file` and maps it onto the models the map renders from, via the new `Gns3File` model + `gns3-file.mapper` (nodes, links, drawings)
- `NodeSymbolResolverService` resolves each node's symbol to its SVG so preview icons match the live map
- `ProjectService.gns3file()` sends `Cache-Control: no-cache`: the FileResponse carries ETag/Last-Modified but no Cache-Control, so browsers heuristically cache it for hours and a reload never revalidates — the preview would keep rendering a stale file after the project is edited elsewhere. With `no-cache`, an unchanged file answers 304 via the ETag
- Emission is forced asynchronous (`subscribeOn(asyncScheduler, 1)`): the consumer's loading frame must actually render once, or the map never remounts and the canvas origin stays locked to the previous project's content

## Rendering fixes (cartography)

- Drawing extents are reserved in `getSize()`: a drawing's `(x, y)` is the **top-left** of its box and its svg root `width`/`height` is the box size — drawings used to count as points, so the canvas clipped the bottom/right overhang (`maxX = max(maxX, x + element.width)`, with `element?.width ?? 0` for unsupported svg)
- `MapDrawing.element` is now assigned eagerly in `DrawingToMapDrawingConverter` (the `setDrawings` path) instead of lazily inside `DrawingsWidget.draw()` — anything `getSize()` consumes must exist before `graphLayout.draw()` runs; converting in the widget is a silent no-op
- Preview fit-scale uses the `g.canvas` content bbox, not the viewport-floored padded canvas, so small topologies don't shrink to nothing
- Canvas colors come from theme variables scoped to the preview surface (`_map.scss`, `_dialogs.scss`)

## Projects list

- Topology counts merged into one row and detail actions compacted

## Testing

- New specs: `topology-preview.service`, `gns3-file.mapper`, `gns3-preview-pipeline`, `node-symbol-resolver.service`, `projects.component`