### PR TITLE
feat(preferences): render template description as markdown in details panel

### DIFF
--- a/src/app/components/preferences/preferences.component.html
+++ b/src/app/components/preferences/preferences.component.html
@@ -447,7 +447,7 @@
           @if (template.usage) {
           <section class="templates-page__description">
             <span>Description</span>
-            <p>{{ template.usage }}</p>
+            <app-markdown-viewer [data]="template.usage" />
           </section>
           }
 

--- a/src/app/components/preferences/preferences.component.scss
+++ b/src/app/components/preferences/preferences.component.scss
@@ -772,16 +772,20 @@ button.templates-page__action--delete {
   }
 }
 
-.templates-page__description p {
-  margin: 8px 0 0;
-  padding: 10px 12px;
+.templates-page__description app-markdown-viewer {
+  // Card shell for the rendered markdown; typography itself comes from the
+  // global app-markdown-viewer styles, personalized here via the
+  // --markdown-viewer-* tokens. Padding is slim because the global paragraph
+  // margin (8px) completes the visual inset inside the card.
+  display: block;
+  margin-top: 8px;
+  padding: 2px 12px;
   border-radius: 10px;
-  color: var(--mat-sys-on-surface);
   background: var(--mat-sys-surface-container-low);
-  font-size: 13px;
-  line-height: 1.5;
-  white-space: pre-wrap;
   overflow-wrap: anywhere;
+  --markdown-viewer-font-size: 13px;
+  --markdown-viewer-line-height: 1.5;
+  --markdown-viewer-heading-scale: 0.85;
 }
 
 .templates-page__detail-row {

--- a/src/app/components/preferences/preferences.component.ts
+++ b/src/app/components/preferences/preferences.component.ts
@@ -20,6 +20,7 @@ import { ControllerService } from '@services/controller.service';
 import { SymbolService } from '@services/symbol.service';
 import { TemplateService } from '@services/template.service';
 import { ToasterService } from '@services/toaster.service';
+import { MarkdownViewerComponent } from '../../common/markdown-viewer/markdown-viewer.component';
 import { CopyTemplateDialogComponent, CopyTemplateDialogData } from './common/copy-template-dialog/copy-template-dialog.component';
 import { DeleteTemplateComponent } from './common/delete-template-component/delete-template.component';
 
@@ -63,6 +64,7 @@ type TemplateListItem = Template &
     MatTableModule,
     MatTooltipModule,
     DeleteTemplateComponent,
+    MarkdownViewerComponent,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })


### PR DESCRIPTION
## Description

The template details panel in Preferences renders the template's `usage` text as plain interpolated text, so newlines, lists, links and emphasis from appliance registry descriptions were collapsed into a single paragraph.

This swaps the plain `<p>` for the shared `app-markdown-viewer` component (introduced with the unified markdown viewer work), so the description is rendered as markdown with the same typography pipeline used by project READMEs and the info dialog.

## Changes

- `preferences.component.html`: render `template.usage` through `app-markdown-viewer`
- `preferences.component.ts`: import/register `MarkdownViewerComponent`
- `preferences.component.scss`: keep the existing card shell on the viewer host and personalize typography via the `--markdown-viewer-*` tokens (`13px` body, `1.5` line height, `0.85` heading scale to fit the narrow side panel); slim padding compensates the global 8px paragraph margin inside the card

## Notes

- Sanitization stays on ngx-markdown defaults (registry content is semi-trusted)
- No `white-space: pre-wrap` needed anymore — ngx-markdown converts newlines into proper paragraphs/lists

## Testing

- `yarn ng build` passes
- `yarn lint` passes