### PR TITLE
fix(forms): stop writing invalid "" to input[type=color]

### DIFF
--- a/src/app/components/project-map/drawings-editors/link-style-editor/link-style-editor.component.ts
+++ b/src/app/components/project-map/drawings-editors/link-style-editor/link-style-editor.component.ts
@@ -27,6 +27,7 @@ import { LinksDataSource } from '../../../../cartography/datasources/links-datas
 import { LinksEventSource } from '../../../../cartography/events/links-event-source';
 import { LinkToMapLinkConverter } from '../../../../cartography/converters/map/link-to-map-link-converter';
 import { StyleTranslator } from '../../../../cartography/widgets/links/style-translator';
+import { SafeColorValueAccessor } from '../../../../directives/safe-color-value-accessor.directive';
 
 @Component({
   selector: 'app-link-style-editor',
@@ -43,6 +44,7 @@ import { StyleTranslator } from '../../../../cartography/widgets/links/style-tra
     MatOptionModule,
     MatButtonModule,
     MatProgressSpinnerModule,
+    SafeColorValueAccessor,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/src/app/components/project-map/marker-manager/marker-form.component.ts
+++ b/src/app/components/project-map/marker-manager/marker-form.component.ts
@@ -8,6 +8,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { CdkTextareaAutosize } from '@angular/cdk/text-field';
+import { SafeColorValueAccessor } from '../../../directives/safe-color-value-accessor.directive';
 
 /** A capture-node dropdown option — one of the link's endpoints. */
 export interface MarkerCaptureOption {
@@ -50,6 +51,7 @@ export const MARKER_CAPTURE_AUTO = 'auto';
     MatTooltipModule,
     MatProgressSpinnerModule,
     CdkTextareaAutosize,
+    SafeColorValueAccessor,
   ],
   template: `
     <form class="marker-form" [formGroup]="form()" (ngSubmit)="save.emit()">

--- a/src/app/components/project-map/marker-manager/marker-manager.component.ts
+++ b/src/app/components/project-map/marker-manager/marker-manager.component.ts
@@ -30,6 +30,7 @@ import { MatDividerModule } from '@angular/material/divider';
 import { MatDialog } from '@angular/material/dialog';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { CdkTextareaAutosize } from '@angular/cdk/text-field';
+import { SafeColorValueAccessor } from '../../../directives/safe-color-value-accessor.directive';
 import { Subject, animationFrameScheduler, forkJoin, fromEvent } from 'rxjs';
 import { auditTime, switchMap, takeUntil, tap } from 'rxjs/operators';
 import { ResizeEvent, ResizableDirective, ResizeHandleDirective } from 'angular-resizable-element';
@@ -130,6 +131,7 @@ function notGlobalName(control: AbstractControl): { notGlobalName: true } | null
     ResizableDirective,
     ResizeHandleDirective,
     MarkerFormComponent,
+    SafeColorValueAccessor,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/src/app/components/projects/projects.component.ts
+++ b/src/app/components/projects/projects.component.ts
@@ -164,8 +164,7 @@ export class ProjectsComponent implements OnInit {
       if (paginator) {
         paginator.firstPage();
       }
-    },
-    { allowSignalWrites: true }
+    }
   );
 
   /** Avoid destructive bulk actions retaining projects hidden by a filter. */

--- a/src/app/directives/safe-color-value-accessor.directive.spec.ts
+++ b/src/app/directives/safe-color-value-accessor.directive.spec.ts
@@ -1,0 +1,79 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { SafeColorValueAccessor } from './safe-color-value-accessor.directive';
+
+/** Minimal host rendering a reactive color input driven by the accessor under test. */
+@Component({
+  standalone: true,
+  imports: [ReactiveFormsModule, SafeColorValueAccessor],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `<input type="color" [formControl]="ctrl" />`,
+})
+class HostComponent {
+  readonly ctrl = new FormControl<string | null>(null);
+}
+
+describe('SafeColorValueAccessor', () => {
+  let fixture: ComponentFixture<HostComponent>;
+  let host: HostComponent;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    await TestBed.configureTestingModule({
+      imports: [HostComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(HostComponent);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    if (fixture) {
+      fixture.destroy();
+    }
+  });
+
+  function colorInput(): HTMLInputElement {
+    return fixture.nativeElement.querySelector('input[type=color]');
+  }
+
+  it('shows the placeholder swatch for a null model instead of writing "" to the input', () => {
+    expect(host.ctrl.value).toBeNull();
+    expect(colorInput().value).toBe(SafeColorValueAccessor.PLACEHOLDER);
+  });
+
+  it('keeps the model null (server-picked default) while showing the placeholder', () => {
+    colorInput(); // initial write already happened — the model must stay untouched
+    expect(host.ctrl.value).toBeNull();
+  });
+
+  it('shows the placeholder for an empty-string model', () => {
+    host.ctrl.setValue('');
+    fixture.detectChanges();
+    expect(colorInput().value).toBe(SafeColorValueAccessor.PLACEHOLDER);
+  });
+
+  it('falls back to the placeholder for a non-hex value', () => {
+    host.ctrl.setValue('none');
+    fixture.detectChanges();
+    expect(colorInput().value).toBe(SafeColorValueAccessor.PLACEHOLDER);
+  });
+
+  it('writes a valid hex model to the input unchanged', () => {
+    host.ctrl.setValue('#00ff88');
+    fixture.detectChanges();
+    expect(colorInput().value).toBe('#00ff88');
+  });
+
+  it('emits the picked color to the model on user input', () => {
+    const input = colorInput();
+    input.value = '#123456';
+    input.dispatchEvent(new Event('input'));
+
+    expect(host.ctrl.value).toBe('#123456');
+  });
+});

--- a/src/app/directives/safe-color-value-accessor.directive.ts
+++ b/src/app/directives/safe-color-value-accessor.directive.ts
@@ -1,0 +1,42 @@
+import { Directive, forwardRef } from '@angular/core';
+import { DefaultValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+
+/**
+ * `input[type=color]` only accepts `#rrggbb` values. `DefaultValueAccessor`
+ * writes `''` for a `null`/empty model (and forms sometimes start as `''`),
+ * which the browser rejects with
+ * "The specified value "" does not conform to the required format."
+ * every single time the control is written — once per dialog open, reset and
+ * edit-mode patch.
+ *
+ * This accessor keeps the model semantics ("no color picked" stays `null`) but
+ * renders a placeholder swatch instead of writing an invalid value to the DOM.
+ * Any user interaction still emits the picked `#rrggbb` as usual.
+ */
+@Directive({
+  // Value accessors match by input type + form binding (like Angular's own
+  // NumberValueAccessor) so every reactive color input is covered — the prefix
+  // convention doesn't fit that pattern.
+  /* eslint-disable-next-line @angular-eslint/directive-selector -- CVA type-matched selector, like Angular's own accessors */
+  selector: 'input[type=color][formControlName],input[type=color][formControl],input[type=color][ngModel]',
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => SafeColorValueAccessor),
+      multi: true,
+    },
+  ],
+})
+export class SafeColorValueAccessor extends DefaultValueAccessor {
+  private static readonly HEX_COLOR = /^#[0-9a-f]{6}$/i;
+
+  /** Swatch shown while the model has no color — the browser's own fallback. */
+  static readonly PLACEHOLDER = '#000000';
+
+  override writeValue(value: string | null): void {
+    this.setProperty(
+      'value',
+      value && SafeColorValueAccessor.HEX_COLOR.test(value) ? value : SafeColorValueAccessor.PLACEHOLDER
+    );
+  }
+}


### PR DESCRIPTION
## Problem

The browser console logged the following on every marker dialog open / reset / edit patch:

```
The specified value "" does not conform to the required format.  The value must be a valid CSS color.
```

`<input type="color">` only accepts `#rrggbb`. Angular's `DefaultValueAccessor` writes `''` for a `null`/empty model, and the marker manager's three color controls (`definitionForm`, `markerForm`, `markerEditForm`) initialize to `null` — same for the link style editor, which starts as `''` before being patched. Each `writeValue` call logs the warning once, so a session accumulated 11+ of them.

## Solution

New `SafeColorValueAccessor` (`src/app/directives/`), a `DefaultValueAccessor` subclass matched by `input[type=color][formControlName]` / `[formControl]` / `[ngModel]` — the same type-matching pattern as Angular's built-in accessors, so every reactive color input is covered automatically.

- `writeValue(null | '' | non-hex)` renders a `#000000` placeholder swatch (the browser's own fallback) instead of writing an invalid value to the DOM
- The model is **not** touched — "no color picked" stays `null`, so the existing server-default semantics (`if (v.color) body.color = ...`) are preserved
- Valid `#rrggbb` values and user picks behave exactly as before

Also removes the deprecated `allowSignalWrites` effect flag in `projects.component.ts` (Angular 21: writes are always allowed, the flag logs a deprecation notice).

## Testing

- New spec `safe-color-value-accessor.directive.spec.ts` (6 cases): null → placeholder + model stays null, `''` → placeholder, `none` → placeholder, valid hex passes through, user input emits to the model
- All affected specs pass: 54 tests across the directive, projects, and marker-manager specs
- `yarn lint` and Prettier check pass