### PR TITLE
fix(preferences): remove deleted template from local state instead of refetching

### DIFF
--- a/src/app/components/preferences/preferences.component.spec.ts
+++ b/src/app/components/preferences/preferences.component.spec.ts
@@ -189,6 +189,20 @@ describe('PreferencesComponent', () => {
     expect(deleteItem).toHaveBeenCalledWith('Edge Router', 'qemu-1');
   });
 
+  it('removes a deleted template from local state without refetching the list', () => {
+    const listCallsBefore = mockTemplateService.list.mock.calls.length;
+    component.selectTemplate(templates[0]);
+
+    component.onTemplateDeleted('qemu-1');
+    fixture.detectChanges();
+
+    expect(component.templates().map((template) => template.template_id)).toEqual(['docker-1', 'switch-1']);
+    expect(component.filteredTemplates()).toHaveLength(2);
+    expect(component.selectedTemplate()).toBeNull();
+    expect(component.loading()).toBe(false);
+    expect(mockTemplateService.list.mock.calls.length).toBe(listCallsBefore);
+  });
+
   it('provides readable type labels and resource summaries', () => {
     expect(component.templateTypeLabel('ethernet_switch')).toBe('Ethernet Switch');
     expect(component.templateTypeLabel('custom_emulator')).toBe('Custom Emulator');

--- a/src/app/components/preferences/preferences.component.ts
+++ b/src/app/components/preferences/preferences.component.ts
@@ -350,11 +350,18 @@ export class PreferencesComponent implements OnInit {
     }
   }
 
+  /**
+   * Removes a deleted template from local state instead of refetching the
+   * whole list: the delete event only fires after the server confirmed the
+   * deletion, and the signal -> computed -> trackBy chain updates the DOM
+   * surgically (no full-table reload flicker).
+   */
   onTemplateDeleted(templateId: string): void {
+    this.templates.update((templates) => templates.filter((template) => template.template_id !== templateId));
     if (this.selectedTemplate()?.template_id === templateId) {
       this.closeDetails();
     }
-    this.loadTemplates();
+    this.ensureValidPage();
   }
 
   trackTemplate(_index: number, template: TemplateListItem): string {


### PR DESCRIPTION
## Problem

Deleting a template in the Preferences dialog called `loadTemplates()`, which refetched the whole list and rebuilt the table. This caused a visible full-table flicker and needlessly re-set the loading state, even though the server had already confirmed the deletion.

## Solution

`onTemplateDeleted()` now removes the template from the local `templates` signal and calls `ensureValidPage()` to fix up pagination. The delete event only fires after the server confirmed the deletion, so the local removal is safe. The signal → computed → `trackTemplate` chain updates the DOM surgically with no full-table reload.

## Testing

- New unit test: `removes a deleted template from local state without refetching the list` — verifies the template disappears from `templates()` and `filteredTemplates()`, the selection resets when the deleted template was selected, `loading()` stays `false`, and `TemplateService.list` is not called again.