### PR TITLE
feat(templates): pull new Docker images while creating a template

### DIFF
--- a/src/app/components/preferences/docker/add-docker-template/add-docker-template.component.html
+++ b/src/app/components/preferences/docker/add-docker-template/add-docker-template.component.html
@@ -90,18 +90,31 @@
                   </mat-select>
                 </mat-form-field>
                 } @if (newImageSelected) {
-                <mat-form-field appearance="fill" class="docker-add__field">
-                  <mat-label>Image name</mat-label>
-                  <input
-                    matInput
-                    required
-                    class="filename"
-                    type="text"
-                    [value]="filename()"
-                    (input)="filename.set($event.target.value)"
-                    placeholder="Image name"
-                  />
-                </mat-form-field>
+                <div class="docker-add__image-row">
+                  <mat-form-field appearance="fill" class="docker-add__field">
+                    <mat-label>Image name</mat-label>
+                    <input
+                      matInput
+                      required
+                      class="filename"
+                      type="text"
+                      [value]="filename()"
+                      (input)="filename.set($event.target.value)"
+                      placeholder="Image name"
+                    />
+                  </mat-form-field>
+                  <button
+                    mat-stroked-button
+                    color="primary"
+                    class="docker-add__pull-btn"
+                    type="button"
+                    [disabled]="isPulling() || !filename().trim()"
+                    (click)="pullImage()"
+                  >
+                    <mat-icon>cloud_download</mat-icon>
+                    {{ isPulling() ? 'Pulling…' : 'Pull image' }}
+                  </button>
+                </div>
                 }
               </div>
             </section>

--- a/src/app/components/preferences/docker/add-docker-template/add-docker-template.component.scss
+++ b/src/app/components/preferences/docker/add-docker-template/add-docker-template.component.scss
@@ -87,6 +87,27 @@
   width: 100%;
 }
 
+/* "Image name" + inline "Pull image" action, mirroring the template editor. */
+.docker-add__image-row {
+  display: flex;
+  align-items: center;
+  gap: var(--gns3-density-card-gap);
+}
+
+.docker-add__image-row .docker-add__field {
+  flex: 1;
+}
+
+.docker-add__image-row .mat-mdc-form-field-subscript-wrapper {
+  display: none;
+}
+
+/* Match the "Pull image" button height to the Image name field so it sits flush. */
+.docker-add__image-row .docker-add__pull-btn {
+  align-self: stretch;
+  white-space: nowrap;
+}
+
 /* =============================================
 // Actions
 // ============================================= */
@@ -147,6 +168,14 @@
 
   .docker-add__step-content {
     padding: 12px 16px 20px;
+  }
+
+  .docker-add__image-row {
+    flex-direction: column;
+  }
+
+  .docker-add__pull-btn {
+    width: 100%;
   }
 
   .docker-add__actions {

--- a/src/app/components/preferences/docker/add-docker-template/add-docker-template.component.spec.ts
+++ b/src/app/components/preferences/docker/add-docker-template/add-docker-template.component.spec.ts
@@ -102,6 +102,7 @@ describe('AddDockerTemplateComponent', () => {
     mockDockerService = {
       getImages: vi.fn().mockReturnValue(of(mockDockerImages)),
       addTemplate: vi.fn().mockReturnValue(of(mockDockerTemplate)),
+      pullImage: vi.fn().mockReturnValue(of(undefined)),
     };
 
     mockTemplateMocksService = {
@@ -247,6 +248,41 @@ describe('AddDockerTemplateComponent', () => {
       component.setDiskImage('existingImage');
 
       expect(component.newImageSelected).toBe(false);
+    });
+  });
+
+  describe('pullImage', () => {
+    it('should not pull when the image name is empty', () => {
+      component.filename.set('   ');
+
+      component.pullImage();
+
+      expect(mockDockerService.pullImage).not.toHaveBeenCalled();
+      expect(component.isPulling()).toBe(false);
+    });
+
+    it('should pull the trimmed image name on the local compute and refresh the image list', () => {
+      component.filename.set('  nginx:1.27  ');
+      // The harness runs ngOnInit twice (explicit call + first detectChanges),
+      // so assert the pull adds exactly one refresh instead of an absolute count.
+      const getImagesCallsBefore = mockDockerService.getImages.mock.calls.length;
+
+      component.pullImage();
+
+      expect(mockDockerService.pullImage).toHaveBeenCalledWith(mockController, 'nginx:1.27', 'local');
+      expect(mockToasterService.success).toHaveBeenCalledWith("Docker image 'nginx:1.27' pulled");
+      expect(component.isPulling()).toBe(false);
+      expect(mockDockerService.getImages.mock.calls.length).toBe(getImagesCallsBefore + 1);
+    });
+
+    it('should show an error toaster and reset isPulling when the pull fails', () => {
+      mockDockerService.pullImage.mockReturnValue(throwError(() => ({ error: { message: 'Pull failed' } })));
+      component.filename.set('nginx:1.27');
+
+      component.pullImage();
+
+      expect(mockToasterService.error).toHaveBeenCalledWith('Pull failed');
+      expect(component.isPulling()).toBe(false);
     });
   });
 

--- a/src/app/components/preferences/docker/add-docker-template/add-docker-template.component.ts
+++ b/src/app/components/preferences/docker/add-docker-template/add-docker-template.component.ts
@@ -8,6 +8,7 @@ import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { MatStepperModule } from '@angular/material/stepper';
 import { CdkTextareaAutosize } from '@angular/cdk/text-field';
+import { finalize } from 'rxjs';
 import { v4 as uuid } from 'uuid';
 import { DockerImage } from '@models/docker/docker-image';
 import { Controller } from '@models/controller';
@@ -60,6 +61,7 @@ export class AddDockerTemplateComponent implements OnInit {
   newImageSelected: boolean = false;
   isLocalComputerChosen: boolean = true;
   readonly selectedStepIndex = signal(0);
+  readonly isPulling = signal(false);
 
   // Model signals for form fields
   filename = model('');
@@ -123,6 +125,46 @@ export class AddDockerTemplateComponent implements OnInit {
 
   setDiskImage(value: string) {
     this.newImageSelected = value === 'newImage';
+  }
+
+  /**
+   * Pulls the named image on the local compute while the wizard is still open,
+   * so the template is created against an image that is already present.
+   */
+  pullImage() {
+    const image = this.filename().trim();
+    const controller = this.controller;
+    if (!image || !controller || this.isPulling()) {
+      return;
+    }
+
+    this.isPulling.set(true);
+    this.dockerService
+      .pullImage(controller, image, 'local')
+      .pipe(
+        finalize(() => {
+          this.isPulling.set(false);
+          this.cd.markForCheck();
+        })
+      )
+      .subscribe({
+        next: () => {
+          this.toasterService.success(`Docker image '${image}' pulled`);
+          // Refresh the list so the pulled image also shows under "Existing image".
+          // The pull already succeeded, so a refresh failure is not worth a toaster.
+          this.dockerService.getImages(controller).subscribe({
+            next: (images) => {
+              this.dockerImages = images;
+              this.cd.markForCheck();
+            },
+            error: () => {},
+          });
+        },
+        error: (err) => {
+          const message = err.error?.message || err.message || `Failed to pull Docker image '${image}'`;
+          this.toasterService.error(message);
+        },
+      });
   }
 
   canAdvance(): boolean {


### PR DESCRIPTION
## Problem

In the Docker template wizard, choosing "New image" and typing an image name only recorded the name — the image itself had to be pulled some other way (e.g. from the template editor after the fact) before nodes created from the template could start.

## Solution

The "New image" branch now shows the image name field with an inline **Pull image** action, mirroring the template editor's interaction:

- Pulls the trimmed image name on the `local` compute (the wizard only offers running locally).
- The button is disabled while the name is empty or a pull is in flight, and shows "Pulling…" during the pull.
- On success: a toaster confirms the pull and the image list is refreshed so the pulled image immediately appears under "Existing image"; a failed refresh is silent because the pull itself already succeeded.
- On failure: the server message (with fallback) is shown via toaster and the pulling state is reset.

## Testing

- Three new `AddDockerTemplateComponent` tests: empty name never triggers a pull; success pulls the trimmed name on `local` and adds exactly one image-list refresh; failure shows the error toaster and resets `isPulling`.
- Full spec passes (50/50) and `yarn ng lint` passes.
- Layout mirrors `docker-template-details` (flush button height, stacked full-width on <768px).