### PR TITLE
feat: Display Docker interface status on link labels

### DIFF
--- a/src/app/cartography/converters/map/link-to-map-link-converter.spec.ts
+++ b/src/app/cartography/converters/map/link-to-map-link-converter.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Link } from '@models/link';
+import { LabelToMapLabelConverter } from './label-to-map-label-converter';
+import { LinkNodeToMapLinkNodeConverter } from './link-node-to-map-link-node-converter';
+import { LinkToMapLinkConverter } from './link-to-map-link-converter';
+
+function createConverter(): LinkToMapLinkConverter {
+  const labelConverter = {
+    convert: vi.fn((label) => label),
+  } as unknown as LabelToMapLabelConverter;
+  return new LinkToMapLinkConverter(new LinkNodeToMapLinkNodeConverter(labelConverter));
+}
+
+describe('LinkToMapLinkConverter', () => {
+  it('maps runtime interface states to endpoint render states', () => {
+    const converter = createConverter();
+    const link = {
+      link_id: 'link-1',
+      nodes: [
+        { node_id: 'node-1', adapter_number: 0, port_number: 0, label: { text: 'eth0' } },
+        { node_id: 'node-2', adapter_number: 1, port_number: 0, label: { text: 'eth1' } },
+      ],
+      interface_statuses: ['stopped', 'started'],
+    } as Link;
+
+    const mapLink = converter.convert(link);
+
+    expect(mapLink.nodes[0].interfaceStatus).toBe('stopped');
+    expect(mapLink.nodes[1].interfaceStatus).toBe('started');
+  });
+
+  it('leaves endpoint status undefined when no runtime state was reported', () => {
+    const converter = createConverter();
+    const link = {
+      link_id: 'link-1',
+      nodes: [{ node_id: 'node-1', adapter_number: 0, port_number: 0, label: { text: 'eth0' } }],
+    } as Link;
+
+    expect(converter.convert(link).nodes[0].interfaceStatus).toBeUndefined();
+  });
+});

--- a/src/app/cartography/converters/map/link-to-map-link-converter.ts
+++ b/src/app/cartography/converters/map/link-to-map-link-converter.ts
@@ -34,9 +34,12 @@ export class LinkToMapLinkConverter implements Converter<Link, MapLink> {
     }
 
     mapLink.linkType = link.link_type;
-    mapLink.nodes = link.nodes.map((linkNode) =>
-      this.linkNodeToMapLinkNode.convert(linkNode, { link_id: link.link_id })
-    );
+    mapLink.nodes = link.nodes.map((linkNode, index) => {
+      const mapLinkNode = this.linkNodeToMapLinkNode.convert(linkNode, { link_id: link.link_id });
+      const interfaceStatus = link.interface_statuses?.[index];
+      if (interfaceStatus) mapLinkNode.interfaceStatus = interfaceStatus;
+      return mapLinkNode;
+    });
     mapLink.projectId = link.project_id;
     mapLink.suspend = link.suspend;
     mapLink.show_filters_icon = link.show_filters_icon;

--- a/src/app/cartography/helpers/item-signature.spec.ts
+++ b/src/app/cartography/helpers/item-signature.spec.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { linkSignatures } from './item-signature';
+
+describe('linkSignatures', () => {
+  it('detects runtime interface status changes as visual changes', () => {
+    const link = {
+      link_id: 'link-1',
+      nodes: [],
+      capturing: false,
+      suspend: false,
+      show_filters_icon: true,
+      wireshark: false,
+      link_type: 'ethernet',
+      interface_statuses: ['started'],
+    };
+    const before = linkSignatures(link);
+
+    link.interface_statuses = ['stopped'];
+    const after = linkSignatures(link);
+
+    expect(after.groups.visual).not.toBe(before.groups.visual);
+  });
+});

--- a/src/app/cartography/helpers/item-signature.ts
+++ b/src/app/cartography/helpers/item-signature.ts
@@ -84,10 +84,10 @@ export function nodeSignatures(
 // ── Link ────────────────────────────────────────────────────────
 
 export function linkSignatures(
-  l: { link_id: string; nodes: unknown; capturing: unknown; suspend: unknown; show_filters_icon: unknown; wireshark: unknown; link_type: unknown; filters?: unknown; link_style?: unknown }
+  l: { link_id: string; nodes: unknown; capturing: unknown; suspend: unknown; show_filters_icon: unknown; wireshark: unknown; link_type: unknown; filters?: unknown; link_style?: unknown; interface_statuses?: unknown }
 ): ItemSignatures<LinkSigGroup> {
   const nodes = JSON.stringify(l.nodes);
-  const visual = `${l.capturing}|${l.suspend}|${l.show_filters_icon}|${l.wireshark}|${l.link_type}|${JSON.stringify(l.filters)}|${JSON.stringify(l.link_style)}`;
+  const visual = `${l.capturing}|${l.suspend}|${l.show_filters_icon}|${l.wireshark}|${l.link_type}|${JSON.stringify(l.filters)}|${JSON.stringify(l.link_style)}|${JSON.stringify(l.interface_statuses)}`;
   return {
     all: `${l.link_id}|${nodes}|${visual}`,
     groups: { nodes, visual },

--- a/src/app/cartography/models/map/map-link-node.ts
+++ b/src/app/cartography/models/map/map-link-node.ts
@@ -8,6 +8,7 @@ export class MapLinkNode implements Indexed {
   adapterNumber: number;
   portNumber: number;
   label: MapLabel;
+  interfaceStatus?: 'started' | 'stopped';
   // Runtime-only render offsets used to dynamically swap Bezier label sides.
   bezierRenderOffsetX?: number;
   bezierRenderOffsetY?: number;

--- a/src/app/cartography/widgets/interface-status.spec.ts
+++ b/src/app/cartography/widgets/interface-status.spec.ts
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+
+import { select } from 'd3-selection';
+import { describe, expect, it } from 'vitest';
+
+import { MapLink } from '../models/map/map-link';
+import { MapNode } from '../models/map/map-node';
+import { InterfaceStatusWidget } from './interface-status';
+
+describe('InterfaceStatusWidget', () => {
+  it('renders each self-link endpoint using its own runtime interface status', () => {
+    const node = { id: 'docker-1', status: 'started' } as MapNode;
+    const link = {
+      nodes: [
+        { nodeId: node.id, label: { text: 'eth0' }, interfaceStatus: 'stopped' },
+        { nodeId: node.id, label: { text: 'eth1' }, interfaceStatus: 'started' },
+      ],
+      source: node,
+      target: node,
+      suspend: false,
+      parallelLinksCount: 1,
+    } as MapLink;
+    const widget = new InterfaceStatusWidget({
+      showInterfaceLabels: true,
+      integrateLinkLabelsToLinks: true,
+    } as any);
+    const svg = select(document.body).append('svg');
+    const view = svg.append('g').datum(link) as any;
+    const path = view.append('path').node() as SVGPathElement;
+    path.getTotalLength = () => 200;
+    path.getPointAtLength = (distance: number) => ({ x: distance, y: 0 }) as SVGPoint;
+
+    widget.draw(view);
+
+    expect(view.selectAll('rect.status_stopped').size()).toBe(1);
+    expect(view.selectAll('rect.status_started').size()).toBe(1);
+    expect(view.select('text.status_stopped_label').text()).toBe('eth0');
+    expect(view.select('text.status_started_label').text()).toBe('eth1');
+  });
+
+  it('keeps a stopped node red even if its last interface status was up', () => {
+    const stoppedNode = { id: 'docker-1', status: 'stopped' } as MapNode;
+    const startedNode = { id: 'docker-2', status: 'started' } as MapNode;
+    const link = {
+      nodes: [
+        { nodeId: stoppedNode.id, label: { text: 'eth0' }, interfaceStatus: 'started' },
+        { nodeId: startedNode.id, label: { text: 'eth0' }, interfaceStatus: 'started' },
+      ],
+      source: stoppedNode,
+      target: startedNode,
+      suspend: false,
+      parallelLinksCount: 1,
+    } as MapLink;
+    const widget = new InterfaceStatusWidget({
+      showInterfaceLabels: true,
+      integrateLinkLabelsToLinks: true,
+    } as any);
+    const svg = select(document.body).append('svg');
+    const view = svg.append('g').datum(link) as any;
+    const path = view.append('path').node() as SVGPathElement;
+    path.getTotalLength = () => 200;
+    path.getPointAtLength = (distance: number) => ({ x: distance, y: 0 }) as SVGPoint;
+
+    widget.draw(view);
+
+    expect(view.selectAll('rect.status_stopped').size()).toBe(1);
+    expect(view.selectAll('rect.status_started').size()).toBe(1);
+  });
+});

--- a/src/app/cartography/widgets/interface-status.ts
+++ b/src/app/cartography/widgets/interface-status.ts
@@ -50,12 +50,20 @@ export class InterfaceStatusWidget implements Widget {
             : InterfaceStatusWidget.LABEL_DISTANCE;
           const start_point: SVGPoint = pathNode.getPointAtLength(labelDistance);
           const end_point: SVGPoint = pathNode.getPointAtLength(totalLength - labelDistance);
-          const sourcePort = l.nodes?.find((node) => node.nodeId === l.source.id)?.label?.text || '';
-          const destinationPort = l.nodes?.find((node) => node.nodeId === l.target.id)?.label?.text || '';
+          // GraphDataManager resolves source/target from nodes[0]/nodes[1].
+          // Preserve that ordering so self-links can report each adapter independently.
+          const sourceEndpoint = l.nodes?.[0];
+          const destinationEndpoint = l.nodes?.[1];
+          const sourcePort = sourceEndpoint?.label?.text || '';
+          const destinationPort = destinationEndpoint?.label?.text || '';
+          const sourceStatus =
+            l.source.status === 'started' ? sourceEndpoint?.interfaceStatus || l.source.status : l.source.status;
+          const destinationStatus =
+            l.target.status === 'started' ? destinationEndpoint?.interfaceStatus || l.target.status : l.target.status;
 
           statuses = [
-            new LinkStatus(start_point.x, start_point.y, l.suspend ? 'suspended' : l.source.status, sourcePort),
-            new LinkStatus(end_point.x, end_point.y, l.suspend ? 'suspended' : l.target.status, destinationPort),
+            new LinkStatus(start_point.x, start_point.y, l.suspend ? 'suspended' : sourceStatus, sourcePort),
+            new LinkStatus(end_point.x, end_point.y, l.suspend ? 'suspended' : destinationStatus, destinationPort),
           ];
         }
       }

--- a/src/app/components/project-map/project-map.component.spec.ts
+++ b/src/app/components/project-map/project-map.component.spec.ts
@@ -360,6 +360,8 @@ describe('ProjectMapComponent', () => {
       errorNotificationEmitter: of({ type: 'error', message: 'Test error' }),
       warningNotificationEmitter: of({ type: 'warning', message: 'Test warning' }),
       handleMessage: vi.fn(),
+      applyInterfaceStatuses: vi.fn(),
+      clearInterfaceStatuses: vi.fn(),
     };
 
     mockMapChangeDetectorRef = {

--- a/src/app/components/project-map/project-map.component.ts
+++ b/src/app/components/project-map/project-map.component.ts
@@ -759,6 +759,7 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
       }),
       mergeMap(() => this.projectService.links(this.controller, project.project_id)),
       tap((links: Link[]) => {
+        this.projectWebServiceHandler.applyInterfaceStatuses(links);
         this.linksDataSource.set(links);
         this.markerRegistryService.rebuildAll(links);
       }),
@@ -1945,6 +1946,7 @@ export class ProjectMapComponent implements OnInit, OnDestroy {
     this.drawingsDataSource.clear();
     this.nodesDataSource.clear();
     this.linksDataSource.clear();
+    if (this.project.project_id) this.projectWebServiceHandler.clearInterfaceStatuses(this.project.project_id);
 
     // Marker services are app-lifetime singletons that outlive this component:
     // clear the legend registry (stale pills until the next project's links

--- a/src/app/handlers/project-web-service-handler.spec.ts
+++ b/src/app/handlers/project-web-service-handler.spec.ts
@@ -42,6 +42,7 @@ describe('ProjectWebServiceHandler', () => {
       add: vi.fn(),
       remove: vi.fn(),
       get: vi.fn(),
+      getItems: vi.fn().mockReturnValue([]),
     };
 
     mockDrawingsDataSource = {
@@ -104,6 +105,159 @@ describe('ProjectWebServiceHandler', () => {
   });
 
   describe('handleMessage - node actions', () => {
+    it('should apply a Docker interface status to the matching link endpoint', () => {
+      const link = {
+        link_id: 'link-1',
+        project_id: 'project-1',
+        nodes: [
+          { node_id: 'node-1', adapter_number: 0, port_number: 0 },
+          { node_id: 'node-2', adapter_number: 0, port_number: 0 },
+        ],
+      } as Link;
+      mockLinksDataSource.getItems.mockReturnValue([link]);
+      const event = {
+        project_id: 'project-1',
+        node_id: 'node-1',
+        adapter_number: 0,
+        port_number: 0,
+        status: 'started' as const,
+      };
+
+      handler.handleMessage({ action: 'node.interface_status', event });
+
+      expect(link.interface_statuses).toEqual(['started']);
+      expect(mockLinksDataSource.update).toHaveBeenCalledWith(link);
+    });
+
+    it('should apply a cached interface status when its link is created later', () => {
+      const event = {
+        project_id: 'project-1',
+        node_id: 'node-1',
+        adapter_number: 0,
+        port_number: 0,
+        status: 'down' as const,
+      };
+      handler.handleMessage({ action: 'node.interface_status', event });
+      const link = {
+        link_id: 'link-1',
+        project_id: 'project-1',
+        nodes: [{ node_id: 'node-1', adapter_number: 0, port_number: 0 }],
+      } as Link;
+
+      handler.handleMessage({ action: 'link.created', event: link });
+
+      expect(link.interface_statuses).toEqual(['stopped']);
+      expect(mockLinksDataSource.add).toHaveBeenCalledWith(link);
+    });
+
+    it('should not redraw a link for an unchanged interface status resync', () => {
+      const link = {
+        link_id: 'link-1',
+        project_id: 'project-1',
+        nodes: [{ node_id: 'node-1', adapter_number: 0, port_number: 0 }],
+      } as Link;
+      mockLinksDataSource.getItems.mockReturnValue([link]);
+      const message: WebServiceMessage = {
+        action: 'node.interface_status',
+        event: {
+          project_id: 'project-1',
+          node_id: 'node-1',
+          adapter_number: 0,
+          port_number: 0,
+          status: 'down',
+        },
+      };
+
+      handler.handleMessage(message);
+      handler.handleMessage(message);
+
+      expect(mockLinksDataSource.update).toHaveBeenCalledTimes(1);
+    });
+
+    it('should reapply cached interface statuses after a topology refresh', () => {
+      const event = {
+        project_id: 'project-1',
+        node_id: 'node-1',
+        adapter_number: 0,
+        port_number: 0,
+        status: 'down' as const,
+      };
+      handler.handleMessage({ action: 'node.interface_status', event });
+      const refreshedLink = {
+        link_id: 'link-1',
+        project_id: 'project-1',
+        nodes: [{ node_id: 'node-1', adapter_number: 0, port_number: 0 }],
+      } as Link;
+
+      handler.applyInterfaceStatuses([refreshedLink]);
+
+      expect(refreshedLink.interface_statuses).toEqual(['stopped']);
+    });
+
+    it('should clear cached interface statuses for only the requested project', () => {
+      handler.handleMessage({
+        action: 'node.interface_status',
+        event: {
+          project_id: 'project-1',
+          node_id: 'node-1',
+          adapter_number: 0,
+          port_number: 0,
+          status: 'down',
+        },
+      });
+      handler.handleMessage({
+        action: 'node.interface_status',
+        event: {
+          project_id: 'project-2',
+          node_id: 'node-2',
+          adapter_number: 0,
+          port_number: 0,
+          status: 'up',
+        },
+      });
+
+      handler.clearInterfaceStatuses('project-1');
+      const projectOneLink = {
+        project_id: 'project-1',
+        nodes: [{ node_id: 'node-1', adapter_number: 0, port_number: 0 }],
+      } as Link;
+      const projectTwoLink = {
+        project_id: 'project-2',
+        nodes: [{ node_id: 'node-2', adapter_number: 0, port_number: 0 }],
+      } as Link;
+      handler.applyInterfaceStatuses([projectOneLink, projectTwoLink]);
+
+      expect(projectOneLink.interface_statuses).toBeUndefined();
+      expect(projectTwoLink.interface_statuses).toEqual(['started']);
+    });
+
+    it('should apply started, stopped, and started transitions to a running interface', () => {
+      const link = {
+        link_id: 'link-1',
+        project_id: 'project-1',
+        nodes: [{ node_id: 'node-1', adapter_number: 0, port_number: 0 }],
+      } as Link;
+      mockLinksDataSource.getItems.mockReturnValue([link]);
+      const event = {
+        project_id: 'project-1',
+        node_id: 'node-1',
+        adapter_number: 0,
+        port_number: 0,
+        status: 'started' as 'started' | 'stopped',
+      };
+
+      handler.handleMessage({ action: 'node.interface_status', event });
+      expect(link.interface_statuses).toEqual(['started']);
+      event.status = 'stopped';
+      handler.handleMessage({ action: 'node.interface_status', event });
+      expect(link.interface_statuses).toEqual(['stopped']);
+      event.status = 'started';
+      handler.handleMessage({ action: 'node.interface_status', event });
+
+      expect(link.interface_statuses).toEqual(['started']);
+      expect(mockLinksDataSource.update).toHaveBeenCalledTimes(3);
+    });
+
     it('should call nodesDataSource.update and emit for node.updated', () => {
       const message: WebServiceMessage = {
         action: 'node.updated',

--- a/src/app/handlers/project-web-service-handler.ts
+++ b/src/app/handlers/project-web-service-handler.ts
@@ -14,6 +14,16 @@ export class WebServiceMessage {
   event: Node | Link | Drawing | any;
 }
 
+export interface InterfaceStatusEvent {
+  project_id: string;
+  node_id: string;
+  adapter_number: number;
+  port_number: number;
+  status: 'started' | 'stopped' | 'up' | 'down';
+}
+
+type InterfaceStatus = 'started' | 'stopped';
+
 @Injectable()
 export class ProjectWebServiceHandler {
   public nodeNotificationEmitter = new EventEmitter<WebServiceMessage>();
@@ -24,6 +34,8 @@ export class ProjectWebServiceHandler {
   public warningNotificationEmitter = new EventEmitter<any>();
   public errorNotificationEmitter = new EventEmitter<any>();
 
+  private interfaceStatuses = new Map<string, InterfaceStatus>();
+
   constructor(
     private nodesDataSource: NodesDataSource,
     private linksDataSource: LinksDataSource,
@@ -33,6 +45,24 @@ export class ProjectWebServiceHandler {
   ) {}
 
   public handleMessage(message: WebServiceMessage) {
+    if (message.action === 'node.interface_status') {
+      const event = message.event as InterfaceStatusEvent;
+      const status = this.normalizeInterfaceStatus(event.status);
+      if (!status) return;
+      this.interfaceStatuses.set(this.interfaceStatusKey(event), status);
+      for (const link of this.linksDataSource.getItems()) {
+        const endpointIndex = (link.nodes || []).findIndex(
+          (node) =>
+            node.node_id === event.node_id &&
+            node.adapter_number === event.adapter_number &&
+            node.port_number === event.port_number
+        );
+        if (endpointIndex >= 0 && link.interface_statuses?.[endpointIndex] !== status) {
+          this.setInterfaceStatus(link, endpointIndex, status);
+          this.linksDataSource.update(link);
+        }
+      }
+    }
     if (message.action === 'node.updated') {
       this.nodesDataSource.update(message.event as Node);
       this.nodeNotificationEmitter.emit(message);
@@ -42,17 +72,23 @@ export class ProjectWebServiceHandler {
       this.nodeNotificationEmitter.emit(message);
     }
     if (message.action === 'node.deleted') {
-      this.nodesDataSource.remove(message.event as Node);
+      const node = message.event as Node;
+      this.nodesDataSource.remove(node);
+      for (const key of this.interfaceStatuses.keys()) {
+        if (key.startsWith(`${node.project_id}:${node.node_id}:`)) this.interfaceStatuses.delete(key);
+      }
       this.nodeNotificationEmitter.emit(message);
     }
     if (message.action === 'link.created') {
       const link = message.event as Link;
+      this.applyInterfaceStatusesToLink(link);
       this.linksDataSource.add(link);
       this.markerRegistryService.reconcileLink(link);
       this.linkNotificationEmitter.emit(message);
     }
     if (message.action === 'link.updated') {
       const link = message.event as Link;
+      this.applyInterfaceStatusesToLink(link);
       this.linksDataSource.update(link);
       this.markerRegistryService.reconcileLink(link);
       this.linkNotificationEmitter.emit(message);
@@ -103,5 +139,50 @@ export class ProjectWebServiceHandler {
     if (message.action === 'log.info') {
       this.infoNotificationEmitter.emit(message.event.message);
     }
+  }
+
+  public applyInterfaceStatuses(links: Link[]): void {
+    links.forEach((link) => this.applyInterfaceStatusesToLink(link));
+  }
+
+  public clearInterfaceStatuses(projectId: string): void {
+    for (const key of this.interfaceStatuses.keys()) {
+      if (key.startsWith(`${projectId}:`)) this.interfaceStatuses.delete(key);
+    }
+  }
+
+  private interfaceStatusKey(event: {
+    project_id: string;
+    node_id: string;
+    adapter_number: number;
+    port_number: number;
+  }): string {
+    return `${event.project_id}:${event.node_id}:${event.adapter_number}:${event.port_number}`;
+  }
+
+  private normalizeInterfaceStatus(status: InterfaceStatusEvent['status']): InterfaceStatus | undefined {
+    if (status === 'started' || status === 'up') return 'started';
+    if (status === 'stopped' || status === 'down') return 'stopped';
+    return undefined;
+  }
+
+  private applyInterfaceStatusesToLink(link: Link): void {
+    for (const [index, endpoint] of (link.nodes || []).entries()) {
+      const status = this.interfaceStatuses.get(
+        this.interfaceStatusKey({
+          project_id: link.project_id,
+          node_id: endpoint.node_id,
+          adapter_number: endpoint.adapter_number,
+          port_number: endpoint.port_number,
+        })
+      );
+      if (status && link.interface_statuses?.[index] !== status) this.setInterfaceStatus(link, index, status);
+    }
+  }
+
+  private setInterfaceStatus(link: Link, endpointIndex: number, status: InterfaceStatus): void {
+    const statuses = [...(link.interface_statuses || [])];
+    statuses[endpointIndex] = status;
+    link.interface_statuses = statuses;
   }
 }

--- a/src/app/models/link.ts
+++ b/src/app/models/link.ts
@@ -18,6 +18,7 @@ export class Link {
   show_filters_icon: boolean; // Control visibility of filter icons on the link (from server)
   wireshark: boolean; // true for Web Wireshark, false for traditional Wireshark
   markers?: MarkerMap; // Traffic-insight markers (non-empty ⇒ show the markers icon)
+  interface_statuses?: Array<'started' | 'stopped' | undefined>; // runtime only; excluded from update payloads
 
   distance: number; // this is not from controller
   length: number; // this is not from controller

--- a/src/app/services/link.service.spec.ts
+++ b/src/app/services/link.service.spec.ts
@@ -420,6 +420,19 @@ describe('LinkService', () => {
       expect(payload).toEqual({});
     });
 
+    it('should exclude runtime interface statuses from the payload', () => {
+      const mockLink = {
+        link_id: 'link-status',
+        project_id: 'project-status',
+        interface_statuses: ['stopped', 'started'],
+      } as Link;
+      mockHttpController.put.mockReturnValue(of(mockLink));
+
+      service.updateLink(mockController, mockLink);
+
+      expect(mockHttpController.put.mock.calls[0][2]).toEqual({});
+    });
+
     it('should call correct endpoint', () => {
       const mockLink: Link = {
         link_id: 'link-update',


### PR DESCRIPTION
## Summary

Display live Docker interface status on link endpoint labels.

- Process `node.interface_status` project notifications.
- Render started interfaces in green and stopped interfaces in red.
- Preserve node-stopped and link-suspended status precedence.
- Support independent endpoint states, including self-links.
- Cache runtime states for links created or refreshed after notifications arrive.
- Preserve states across WebSocket topology refreshes and clear them when leaving a project.
- Avoid unnecessary redraws for unchanged periodic notifications.
- Exclude runtime interface states from link update API payloads.
- Accept both `started`/`stopped` and `up`/`down` notification values for compatibility.

## Testing

- Full test suite: 6,987 passed, 13 skipped
- Focused interface-status tests: 103 passed
- Lint: passed
- Development build: passed
---
The web-ui changes required for implementing https://github.com/GNS3/gns3-server/issues/1672

## Demo
https://github.com/user-attachments/assets/fe96c711-70ed-4936-9916-0a807afb1650