### PR TITLE
feat(templates): preserve list filters across edit-page navigation

### DIFF
--- a/src/app/components/preferences/built-in/cloud-nodes/cloud-nodes-add-template/cloud-nodes-add-template.component.ts
+++ b/src/app/components/preferences/built-in/cloud-nodes/cloud-nodes-add-template/cloud-nodes-add-template.component.ts
@@ -1,4 +1,6 @@
 import { Component, ChangeDetectionStrategy, ChangeDetectorRef, OnInit, inject, model } from '@angular/core';
+import { Location } from '@angular/common';
+import { goBackOrNavigate } from '@utils/back-navigation.util';
 import {
   ReactiveFormsModule,
   UntypedFormBuilder,
@@ -42,6 +44,7 @@ export class CloudNodesAddTemplateComponent implements OnInit {
   private controllerService = inject(ControllerService);
   private builtInTemplatesService = inject(BuiltInTemplatesService);
   private router = inject(Router);
+  private location = inject(Location);
   private toasterService = inject(ToasterService);
   private templateMocksService = inject(TemplateMocksService);
   private formBuilder = inject(UntypedFormBuilder);
@@ -83,7 +86,7 @@ export class CloudNodesAddTemplateComponent implements OnInit {
 
   goBack() {
     const controllerId = this.controller?.id ?? parseInt(this.route.snapshot.paramMap.get('controller_id'), 10);
-    this.router.navigate(['/controller', controllerId, 'preferences']);
+    goBackOrNavigate(this.location, this.router, ['/controller', controllerId, 'preferences']);
   }
 
   addTemplate() {

--- a/src/app/components/preferences/built-in/cloud-nodes/cloud-nodes-template-details/cloud-nodes-template-details.component.ts
+++ b/src/app/components/preferences/built-in/cloud-nodes/cloud-nodes-template-details/cloud-nodes-template-details.component.ts
@@ -1,13 +1,6 @@
-import {
-  Component,
-  ChangeDetectionStrategy,
-  ChangeDetectorRef,
-  OnInit,
-  model,
-  inject,
-  signal,
-} from '@angular/core';
-import { CommonModule } from '@angular/common';
+import { Component, ChangeDetectionStrategy, ChangeDetectorRef, OnInit, model, inject, signal } from '@angular/core';
+import { CommonModule, Location } from '@angular/common';
+import { goBackOrNavigate } from '@utils/back-navigation.util';
 import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { MatIconModule } from '@angular/material/icon';
@@ -66,6 +59,7 @@ export class CloudNodesTemplateDetailsComponent implements OnInit {
   private builtInTemplatesConfigurationService = inject(BuiltInTemplatesConfigurationService);
   private validationService = inject(CloudValidationService);
   private router = inject(Router);
+  private location = inject(Location);
   private cd = inject(ChangeDetectorRef);
   private dialog = inject(MatDialog);
   private dialogConfig = inject(DialogConfigService);
@@ -174,20 +168,32 @@ export class CloudNodesTemplateDetailsComponent implements OnInit {
   }
 
   goBack() {
-    this.router.navigate(['/controller', this.controller.id, 'preferences']);
+    goBackOrNavigate(this.location, this.router, ['/controller', this.controller.id, 'preferences']);
   }
 
   toggleSection(section: string) {
     switch (section) {
-      case 'general': this.generalExpanded = !this.generalExpanded; break;
-      case 'ethernet': this.ethernetExpanded = !this.ethernetExpanded; break;
-      case 'tap': this.tapExpanded = !this.tapExpanded; break;
-      case 'udp': this.udpExpanded = !this.udpExpanded; break;
-      case 'usage': this.usageExpanded = !this.usageExpanded; break;
+      case 'general':
+        this.generalExpanded = !this.generalExpanded;
+        break;
+      case 'ethernet':
+        this.ethernetExpanded = !this.ethernetExpanded;
+        break;
+      case 'tap':
+        this.tapExpanded = !this.tapExpanded;
+        break;
+      case 'udp':
+        this.udpExpanded = !this.udpExpanded;
+        break;
+      case 'usage':
+        this.usageExpanded = !this.usageExpanded;
+        break;
     }
   }
 
-  selectSection(section: string): void { this.activeSection = section; }
+  selectSection(section: string): void {
+    this.activeSection = section;
+  }
 
   getConfiguration() {
     this.categories = this.builtInTemplatesConfigurationService.getCategoriesForCloudNodes();

--- a/src/app/components/preferences/built-in/ethernet-hubs/ethernet-hubs-add-template/ethernet-hubs-add-template.component.ts
+++ b/src/app/components/preferences/built-in/ethernet-hubs/ethernet-hubs-add-template/ethernet-hubs-add-template.component.ts
@@ -1,4 +1,6 @@
 import { Component, ChangeDetectionStrategy, ChangeDetectorRef, OnInit, inject, model } from '@angular/core';
+import { Location } from '@angular/common';
+import { goBackOrNavigate } from '@utils/back-navigation.util';
 import {
   ReactiveFormsModule,
   UntypedFormBuilder,
@@ -42,6 +44,7 @@ export class EthernetHubsAddTemplateComponent implements OnInit {
   private controllerService = inject(ControllerService);
   private builtInTemplatesService = inject(BuiltInTemplatesService);
   private router = inject(Router);
+  private location = inject(Location);
   private toasterService = inject(ToasterService);
   private templateMocksService = inject(TemplateMocksService);
   private formBuilder = inject(UntypedFormBuilder);
@@ -84,7 +87,7 @@ export class EthernetHubsAddTemplateComponent implements OnInit {
 
   goBack() {
     const controllerId = this.controller?.id ?? parseInt(this.route.snapshot.paramMap.get('controller_id'), 10);
-    this.router.navigate(['/controller', controllerId, 'preferences']);
+    goBackOrNavigate(this.location, this.router, ['/controller', controllerId, 'preferences']);
   }
 
   addTemplate() {

--- a/src/app/components/preferences/built-in/ethernet-hubs/ethernet-hubs-template-details/ethernet-hubs-template-details.component.ts
+++ b/src/app/components/preferences/built-in/ethernet-hubs/ethernet-hubs-template-details/ethernet-hubs-template-details.component.ts
@@ -1,5 +1,6 @@
 import { Component, ChangeDetectionStrategy, ChangeDetectorRef, OnInit, model, inject } from '@angular/core';
-import { CommonModule } from '@angular/common';
+import { goBackOrNavigate } from '@utils/back-navigation.util';
+import { CommonModule, Location } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { MatIconModule } from '@angular/material/icon';
@@ -50,6 +51,7 @@ export class EthernetHubsTemplateDetailsComponent implements OnInit {
   private builtInTemplatesConfigurationService = inject(BuiltInTemplatesConfigurationService);
   private validationService = inject(ValidationService);
   private router = inject(Router);
+  private location = inject(Location);
   private cd = inject(ChangeDetectorRef);
   private dialog = inject(MatDialog);
   private dialogConfig = inject(DialogConfigService);
@@ -120,7 +122,7 @@ export class EthernetHubsTemplateDetailsComponent implements OnInit {
   }
 
   goBack() {
-    this.router.navigate(['/controller', this.controller.id, 'preferences']);
+    goBackOrNavigate(this.location, this.router, ['/controller', this.controller.id, 'preferences']);
   }
 
   onSave() {
@@ -204,10 +206,16 @@ export class EthernetHubsTemplateDetailsComponent implements OnInit {
 
   toggleSection(section: string): void {
     switch (section) {
-      case 'general': this.generalSettingsExpanded.set(!this.generalSettingsExpanded()); break;
-      case 'usage': this.usageExpanded.set(!this.usageExpanded()); break;
+      case 'general':
+        this.generalSettingsExpanded.set(!this.generalSettingsExpanded());
+        break;
+      case 'usage':
+        this.usageExpanded.set(!this.usageExpanded());
+        break;
     }
   }
 
-  selectSection(section: string): void { this.activeSection = section; }
+  selectSection(section: string): void {
+    this.activeSection = section;
+  }
 }

--- a/src/app/components/preferences/built-in/ethernet-switches/ethernet-switches-add-template/ethernet-switches-add-template.component.ts
+++ b/src/app/components/preferences/built-in/ethernet-switches/ethernet-switches-add-template/ethernet-switches-add-template.component.ts
@@ -1,4 +1,6 @@
 import { Component, ChangeDetectionStrategy, ChangeDetectorRef, OnInit, inject, model } from '@angular/core';
+import { Location } from '@angular/common';
+import { goBackOrNavigate } from '@utils/back-navigation.util';
 import {
   ReactiveFormsModule,
   UntypedFormBuilder,
@@ -41,6 +43,7 @@ export class EthernetSwitchesAddTemplateComponent implements OnInit {
   private controllerService = inject(ControllerService);
   private builtInTemplatesService = inject(BuiltInTemplatesService);
   private router = inject(Router);
+  private location = inject(Location);
   private toasterService = inject(ToasterService);
   private formBuilder = inject(UntypedFormBuilder);
   private cd = inject(ChangeDetectorRef);
@@ -81,7 +84,7 @@ export class EthernetSwitchesAddTemplateComponent implements OnInit {
 
   goBack() {
     const controllerId = this.controller?.id ?? parseInt(this.route.snapshot.paramMap.get('controller_id'), 10);
-    this.router.navigate(['/controller', controllerId, 'preferences']);
+    goBackOrNavigate(this.location, this.router, ['/controller', controllerId, 'preferences']);
   }
 
   addTemplate() {

--- a/src/app/components/preferences/built-in/ethernet-switches/ethernet-switches-template-details/ethernet-switches-template-details.component.ts
+++ b/src/app/components/preferences/built-in/ethernet-switches/ethernet-switches-template-details/ethernet-switches-template-details.component.ts
@@ -1,4 +1,6 @@
 import { Component, ChangeDetectionStrategy, ChangeDetectorRef, OnInit, model, inject } from '@angular/core';
+import { Location } from '@angular/common';
+import { goBackOrNavigate } from '@utils/back-navigation.util';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
@@ -48,6 +50,7 @@ export class EthernetSwitchesTemplateDetailsComponent implements OnInit {
   private toasterService = inject(ToasterService);
   private builtInTemplatesConfigurationService = inject(BuiltInTemplatesConfigurationService);
   private router = inject(Router);
+  private location = inject(Location);
   private cd = inject(ChangeDetectorRef);
   private dialog = inject(MatDialog);
   private dialogConfig = inject(DialogConfigService);
@@ -117,7 +120,7 @@ export class EthernetSwitchesTemplateDetailsComponent implements OnInit {
   }
 
   goBack() {
-    this.router.navigate(['/controller', this.controller.id, 'preferences']);
+    goBackOrNavigate(this.location, this.router, ['/controller', this.controller.id, 'preferences']);
   }
 
   onSave() {

--- a/src/app/components/preferences/docker/add-docker-template/add-docker-template.component.ts
+++ b/src/app/components/preferences/docker/add-docker-template/add-docker-template.component.ts
@@ -1,4 +1,6 @@
 import { Component, ChangeDetectionStrategy, ChangeDetectorRef, OnInit, model, signal, inject } from '@angular/core';
+import { Location } from '@angular/common';
+import { goBackOrNavigate } from '@utils/back-navigation.util';
 import { ActivatedRoute, Router } from '@angular/router';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
@@ -47,6 +49,7 @@ export class AddDockerTemplateComponent implements OnInit {
   private dockerService = inject(DockerService);
   private toasterService = inject(ToasterService);
   private router = inject(Router);
+  private location = inject(Location);
   private templateMocksService = inject(TemplateMocksService);
   private configurationService = inject(DockerConfigurationService);
   private validationService = inject(ValidationService);
@@ -189,19 +192,14 @@ export class AddDockerTemplateComponent implements OnInit {
 
   goBack() {
     const controllerId = this.controller?.id ?? parseInt(this.route.snapshot.paramMap.get('controller_id'), 10);
-    this.router.navigate(['/controller', controllerId, 'preferences']);
+    goBackOrNavigate(this.location, this.router, ['/controller', controllerId, 'preferences']);
   }
 
   addTemplate() {
     const controller = this.controller;
     const template = this.dockerTemplate;
     const selectedImage = this.selectedImage;
-    if (
-      !this.canCreateTemplate() ||
-      !controller ||
-      !template ||
-      (!this.newImageSelected && !selectedImage)
-    ) {
+    if (!this.canCreateTemplate() || !controller || !template || (!this.newImageSelected && !selectedImage)) {
       this.toasterService.error(`Fill all required fields`);
       return;
     }

--- a/src/app/components/preferences/docker/docker-template-details/docker-template-details.component.ts
+++ b/src/app/components/preferences/docker/docker-template-details/docker-template-details.component.ts
@@ -8,7 +8,8 @@ import {
   signal,
   computed,
 } from '@angular/core';
-import { CommonModule } from '@angular/common';
+import { CommonModule, Location } from '@angular/common';
+import { goBackOrNavigate } from '@utils/back-navigation.util';
 import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { MatIconModule } from '@angular/material/icon';
@@ -76,6 +77,7 @@ export class DockerTemplateDetailsComponent implements OnInit {
   private validationService = inject(DockerValidationService);
   private configurationService = inject(DockerConfigurationService);
   private router = inject(Router);
+  private location = inject(Location);
   private cd = inject(ChangeDetectorRef);
   private dialog = inject(MatDialog);
   private dialogConfig = inject(DialogConfigService);
@@ -191,7 +193,7 @@ export class DockerTemplateDetailsComponent implements OnInit {
   }
 
   goBack() {
-    this.router.navigate(['/controller', this.controller.id, 'preferences']);
+    goBackOrNavigate(this.location, this.router, ['/controller', this.controller.id, 'preferences']);
   }
 
   toggleSection(section: string) {

--- a/src/app/components/preferences/dynamips/add-ios-template/add-ios-template.component.ts
+++ b/src/app/components/preferences/dynamips/add-ios-template/add-ios-template.component.ts
@@ -10,6 +10,8 @@ import {
   computed,
 } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
+import { Location } from '@angular/common';
+import { goBackOrNavigate } from '@utils/back-navigation.util';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCheckboxModule } from '@angular/material/checkbox';
@@ -63,6 +65,7 @@ export class AddIosTemplateComponent implements OnInit, OnDestroy {
   private toasterService = inject(ToasterService);
   private validationService = inject(ValidationService);
   private router = inject(Router);
+  private location = inject(Location);
   private templateMocksService = inject(TemplateMocksService);
   private iosConfigurationService = inject(IosConfigurationService);
   private uploadServiceService = inject(UploadServiceService);
@@ -322,7 +325,7 @@ export class AddIosTemplateComponent implements OnInit, OnDestroy {
 
   goBack() {
     const controllerId = this.controller()?.id ?? parseInt(this.route.snapshot.paramMap.get('controller_id'), 10);
-    this.router.navigate(['/controller', controllerId, 'preferences']);
+    goBackOrNavigate(this.location, this.router, ['/controller', controllerId, 'preferences']);
   }
 
   onImageChosen() {

--- a/src/app/components/preferences/dynamips/ios-template-details/ios-template-details.component.ts
+++ b/src/app/components/preferences/dynamips/ios-template-details/ios-template-details.component.ts
@@ -1,5 +1,15 @@
-import { Component, ChangeDetectionStrategy, ChangeDetectorRef, OnInit, inject, model, signal, computed } from '@angular/core';
-import { CommonModule } from '@angular/common';
+import {
+  Component,
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  OnInit,
+  inject,
+  model,
+  signal,
+  computed,
+} from '@angular/core';
+import { goBackOrNavigate } from '@utils/back-navigation.util';
+import { CommonModule, Location } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { MatChipInputEvent, MatChipsModule } from '@angular/material/chips';
@@ -65,6 +75,7 @@ export class IosTemplateDetailsComponent implements OnInit {
   private iosConfigurationService = inject(IosConfigurationService);
   private progressService = inject(ProgressService);
   private router = inject(Router);
+  private location = inject(Location);
   private cd = inject(ChangeDetectorRef);
   private dialog = inject(MatDialog);
   private dialogConfig = inject(DialogConfigService);
@@ -312,7 +323,10 @@ export class IosTemplateDetailsComponent implements OnInit {
       return;
     }
     const netmikoValidation = this.validationService.validateNetmikoDeviceType(this.netmikoDeviceType());
-    if (!netmikoValidation.isValid) { this.toasterService.error(netmikoValidation.errorMessage); return; }
+    if (!netmikoValidation.isValid) {
+      this.toasterService.error(netmikoValidation.errorMessage);
+      return;
+    }
 
     this.saveSlotsData();
 
@@ -352,7 +366,7 @@ export class IosTemplateDetailsComponent implements OnInit {
   }
 
   goBack() {
-    this.router.navigate(['/controller', this.controller.id, 'preferences']);
+    goBackOrNavigate(this.location, this.router, ['/controller', this.controller.id, 'preferences']);
   }
 
   chooseSymbol() {
@@ -399,13 +413,25 @@ export class IosTemplateDetailsComponent implements OnInit {
 
   toggleSection(section: string): void {
     switch (section) {
-      case 'general': this.generalSettingsExpanded = !this.generalSettingsExpanded; break;
-      case 'memory': this.memoryExpanded = !this.memoryExpanded; break;
-      case 'slots': this.slotsExpanded = !this.slotsExpanded; break;
-      case 'advanced': this.advancedExpanded = !this.advancedExpanded; break;
-      case 'usage': this.usageExpanded = !this.usageExpanded; break;
+      case 'general':
+        this.generalSettingsExpanded = !this.generalSettingsExpanded;
+        break;
+      case 'memory':
+        this.memoryExpanded = !this.memoryExpanded;
+        break;
+      case 'slots':
+        this.slotsExpanded = !this.slotsExpanded;
+        break;
+      case 'advanced':
+        this.advancedExpanded = !this.advancedExpanded;
+        break;
+      case 'usage':
+        this.usageExpanded = !this.usageExpanded;
+        break;
     }
   }
 
-  selectSection(section: string): void { this.activeSection = section; }
+  selectSection(section: string): void {
+    this.activeSection = section;
+  }
 }

--- a/src/app/components/preferences/ios-on-unix/add-iou-template/add-iou-template.component.ts
+++ b/src/app/components/preferences/ios-on-unix/add-iou-template/add-iou-template.component.ts
@@ -10,6 +10,8 @@ import {
   computed,
 } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
+import { Location } from '@angular/common';
+import { goBackOrNavigate } from '@utils/back-navigation.util';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
 import { MatRadioModule } from '@angular/material/radio';
@@ -59,6 +61,7 @@ export class AddIouTemplateComponent implements OnInit, OnDestroy {
   private toasterService = inject(ToasterService);
   private validationService = inject(ValidationService);
   private router = inject(Router);
+  private location = inject(Location);
   private templateMocksService = inject(TemplateMocksService);
   private uploadServiceService = inject(UploadServiceService);
   private snackBar = inject(MatSnackBar);
@@ -197,7 +200,7 @@ export class AddIouTemplateComponent implements OnInit, OnDestroy {
 
   goBack() {
     const controllerId = this.controller()?.id ?? parseInt(this.route.snapshot.paramMap.get('controller_id'), 10);
-    this.router.navigate(['/controller', controllerId, 'preferences']);
+    goBackOrNavigate(this.location, this.router, ['/controller', controllerId, 'preferences']);
   }
 
   addTemplate() {

--- a/src/app/components/preferences/ios-on-unix/iou-template-details/iou-template-details.component.ts
+++ b/src/app/components/preferences/ios-on-unix/iou-template-details/iou-template-details.component.ts
@@ -1,5 +1,15 @@
-import { Component, ChangeDetectionStrategy, ChangeDetectorRef, OnInit, model, inject, signal, computed } from '@angular/core';
-import { CommonModule } from '@angular/common';
+import {
+  Component,
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  OnInit,
+  model,
+  inject,
+  signal,
+  computed,
+} from '@angular/core';
+import { goBackOrNavigate } from '@utils/back-navigation.util';
+import { CommonModule, Location } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { MatIconModule } from '@angular/material/icon';
@@ -61,6 +71,7 @@ export class IouTemplateDetailsComponent implements OnInit {
   private toasterService = inject(ToasterService);
   private configurationService = inject(IouConfigurationService);
   private router = inject(Router);
+  private location = inject(Location);
   private cd = inject(ChangeDetectorRef);
   private dialog = inject(MatDialog);
   private dialogConfig = inject(DialogConfigService);
@@ -163,7 +174,7 @@ export class IouTemplateDetailsComponent implements OnInit {
   }
 
   goBack() {
-    this.router.navigate(['/controller', this.controller.id, 'preferences']);
+    goBackOrNavigate(this.location, this.router, ['/controller', this.controller.id, 'preferences']);
   }
 
   onCredentialInput(field: ApplianceCredentialField, event: Event) {
@@ -184,7 +195,10 @@ export class IouTemplateDetailsComponent implements OnInit {
       return;
     }
     const netmikoValidation = this.validationService.validateNetmikoDeviceType(this.netmikoDeviceType());
-    if (!netmikoValidation.isValid) { this.toasterService.error(netmikoValidation.errorMessage); return; }
+    if (!netmikoValidation.isValid) {
+      this.toasterService.error(netmikoValidation.errorMessage);
+      return;
+    }
 
     // Update iouTemplate from model signals
     this.iouTemplate.name = this.templateName();
@@ -270,11 +284,19 @@ export class IouTemplateDetailsComponent implements OnInit {
 
   toggleSection(section: string): void {
     switch (section) {
-      case 'general': this.generalSettingsExpanded.set(!this.generalSettingsExpanded()); break;
-      case 'network': this.networkExpanded.set(!this.networkExpanded()); break;
-      case 'usage': this.usageExpanded.set(!this.usageExpanded()); break;
+      case 'general':
+        this.generalSettingsExpanded.set(!this.generalSettingsExpanded());
+        break;
+      case 'network':
+        this.networkExpanded.set(!this.networkExpanded());
+        break;
+      case 'usage':
+        this.usageExpanded.set(!this.usageExpanded());
+        break;
     }
   }
 
-  selectSection(section: string): void { this.activeSection = section; }
+  selectSection(section: string): void {
+    this.activeSection = section;
+  }
 }

--- a/src/app/components/preferences/preferences.component.spec.ts
+++ b/src/app/components/preferences/preferences.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { PageEvent } from '@angular/material/paginator';
 import { ActivatedRoute, Router, provideRouter } from '@angular/router';
 import { Controller } from '@models/controller';
 import { Template } from '@models/template';
@@ -15,7 +16,14 @@ describe('PreferencesComponent', () => {
   let component: PreferencesComponent;
   let fixture: ComponentFixture<PreferencesComponent>;
   let router: Router;
-  let mockTemplateService: { list: ReturnType<typeof vi.fn>; deleteTemplate: ReturnType<typeof vi.fn>; duplicate: ReturnType<typeof vi.fn> };
+  let navigateSpy: ReturnType<typeof vi.spyOn>;
+  /** Query params served to the component — mutated in place so the stub closure sees updates. */
+  let routeQueryParams: Record<string, string> = {};
+  let mockTemplateService: {
+    list: ReturnType<typeof vi.fn>;
+    deleteTemplate: ReturnType<typeof vi.fn>;
+    duplicate: ReturnType<typeof vi.fn>;
+  };
   let mockToasterService: { error: ReturnType<typeof vi.fn>; success: ReturnType<typeof vi.fn> };
 
   const controller = {
@@ -65,6 +73,9 @@ describe('PreferencesComponent', () => {
   ];
 
   beforeEach(async () => {
+    vi.clearAllMocks();
+    Object.keys(routeQueryParams).forEach((key) => delete routeQueryParams[key]);
+
     mockTemplateService = {
       list: vi.fn().mockReturnValue(of(templates)),
       deleteTemplate: vi.fn().mockReturnValue(of({})),
@@ -87,6 +98,9 @@ describe('PreferencesComponent', () => {
               paramMap: {
                 get: vi.fn().mockReturnValue('1'),
               },
+              queryParamMap: {
+                get: (key: string) => routeQueryParams[key] ?? null,
+              },
             },
           },
         },
@@ -101,6 +115,9 @@ describe('PreferencesComponent', () => {
     }).compileComponents();
 
     router = TestBed.inject(Router);
+    // Filter setters sync to the URL via router.navigate — the stubbed
+    // ActivatedRoute has no route tree, so keep navigation a no-op spy.
+    navigateSpy = vi.spyOn(router, 'navigate').mockResolvedValue(true);
     fixture = TestBed.createComponent(PreferencesComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
@@ -157,6 +174,108 @@ describe('PreferencesComponent', () => {
     component.setType('all');
     component.setScope('builtin');
     expect(component.filteredTemplates().map((template) => template.name)).toEqual(['Ethernet Switch']);
+  });
+
+  it('restores the filter state from URL query params', async () => {
+    vi.useFakeTimers();
+    try {
+      Object.assign(routeQueryParams, {
+        search: 'edge',
+        type: 'qemu',
+        scope: 'custom',
+        sort: 'category',
+        dir: 'desc',
+        page: '1',
+        size: '5',
+        view: 'grid',
+      });
+
+      component.ngOnInit();
+      await vi.runAllTimersAsync();
+      fixture.detectChanges();
+
+      expect(component.searchText()).toBe('edge');
+      expect(component.selectedType()).toBe('qemu');
+      expect(component.selectedScope()).toBe('custom');
+      expect(component.sortActive()).toBe('category');
+      expect(component.sortDirection()).toBe('desc');
+      expect(component.pageSize()).toBe(5);
+      expect(component.viewMode()).toBe('grid');
+      // Only 1 template survives the filters, so page 1 is clamped back to page 0
+      // by ensureValidPage — restoring must never land on an empty page.
+      expect(component.pageIndex()).toBe(0);
+      // Restoring is passive — it never rewrites the URL or history.
+      expect(navigateSpy).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('falls back to defaults for invalid query param values', async () => {
+    vi.useFakeTimers();
+    try {
+      Object.assign(routeQueryParams, {
+        search: 'x',
+        type: 'does-not-exist',
+        scope: 'nope',
+        sort: 'bogus',
+        dir: 'sideways',
+        page: 'abc',
+        size: '7',
+        view: 'diagram',
+      });
+
+      component.ngOnInit();
+      await vi.runAllTimersAsync();
+      fixture.detectChanges();
+
+      expect(component.searchText()).toBe('x'); // free text — always kept
+      expect(component.selectedType()).toBe('all'); // stale type dropped after templates load
+      expect(component.selectedScope()).toBe('all');
+      expect(component.sortActive()).toBe('name');
+      expect(component.sortDirection()).toBe('asc');
+      expect(component.pageIndex()).toBe(0);
+      expect(component.pageSize()).toBe(25);
+      expect(component.viewMode()).toBe('list');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('syncs filter changes to the URL with replaceUrl, omitting defaults', () => {
+    component.setType('qemu');
+    component.setScope('builtin');
+    component.onPageChange({ pageIndex: 2, pageSize: 50 } as PageEvent);
+
+    expect(navigateSpy).toHaveBeenCalled();
+    const [commands, extras] = navigateSpy.mock.calls[navigateSpy.mock.calls.length - 1] as unknown[];
+    expect(commands).toEqual([]);
+    expect(extras).toMatchObject({ replaceUrl: true });
+    expect((extras as { queryParams: object }).queryParams).toEqual({
+      type: 'qemu',
+      scope: 'builtin',
+      page: 2,
+      size: 50,
+    });
+  });
+
+  it('debounces search-driven URL syncs into one update per typing burst', async () => {
+    vi.useFakeTimers();
+    try {
+      component.setSearch('router');
+      component.setSearch('router ');
+      component.setSearch('router s');
+
+      expect(navigateSpy).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(300);
+
+      expect(navigateSpy).toHaveBeenCalledTimes(1);
+      const [, extras] = navigateSpy.mock.calls[0] as unknown[];
+      expect((extras as { queryParams: { search: string } }).queryParams.search).toBe('router s');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('opens and closes details for a selected template', () => {

--- a/src/app/components/preferences/preferences.component.ts
+++ b/src/app/components/preferences/preferences.component.ts
@@ -1,5 +1,14 @@
 import { CommonModule } from '@angular/common';
-import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit, computed, inject, signal } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  OnDestroy,
+  OnInit,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatDialog } from '@angular/material/dialog';
 import { MatIconModule } from '@angular/material/icon';
@@ -21,7 +30,10 @@ import { SymbolService } from '@services/symbol.service';
 import { TemplateService } from '@services/template.service';
 import { ToasterService } from '@services/toaster.service';
 import { MarkdownViewerComponent } from '../../common/markdown-viewer/markdown-viewer.component';
-import { CopyTemplateDialogComponent, CopyTemplateDialogData } from './common/copy-template-dialog/copy-template-dialog.component';
+import {
+  CopyTemplateDialogComponent,
+  CopyTemplateDialogData,
+} from './common/copy-template-dialog/copy-template-dialog.component';
 import { DeleteTemplateComponent } from './common/delete-template-component/delete-template.component';
 
 type TemplateViewMode = 'list' | 'grid';
@@ -68,7 +80,11 @@ type TemplateListItem = Template &
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class PreferencesComponent implements OnInit {
+export class PreferencesComponent implements OnInit, OnDestroy {
+  private static readonly SORT_COLUMNS = ['name', 'template_type', 'category', 'compute_id'];
+  private static readonly DEFAULT_PAGE_SIZE = 25;
+  private static readonly SEARCH_SYNC_DELAY_MS = 300;
+
   controllerId = '';
   controller: Controller;
 
@@ -82,7 +98,7 @@ export class PreferencesComponent implements OnInit {
   readonly sortActive = signal('name');
   readonly sortDirection = signal<TemplateSortDirection>('asc');
   readonly pageIndex = signal(0);
-  readonly pageSize = signal(25);
+  readonly pageSize = signal(PreferencesComponent.DEFAULT_PAGE_SIZE);
   readonly pageSizeOptions = [5, 10, 25, 50, 100];
   readonly displayedColumns = ['name', 'template_type', 'category', 'compute_id', 'builtin', 'actions'];
   readonly symbolBlobUrls = signal<Map<string, string>>(new Map());
@@ -157,9 +173,12 @@ export class PreferencesComponent implements OnInit {
   private symbolService = inject(SymbolService);
   private toasterService = inject(ToasterService);
   private cd = inject(ChangeDetectorRef);
+  /** Pending debounced search → URL sync (cleared on destroy / superseded sync). */
+  private searchSyncTimer: ReturnType<typeof setTimeout> | null = null;
 
   ngOnInit(): void {
     this.controllerId = this.route.snapshot.paramMap.get('controller_id') ?? '';
+    this.restoreFiltersFromUrl();
     const numericControllerId = Number.parseInt(this.controllerId, 10);
 
     this.controllerService.get(numericControllerId).then(
@@ -175,6 +194,13 @@ export class PreferencesComponent implements OnInit {
     );
   }
 
+  ngOnDestroy(): void {
+    if (this.searchSyncTimer !== null) {
+      clearTimeout(this.searchSyncTimer);
+      this.searchSyncTimer = null;
+    }
+  }
+
   loadTemplates(): void {
     if (!this.controller) {
       return;
@@ -185,6 +211,7 @@ export class PreferencesComponent implements OnInit {
       next: (templates: TemplateListItem[]) => {
         this.templates.set(templates || []);
         this.loading.set(false);
+        this.dropStaleTypeFilter();
         this.refreshSelectedTemplate();
         this.ensureValidPage();
         this.loadTemplateSymbols(templates || []);
@@ -201,20 +228,31 @@ export class PreferencesComponent implements OnInit {
   setScope(scope: TemplateScope): void {
     this.selectedScope.set(scope);
     this.resetPage();
+    this.syncFiltersToUrl();
   }
 
   setSearch(value: string): void {
     this.searchText.set(value);
     this.resetPage();
+    // Debounced: one URL update per typing burst instead of one per keystroke.
+    if (this.searchSyncTimer !== null) {
+      clearTimeout(this.searchSyncTimer);
+    }
+    this.searchSyncTimer = setTimeout(() => {
+      this.searchSyncTimer = null;
+      this.syncFiltersToUrl();
+    }, PreferencesComponent.SEARCH_SYNC_DELAY_MS);
   }
 
   setType(value: string): void {
     this.selectedType.set(value);
     this.resetPage();
+    this.syncFiltersToUrl();
   }
 
   setViewMode(mode: TemplateViewMode): void {
     this.viewMode.set(mode);
+    this.syncFiltersToUrl();
   }
 
   onSortByChange(active: string): void {
@@ -223,17 +261,20 @@ export class PreferencesComponent implements OnInit {
       this.sortDirection.set('asc');
     }
     this.resetPage();
+    this.syncFiltersToUrl();
   }
 
   onSortChange(sort: Sort): void {
     this.sortActive.set(sort.active || 'name');
     this.sortDirection.set(sort.direction);
     this.resetPage();
+    this.syncFiltersToUrl();
   }
 
   onPageChange(event: PageEvent): void {
     this.pageIndex.set(event.pageIndex);
     this.pageSize.set(event.pageSize);
+    this.syncFiltersToUrl();
   }
 
   selectTemplate(template: TemplateListItem): void {
@@ -435,6 +476,75 @@ export class PreferencesComponent implements OnInit {
 
   private resetPage(): void {
     this.pageIndex.set(0);
+  }
+
+  /**
+   * Restores the filter state from URL query params
+   * (`?search=&type=&scope=&sort=&dir=&page=&size=&view=`) so coming back
+   * from a template's edit page — or refreshing / sharing the URL — brings
+   * the list up exactly as it was left. Invalid values fall back to defaults.
+   */
+  private restoreFiltersFromUrl(): void {
+    const params = this.route.snapshot.queryParamMap;
+
+    this.searchText.set(params.get('search') ?? '');
+
+    this.selectedType.set(params.get('type') ?? 'all');
+
+    const scope = params.get('scope');
+    this.selectedScope.set(scope === 'custom' || scope === 'builtin' ? scope : 'all');
+
+    const view = params.get('view');
+    this.viewMode.set(view === 'grid' ? 'grid' : 'list');
+
+    const sort = params.get('sort');
+    this.sortActive.set(sort && PreferencesComponent.SORT_COLUMNS.includes(sort) ? sort : 'name');
+
+    const dir = params.get('dir');
+    this.sortDirection.set(dir === 'asc' || dir === 'desc' ? dir : 'asc');
+
+    this.pageIndex.set(Math.max(0, Number.parseInt(params.get('page') ?? '0', 10) || 0));
+
+    const size = Number.parseInt(params.get('size') ?? '', 10);
+    this.pageSize.set(this.pageSizeOptions.includes(size) ? size : PreferencesComponent.DEFAULT_PAGE_SIZE);
+  }
+
+  /**
+   * Mirrors the filter state into the URL (default values omitted) with
+   * `replaceUrl` so filter changes never pollute the browser history — the
+   * URL stays shareable, and Back from an edit page returns to this exact view.
+   */
+  private syncFiltersToUrl(): void {
+    if (this.searchSyncTimer !== null) {
+      clearTimeout(this.searchSyncTimer);
+      this.searchSyncTimer = null;
+    }
+
+    const queryParams: Record<string, string | number> = {};
+    const search = this.searchText().trim();
+    if (search) queryParams['search'] = search;
+    if (this.selectedType() !== 'all') queryParams['type'] = this.selectedType();
+    if (this.selectedScope() !== 'all') queryParams['scope'] = this.selectedScope();
+    if (this.viewMode() !== 'list') queryParams['view'] = this.viewMode();
+    if (this.sortActive() !== 'name') queryParams['sort'] = this.sortActive();
+    const dir = this.sortDirection();
+    if (dir && dir !== 'asc') queryParams['dir'] = dir;
+    if (this.pageIndex() > 0) queryParams['page'] = this.pageIndex();
+    if (this.pageSize() !== PreferencesComponent.DEFAULT_PAGE_SIZE) queryParams['size'] = this.pageSize();
+
+    this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams,
+      replaceUrl: true,
+    });
+  }
+
+  /** A restored `?type=` whose type no longer exists would hide every row — reset it. */
+  private dropStaleTypeFilter(): void {
+    const type = this.selectedType();
+    if (type !== 'all' && !this.templateTypes().includes(type)) {
+      this.selectedType.set('all');
+    }
   }
 
   private ensureValidPage(): void {

--- a/src/app/components/preferences/qemu/add-qemu-vm-template/add-qemu-vm-template.component.ts
+++ b/src/app/components/preferences/qemu/add-qemu-vm-template/add-qemu-vm-template.component.ts
@@ -10,6 +10,8 @@ import {
   computed,
 } from '@angular/core';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { Location } from '@angular/common';
+import { goBackOrNavigate } from '@utils/back-navigation.util';
 import { ActivatedRoute, Router } from '@angular/router';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
@@ -60,6 +62,7 @@ export class AddQemuVmTemplateComponent implements OnInit, OnDestroy {
   private toasterService = inject(ToasterService);
   private validationService = inject(ValidationService);
   private router = inject(Router);
+  private location = inject(Location);
   private templateMocksService = inject(TemplateMocksService);
   private configurationService = inject(QemuConfigurationService);
   private snackBar = inject(MatSnackBar);
@@ -98,9 +101,7 @@ export class AddQemuVmTemplateComponent implements OnInit, OnDestroy {
   consoleStepCompleted = computed(() => !!this.consoleType());
   auxConsoleStepCompleted = computed(() => !!this.auxConsoleType());
   diskStepCompleted = computed(() =>
-    this.newImageSelected()
-      ? !!this.chosenImage() && !!this.fileName().trim()
-      : !!this.selectedImage()
+    this.newImageSelected() ? !!this.chosenImage() && !!this.fileName().trim() : !!this.selectedImage()
   );
   canCreateTemplate = computed(
     () =>
@@ -277,7 +278,7 @@ export class AddQemuVmTemplateComponent implements OnInit, OnDestroy {
 
   goBack() {
     const controllerId = this.controller()?.id ?? parseInt(this.route.snapshot.paramMap.get('controller_id'), 10);
-    this.router.navigate(['/controller', controllerId, 'preferences']);
+    goBackOrNavigate(this.location, this.router, ['/controller', controllerId, 'preferences']);
   }
 
   addTemplate() {

--- a/src/app/components/preferences/qemu/qemu-vm-template-details/qemu-vm-template-details.component.ts
+++ b/src/app/components/preferences/qemu/qemu-vm-template-details/qemu-vm-template-details.component.ts
@@ -8,7 +8,8 @@ import {
   inject,
   computed,
 } from '@angular/core';
-import { CommonModule } from '@angular/common';
+import { CommonModule, Location } from '@angular/common';
+import { goBackOrNavigate } from '@utils/back-navigation.util';
 import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { MatIconModule } from '@angular/material/icon';
@@ -81,6 +82,7 @@ export class QemuVmTemplateDetailsComponent implements OnInit {
   private toasterService = inject(ToasterService);
   private configurationService = inject(QemuConfigurationService);
   private router = inject(Router);
+  private location = inject(Location);
   private cd = inject(ChangeDetectorRef);
   private dialog = inject(MatDialog);
   private dialogConfig = inject(DialogConfigService);
@@ -465,7 +467,7 @@ export class QemuVmTemplateDetailsComponent implements OnInit {
   }
 
   goBack() {
-    this.router.navigate(['/controller', this.controller.id, 'preferences']);
+    goBackOrNavigate(this.location, this.router, ['/controller', this.controller.id, 'preferences']);
   }
 
   onCredentialInput(field: ApplianceCredentialField, event: Event) {

--- a/src/app/components/preferences/vpcs/add-vpcs-template/add-vpcs-template.component.ts
+++ b/src/app/components/preferences/vpcs/add-vpcs-template/add-vpcs-template.component.ts
@@ -1,4 +1,6 @@
 import { Component, ChangeDetectionStrategy, ChangeDetectorRef, OnInit, inject, model } from '@angular/core';
+import { Location } from '@angular/common';
+import { goBackOrNavigate } from '@utils/back-navigation.util';
 import {
   ReactiveFormsModule,
   UntypedFormBuilder,
@@ -45,6 +47,7 @@ export class AddVpcsTemplateComponent implements OnInit {
   private controllerService = inject(ControllerService);
   private vpcsService = inject(VpcsService);
   private router = inject(Router);
+  private location = inject(Location);
   private toasterService = inject(ToasterService);
   private validationService = inject(ValidationService);
   private templateMocksService = inject(TemplateMocksService);
@@ -88,7 +91,7 @@ export class AddVpcsTemplateComponent implements OnInit {
 
   goBack() {
     const controllerId = this.controller?.id ?? parseInt(this.route.snapshot.paramMap.get('controller_id'), 10);
-    this.router.navigate(['/controller', controllerId, 'preferences']);
+    goBackOrNavigate(this.location, this.router, ['/controller', controllerId, 'preferences']);
   }
 
   addTemplate() {

--- a/src/app/components/preferences/vpcs/vpcs-template-details/vpcs-template-details.component.ts
+++ b/src/app/components/preferences/vpcs/vpcs-template-details/vpcs-template-details.component.ts
@@ -1,5 +1,15 @@
-import { Component, ChangeDetectionStrategy, ChangeDetectorRef, OnInit, model, inject, signal, computed } from '@angular/core';
-import { CommonModule } from '@angular/common';
+import {
+  Component,
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  OnInit,
+  model,
+  inject,
+  signal,
+  computed,
+} from '@angular/core';
+import { goBackOrNavigate } from '@utils/back-navigation.util';
+import { CommonModule, Location } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { MatIconModule } from '@angular/material/icon';
@@ -63,6 +73,7 @@ export class VpcsTemplateDetailsComponent implements OnInit {
   private toasterService = inject(ToasterService);
   private vpcsConfigurationService = inject(VpcsConfigurationService);
   private router = inject(Router);
+  private location = inject(Location);
   private cd = inject(ChangeDetectorRef);
   private dialog = inject(MatDialog);
   private dialogConfig = inject(DialogConfigService);
@@ -145,7 +156,7 @@ export class VpcsTemplateDetailsComponent implements OnInit {
   }
 
   goBack() {
-    this.router.navigate(['/controller', this.controller.id, 'preferences']);
+    goBackOrNavigate(this.location, this.router, ['/controller', this.controller.id, 'preferences']);
   }
 
   onCredentialInput(field: ApplianceCredentialField, event: Event) {

--- a/src/app/components/project-map/new-template-dialog/new-template-dialog.component.ts
+++ b/src/app/components/project-map/new-template-dialog/new-template-dialog.component.ts
@@ -13,7 +13,8 @@ import {
   signal,
   viewChild,
 } from '@angular/core';
-import { CommonModule } from '@angular/common';
+import { CommonModule, Location } from '@angular/common';
+import { goBackOrNavigate } from '@utils/back-navigation.util';
 import { ReactiveFormsModule, UntypedFormControl, Validators } from '@angular/forms';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { MatButtonModule } from '@angular/material/button';
@@ -225,6 +226,8 @@ export class NewTemplateDialogComponent implements OnInit {
   readonly applianceFileInput = viewChild<ElementRef<HTMLInputElement>>('applianceFile');
 
   private router = inject(Router);
+
+  private location = inject(Location);
   private route = inject(ActivatedRoute);
   private controllerService = inject(ControllerService);
   private applianceService = inject(ApplianceService);
@@ -322,9 +325,10 @@ export class NewTemplateDialogComponent implements OnInit {
       [Validators.required, this.projectNameValidator.get],
       [
         (control: UntypedFormControl) =>
-          templateNameAsyncValidator(this.controller, this.templateService)(control).pipe(
-            tap((result) => nameCheckCompleted.next(result === null))
-          ),
+          templateNameAsyncValidator(
+            this.controller,
+            this.templateService
+          )(control).pipe(tap((result) => nameCheckCompleted.next(result === null))),
       ]
     );
     this.templateNameControl.statusChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
@@ -446,7 +450,7 @@ export class NewTemplateDialogComponent implements OnInit {
    */
   goBack(): void {
     const controllerId = this.controller?.id ?? parseInt(this.route.snapshot.paramMap.get('controller_id') ?? '', 10);
-    this.router.navigate(['/controller', controllerId, 'preferences']);
+    goBackOrNavigate(this.location, this.router, ['/controller', controllerId, 'preferences']);
   }
 
   // ------------------------------------------------------------------

--- a/src/app/utils/back-navigation.util.spec.ts
+++ b/src/app/utils/back-navigation.util.spec.ts
@@ -1,0 +1,50 @@
+import { Location } from '@angular/common';
+import { Router } from '@angular/router';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { goBackOrNavigate } from './back-navigation.util';
+
+describe('goBackOrNavigate', () => {
+  let location: Location;
+  let router: Router;
+  const fallback = ['/controller', 1, 'preferences'];
+
+  beforeEach(() => {
+    location = { back: vi.fn() } as unknown as Location;
+    router = { navigate: vi.fn() } as unknown as Router;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function stubNavigationId(id: number | undefined): void {
+    vi.stubGlobal('history', { state: id === undefined ? undefined : { navigationId: id } });
+  }
+
+  it('goes back when there is in-app history (navigationId > 1)', () => {
+    stubNavigationId(2);
+
+    goBackOrNavigate(location, router, fallback);
+
+    expect(location.back).toHaveBeenCalledOnce();
+    expect(router.navigate).not.toHaveBeenCalled();
+  });
+
+  it('navigates to the fallback on the first in-app navigation (deep link)', () => {
+    stubNavigationId(1);
+
+    goBackOrNavigate(location, router, fallback);
+
+    expect(router.navigate).toHaveBeenCalledWith(fallback);
+    expect(location.back).not.toHaveBeenCalled();
+  });
+
+  it('navigates to the fallback when history.state is missing', () => {
+    stubNavigationId(undefined);
+
+    goBackOrNavigate(location, router, fallback);
+
+    expect(router.navigate).toHaveBeenCalledWith(fallback);
+    expect(location.back).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/utils/back-navigation.util.ts
+++ b/src/app/utils/back-navigation.util.ts
@@ -1,0 +1,20 @@
+import { Location } from '@angular/common';
+import { Router } from '@angular/router';
+
+/**
+ * Goes back one history entry when the app has in-app navigation history —
+ * restoring the previous URL with its query params (e.g. the templates list
+ * filters) — and falls back to a plain forward navigation otherwise (deep
+ * link / page refresh on the current page, where `location.back()` would
+ * leave the app).
+ *
+ * The Router stamps every history entry with `navigationId`; `> 1` means
+ * there is an earlier in-app entry to go back to.
+ */
+export function goBackOrNavigate(location: Location, router: Router, fallback: unknown[]): void {
+  if ((history.state?.navigationId ?? 0) > 1) {
+    location.back();
+  } else {
+    router.navigate(fallback);
+  }
+}


### PR DESCRIPTION
## Problem

Filtering the Templates list (search / template type / scope / sort by / pagination) was lost on every round trip: opening a template's edit page destroyed the list component, and the edit page's back button navigated to a bare `/preferences` URL — so after every edit the filters had to be re-entered by hand.

## Solution

Keep the filter state in the URL query params:

- **List page** (`preferences.component.ts`) mirrors every filter change into `?search=&type=&scope=&sort=&dir=&page=&size=&view=` using `replaceUrl` (filter changes never pollute browser history; default values are omitted from the URL). The search field is debounced (300 ms) so typing doesn't spam the router. Sharing or refreshing the URL restores the exact same view.
- **Restore on init** reads the params back into the filter signals, validating every value; a stale `?type=` whose template type no longer exists is dropped after templates load, so restoring can never land on an empty page (`ensureValidPage` also clamps the page index).
- **Back navigation**: the 8 template details pages, 8 add-template pages and the new-template wizard now return through browser history when there is in-app history (`goBackOrNavigate` in `src/app/utils/`), landing on the filtered list URL they came from. Deep links and page refreshes (no in-app history) fall back to the previous plain forward navigation.

VirtualBox / VMware pages are untouched (their routes are disabled).

## Testing

- New `back-navigation.util.spec.ts` (3 cases): history back vs fallback vs missing `history.state`.
- `preferences.component.spec.ts` extended from 14 to 18 cases: restore from query params (incl. page clamping and no URL rewrite during restore), invalid values fall back to defaults, sync writes `replaceUrl` with defaults omitted, debounced search produces a single URL update.
- All affected suites pass (125 tests across 3 spec files); `yarn lint` clean.